### PR TITLE
Phase 3a slice: enforce share link policies with access audit events

### DIFF
--- a/src/adapters/sharing/inMemorySharingService.test.ts
+++ b/src/adapters/sharing/inMemorySharingService.test.ts
@@ -1,0 +1,49 @@
+import { InMemorySharingService } from './inMemorySharingService';
+
+describe('InMemorySharingService', () => {
+  it('enforces password policy and records deny/grant access events', async () => {
+    const service = new InMemorySharingService();
+
+    const link = await service.createShareLink({
+      resourceType: 'album',
+      resourceId: 'album-1',
+      policy: { permission: 'download' },
+      password: 'open-sesame',
+    });
+
+    const missingPassword = await service.resolveShareLink({ token: link.token });
+    const badPassword = await service.resolveShareLink({ token: link.token, password: 'wrong' });
+    const success = await service.resolveShareLink({ token: link.token, password: 'open-sesame' });
+
+    expect(missingPassword).toBeNull();
+    expect(badPassword).toBeNull();
+    expect(success?.id).toBe(link.id);
+
+    const events = await service.listAccessEvents('album-1');
+    expect(events).toHaveLength(3);
+    expect(events.map((event) => event.outcome)).toEqual([
+      'granted',
+      'denied_invalid_password',
+      'denied_invalid_password',
+    ]);
+  });
+
+  it('blocks max-use links after quota and records denial', async () => {
+    const service = new InMemorySharingService();
+
+    const link = await service.createShareLink({
+      resourceType: 'photo',
+      resourceId: 'photo-22',
+      policy: { maxUses: 1 },
+    });
+
+    const first = await service.resolveShareLink({ token: link.token });
+    const second = await service.resolveShareLink({ token: link.token });
+
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+
+    const events = await service.listAccessEvents('photo-22');
+    expect(events.map((event) => event.outcome)).toEqual(['denied_max_uses', 'granted']);
+  });
+});

--- a/src/api/contracts/sharing.ts
+++ b/src/api/contracts/sharing.ts
@@ -1,6 +1,7 @@
 import type {
   CreateShareLinkInput,
   ResolveShareLinkInput,
+  ShareAccessEvent,
   ShareLink,
 } from '../../domain/sharing/types';
 
@@ -15,6 +16,10 @@ export interface CreateShareLinkResponse {
 
 export interface ListShareLinksResponse {
   links: ShareLink[];
+}
+
+export interface ListShareAccessEventsResponse {
+  events: ShareAccessEvent[];
 }
 
 export type ResolveShareLinkRequest = ResolveShareLinkInput;

--- a/src/domain/sharing/contract.ts
+++ b/src/domain/sharing/contract.ts
@@ -1,8 +1,14 @@
-import type { CreateShareLinkInput, ResolveShareLinkInput, ShareLink } from './types';
+import type {
+  CreateShareLinkInput,
+  ResolveShareLinkInput,
+  ShareAccessEvent,
+  ShareLink,
+} from './types';
 
 export interface SharingService {
   createShareLink(input: CreateShareLinkInput): Promise<ShareLink>;
   listShareLinks(resourceId: string): Promise<ShareLink[]>;
   revokeShareLink(linkId: string): Promise<void>;
   resolveShareLink(input: ResolveShareLinkInput): Promise<ShareLink | null>;
+  listAccessEvents(resourceId: string): Promise<ShareAccessEvent[]>;
 }

--- a/src/domain/sharing/types.ts
+++ b/src/domain/sharing/types.ts
@@ -30,3 +30,19 @@ export interface ResolveShareLinkInput {
   token: string;
   password?: string;
 }
+
+export type ShareAccessOutcome =
+  | 'granted'
+  | 'denied_not_found'
+  | 'denied_revoked'
+  | 'denied_expired'
+  | 'denied_max_uses'
+  | 'denied_invalid_password';
+
+export interface ShareAccessEvent {
+  id: string;
+  linkId: string | null;
+  token: string;
+  outcome: ShareAccessOutcome;
+  occurredAt: string;
+}


### PR DESCRIPTION
## Summary\n- enforce password-protected share links during resolve (denies missing/wrong passwords)\n- record share access outcomes for grant + denial paths (not found/revoked/expired/max-use/password)\n- expose access event shape in sharing domain and API contract\n- add tests covering password enforcement and max-use denial audit behavior\n\n## Why\nImplements a narrow, user-usable increment of #27 (sharing policy engine + access activity audit) while staying backward compatible with existing share-link APIs.\n\n## Validation\n- npm run lint\n- npm run test -- --run\n- npm run build\n