### PR TITLE
Phase 2b slice: paginated library grid with load-more control

### DIFF
--- a/src/adapters/library/inMemoryLibraryService.ts
+++ b/src/adapters/library/inMemoryLibraryService.ts
@@ -106,7 +106,15 @@ export class InMemoryLibraryService implements LibraryService {
     results = results.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
 
     const pageSize = input.pageSize ?? results.length;
-    const startIndex = input.pageToken ? results.findIndex((p) => p.id === input.pageToken) : 0;
+    const startIndex = input.pageToken
+      ? Math.max(
+          0,
+          (() => {
+            const tokenIndex = results.findIndex((p) => p.id === input.pageToken);
+            return tokenIndex === -1 ? 0 : tokenIndex;
+          })()
+        )
+      : 0;
     const page = results.slice(startIndex, startIndex + pageSize);
     const nextPageToken =
       startIndex + pageSize < results.length ? results[startIndex + pageSize].id : null;

--- a/src/pages/LibraryPage.tsx
+++ b/src/pages/LibraryPage.tsx
@@ -37,6 +37,9 @@ export function LibraryPage() {
     photos,
     loading,
     error,
+    hasMore,
+    loadingMore,
+    loadMore,
     addPhoto,
     assignToAlbum,
     bulkAddToAlbum,
@@ -321,6 +324,14 @@ export function LibraryPage() {
               onToggleFavorite={(photo) => toggleFavorite(photo.id)}
               viewerStateRef={viewerStateRef}
             />
+          )}
+
+          {!loading && hasMore && !isFilmstrip && (
+            <div className="pagination-controls">
+              <button className="btn-ghost btn-sm" onClick={loadMore} disabled={loadingMore}>
+                {loadingMore ? 'Loading…' : 'Load more'}
+              </button>
+            </div>
           )}
         </div>
         {isFilmstrip ? (

--- a/src/styles.css
+++ b/src/styles.css
@@ -879,6 +879,12 @@ input:focus {
   font-size: 0.9rem;
 }
 
+.pagination-controls {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
 .empty-state {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add paginated library fetching in `useLibrary` with explicit `loadMore` support
- add a user-visible **Load more** control in Library grid mode
- harden in-memory pagination when `pageToken` is unknown and add tests for paging behavior

## Why
Implements a narrow, demoable increment for #22 (gallery MVP pagination).

## Validation
- npm run lint
- npm run test
- npm run build
- npm run format:check

Closes #22