### PR TITLE
Phase 1c slice: album create validation + non-blocking create UX

### DIFF
--- a/src/adapters/albums/inMemoryAlbumsService.test.ts
+++ b/src/adapters/albums/inMemoryAlbumsService.test.ts
@@ -57,6 +57,42 @@ describe('InMemoryAlbumsService', () => {
     expect(updated.folderId).toBe('folder-1');
   });
 
+  it('rejects duplicate album names case-insensitively on create', async () => {
+    const svc = new InMemoryAlbumsService([
+      {
+        id: 'a1',
+        name: 'Road Trip',
+        folderId: null,
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+
+    await expect(svc.createAlbum({ name: '  road trip ' })).rejects.toThrow(
+      'An album with this name already exists.'
+    );
+  });
+
+  it('rejects duplicate album names case-insensitively on rename', async () => {
+    const svc = new InMemoryAlbumsService([
+      {
+        id: 'a1',
+        name: 'Road Trip',
+        folderId: null,
+        createdAt: new Date().toISOString(),
+      },
+      {
+        id: 'a2',
+        name: 'Family',
+        folderId: null,
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+
+    await expect(svc.updateAlbum('a2', { name: 'road trip' })).rejects.toThrow(
+      'An album with this name already exists.'
+    );
+  });
+
   it('updates folder name', async () => {
     const svc = new InMemoryAlbumsService(
       [],

--- a/src/pages/AlbumsPage.tsx
+++ b/src/pages/AlbumsPage.tsx
@@ -306,10 +306,15 @@ export function AlbumsPage() {
 
   async function handleCreateAlbum(e: React.FormEvent) {
     e.preventDefault();
-    if (!albumName.trim()) return;
+    const trimmedName = albumName.trim();
+    if (!trimmedName) return;
+
     setCreating(true);
-    await createAlbum(albumName.trim());
     setAlbumName('');
+    const created = await createAlbum(trimmedName);
+    if (!created) {
+      setAlbumName(trimmedName);
+    }
     setCreating(false);
   }
 


### PR DESCRIPTION
## Summary\n- enforce case-insensitive unique album names in the in-memory albums adapter\n- preserve trimmed input and restore it in the form when create fails\n- add adapter tests for duplicate-name create/rename rejection\n\n## Why\nThis delivers a narrow user-facing increment for #20 around validation/error handling in the create flow while staying contract-aligned and backward compatible.\n\n## Validation\n- npm run lint\n- npm run test\n- npm run build\n- npm run format:check\n\nCloses #20