### PR TITLE
Phase 2b slice: derivative worker tick updates upload processing state

### DIFF
--- a/src/domain/uploads/contract.ts
+++ b/src/domain/uploads/contract.ts
@@ -17,4 +17,5 @@ export interface UploadSessionsService {
   finalizeUpload(input: FinalizeUploadInput): Promise<FinalizeUploadResult>;
   listUploadedMetadata(): Promise<UploadMetadata[]>;
   listDerivativeJobs(): Promise<DerivativeJobEnvelope[]>;
+  processNextDerivativeJob(): Promise<DerivativeJobEnvelope | null>;
 }

--- a/src/pages/LibraryPage.tsx
+++ b/src/pages/LibraryPage.tsx
@@ -60,6 +60,7 @@ export function LibraryPage() {
     jobs: derivativeJobs,
     replayedFinalize,
     createAndFinalizeSession,
+    processNextDerivativeJob,
   } = useUploadSessions(uploadSessionsService);
 
   const [isFilmstrip, setIsFilmstrip] = useState(false);
@@ -190,6 +191,9 @@ export function LibraryPage() {
     () => [...new Set(photos.flatMap((photo) => photo.tags))].sort((a, b) => a.localeCompare(b)),
     [photos]
   );
+
+  const queuedDerivativeJobs = derivativeJobs.filter((job) => job.status === 'queued').length;
+  const completedDerivativeJobs = derivativeJobs.filter((job) => job.status === 'completed').length;
 
   // Gallery toolbar configuration
   const galleryToolbarButtons = useMemo<ToolbarButton[]>(() => {
@@ -336,9 +340,23 @@ export function LibraryPage() {
           {(pendingSession || uploadedMetadata.length > 0) && (
             <div className="state-message" role="status" aria-live="polite">
               <strong>Upload pipeline:</strong> {uploadedMetadata.length} finalized ·{' '}
-              {derivativeJobs.length} derivative job(s) queued
+              {queuedDerivativeJobs} queued · {completedDerivativeJobs} completed
               {pendingSession ? ` · latest key ${pendingSession.objectKey}` : ''}
               {replayedFinalize ? ' · idempotent replay detected' : ''}
+              {queuedDerivativeJobs > 0 ? (
+                <>
+                  {' '}
+                  ·{' '}
+                  <button
+                    className="btn-ghost btn-sm"
+                    onClick={() => void processNextDerivativeJob()}
+                  >
+                    Run derivative worker tick
+                  </button>
+                </>
+              ) : (
+                ''
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- add a `processNextDerivativeJob` contract method for upload services
- implement in-memory derivative processing to move queued jobs to completed and mark upload metadata as completed
- expose a user-triggered "Run derivative worker tick" action in Library upload pipeline status
- add unit coverage for derivative job processing behavior

## Why
This delivers an incremental, demoable step for implementation-plan Phase 2 derivative generation pipeline (#8) while preserving current upload UX.

## Testing
- npm run lint
- npm run test
- npm run build
- npm run format:check

Closes #8