### PR TITLE
Phase 2d: add normalized metadata filters for library listings

### DIFF
--- a/src/adapters/library/inMemoryLibraryService.test.ts
+++ b/src/adapters/library/inMemoryLibraryService.test.ts
@@ -74,6 +74,54 @@ describe('InMemoryLibraryService', () => {
     expect(photos.map((p) => p.id)).not.toContain(p2.id);
   });
 
+  it('filters by normalized metadata camera make', async () => {
+    const svc = new InMemoryLibraryService();
+    const canon = await svc.addPhoto({
+      libraryId: LIBRARY_ID,
+      originalName: 'canon.jpg',
+      dataUrl: 'data:image/jpeg;base64,canon',
+      metadata: { cameraMake: 'Canon', takenAt: '2026-02-21T10:00:00.000Z' },
+    });
+    await svc.addPhoto({
+      libraryId: LIBRARY_ID,
+      originalName: 'nikon.jpg',
+      dataUrl: 'data:image/jpeg;base64,nikon',
+      metadata: { cameraMake: 'Nikon', takenAt: '2026-02-21T10:00:00.000Z' },
+    });
+
+    const { photos } = await svc.listPhotos({
+      libraryId: LIBRARY_ID,
+      metadata: { cameraMake: 'canon' },
+    });
+
+    expect(photos).toHaveLength(1);
+    expect(photos[0].id).toBe(canon.id);
+  });
+
+  it('filters by capture datetime bounds', async () => {
+    const svc = new InMemoryLibraryService();
+    await svc.addPhoto({
+      libraryId: LIBRARY_ID,
+      originalName: 'older.jpg',
+      dataUrl: 'data:image/jpeg;base64,old',
+      metadata: { takenAt: '2026-02-20T10:00:00.000Z' },
+    });
+    const newer = await svc.addPhoto({
+      libraryId: LIBRARY_ID,
+      originalName: 'newer.jpg',
+      dataUrl: 'data:image/jpeg;base64,new',
+      metadata: { takenAt: '2026-02-24T10:00:00.000Z' },
+    });
+
+    const { photos } = await svc.listPhotos({
+      libraryId: LIBRARY_ID,
+      metadata: { takenAfter: '2026-02-22T00:00:00.000Z' },
+    });
+
+    expect(photos).toHaveLength(1);
+    expect(photos[0].id).toBe(newer.id);
+  });
+
   it('deletes a photo', async () => {
     const svc = new InMemoryLibraryService();
     const photo = await svc.addPhoto({

--- a/src/adapters/library/inMemoryLibraryService.ts
+++ b/src/adapters/library/inMemoryLibraryService.ts
@@ -56,6 +56,42 @@ export class InMemoryLibraryService implements LibraryService {
       results = results.filter((p) => input.tags!.every((t) => p.tags.includes(t)));
     }
 
+    if (input.metadata?.cameraMake) {
+      const cameraMake = input.metadata.cameraMake.trim().toLowerCase();
+      results = results.filter((p) => p.metadata?.cameraMake?.toLowerCase() === cameraMake);
+    }
+
+    if (input.metadata?.cameraModel) {
+      const cameraModel = input.metadata.cameraModel.trim().toLowerCase();
+      results = results.filter((p) => p.metadata?.cameraModel?.toLowerCase() === cameraModel);
+    }
+
+    if (input.metadata?.hasLocation !== undefined) {
+      results = results.filter(
+        (p) => (p.metadata?.location !== null) === input.metadata?.hasLocation
+      );
+    }
+
+    if (input.metadata?.takenAfter) {
+      const after = Date.parse(input.metadata.takenAfter);
+      if (!Number.isNaN(after)) {
+        results = results.filter((p) => {
+          const takenAt = p.metadata?.takenAt ? Date.parse(p.metadata.takenAt) : Number.NaN;
+          return !Number.isNaN(takenAt) && takenAt >= after;
+        });
+      }
+    }
+
+    if (input.metadata?.takenBefore) {
+      const before = Date.parse(input.metadata.takenBefore);
+      if (!Number.isNaN(before)) {
+        results = results.filter((p) => {
+          const takenAt = p.metadata?.takenAt ? Date.parse(p.metadata.takenAt) : Number.NaN;
+          return !Number.isNaN(takenAt) && takenAt <= before;
+        });
+      }
+    }
+
     // Sort newest-first
     results = results.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
 

--- a/src/domain/library/types.ts
+++ b/src/domain/library/types.ts
@@ -26,11 +26,20 @@ export interface Photo {
   tags: string[];
 }
 
+export interface MetadataFilterInput {
+  cameraMake?: string;
+  cameraModel?: string;
+  hasLocation?: boolean;
+  takenAfter?: string;
+  takenBefore?: string;
+}
+
 export interface ListPhotosInput {
   libraryId: string;
   albumId?: string;
   favoritesOnly?: boolean;
   tags?: string[];
+  metadata?: MetadataFilterInput;
   pageSize?: number;
   pageToken?: string;
 }

--- a/src/features/library/useLibrary.ts
+++ b/src/features/library/useLibrary.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { BulkAddToAlbumResult, Photo } from '../../domain/library/types';
+import type { BulkAddToAlbumResult, MetadataFilterInput, Photo } from '../../domain/library/types';
 import { useServices } from '../../services/useServices';
 
 interface UseLibraryState {
@@ -28,7 +28,10 @@ function readFileAsDataUrl(file: File): Promise<string> {
   });
 }
 
-export function useLibrary(libraryId: string): UseLibraryReturn {
+export function useLibrary(
+  libraryId: string,
+  filters?: { metadata?: MetadataFilterInput }
+): UseLibraryReturn {
   const { library } = useServices();
   const [photos, setPhotos] = useState<Photo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -42,7 +45,7 @@ export function useLibrary(libraryId: string): UseLibraryReturn {
     let cancelled = false;
     setLoading(true);
     library
-      .listPhotos({ libraryId })
+      .listPhotos({ libraryId, metadata: filters?.metadata })
       .then(({ photos: p, nextPageToken }) => {
         if (!cancelled) {
           setPhotos(p);
@@ -59,7 +62,7 @@ export function useLibrary(libraryId: string): UseLibraryReturn {
     return () => {
       cancelled = true;
     };
-  }, [library, libraryId, tick]);
+  }, [library, libraryId, tick, filters?.metadata]);
 
   const addPhoto = useCallback(
     async (file: File): Promise<Photo> => {

--- a/src/pages/LibraryPage.tsx
+++ b/src/pages/LibraryPage.tsx
@@ -21,6 +21,12 @@ export function LibraryPage() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const libraryId = toLibraryId(user?.id ?? 'local-user-1');
+  const [cameraMakeFilter, setCameraMakeFilter] = useState<string>('');
+  const metadataFilters = useMemo(
+    () => ({ metadata: cameraMakeFilter ? { cameraMake: cameraMakeFilter } : undefined }),
+    [cameraMakeFilter]
+  );
+
   const {
     photos,
     loading,
@@ -30,7 +36,7 @@ export function LibraryPage() {
     bulkAddToAlbum,
     toggleFavorite,
     deletePhoto,
-  } = useLibrary(libraryId);
+  } = useLibrary(libraryId, metadataFilters);
   const { albums } = useAlbums();
 
   const [isFilmstrip, setIsFilmstrip] = useState(false);
@@ -198,6 +204,21 @@ export function LibraryPage() {
         <h1 className="page-title">Library</h1>
         {!isFilmstrip && photos.length > 0 && (
           <div className="titlebar-controls">
+            <select
+              className="btn-ghost btn-sm"
+              aria-label="Filter by camera make"
+              value={cameraMakeFilter}
+              onChange={(e) => setCameraMakeFilter(e.target.value)}
+            >
+              <option value="">All cameras</option>
+              {[...new Set(photos.map((photo) => photo.metadata?.cameraMake).filter(Boolean))].map(
+                (cameraMake) => (
+                  <option key={cameraMake} value={cameraMake ?? ''}>
+                    {cameraMake}
+                  </option>
+                )
+              )}
+            </select>
             <button
               className="btn-ghost btn-sm"
               title="Select all"


### PR DESCRIPTION
## Summary
- add normalized metadata filter input to the library contract (camera make/model, capture date bounds, hasLocation)
- implement metadata-aware filtering in InMemoryLibraryService.listPhotos
- add coverage for camera make and capture date filtering behavior
- expose a user-usable camera make filter control in Library page so filtering is demoable

## Why
Implements an actionable slice of #33 by making EXIF-style metadata queryable in the existing library path without breaking existing clients.

## Safety
- Backward compatible: all metadata filters are optional and default to current behavior
- No DB/API breaking changes; only additive contract fields

Closes #33