### PR TITLE
Issue #23: persist library grid density preference

### DIFF
--- a/src/features/library/quickViewPreferences.test.ts
+++ b/src/features/library/quickViewPreferences.test.ts
@@ -16,6 +16,7 @@ describe('quickViewPreferences', () => {
       quickCollection: 'all',
       activeTagFilter: '',
       cameraMakeFilter: '',
+      gridMode: 'medium',
     });
   });
 
@@ -24,6 +25,7 @@ describe('quickViewPreferences', () => {
       quickCollection: 'favorites',
       activeTagFilter: 'trip',
       cameraMakeFilter: 'Canon',
+      gridMode: 'large',
     };
 
     saveQuickViewPreferences(LIBRARY_ID, preferences);
@@ -38,6 +40,7 @@ describe('quickViewPreferences', () => {
         quickCollection: 'not-a-real-collection',
         activeTagFilter: 'family',
         cameraMakeFilter: 'Nikon',
+        gridMode: 'giant',
       })
     );
 
@@ -45,6 +48,7 @@ describe('quickViewPreferences', () => {
       quickCollection: 'all',
       activeTagFilter: 'family',
       cameraMakeFilter: 'Nikon',
+      gridMode: 'medium',
     });
   });
 });

--- a/src/features/library/quickViewPreferences.ts
+++ b/src/features/library/quickViewPreferences.ts
@@ -1,9 +1,12 @@
+import type { GridMode } from '../../components/photoGalleryConfig';
+
 export type LibraryQuickCollectionSelection = 'all' | 'favorites' | 'untagged' | 'recent';
 
 export interface LibraryQuickViewPreferences {
   quickCollection: LibraryQuickCollectionSelection;
   activeTagFilter: string;
   cameraMakeFilter: string;
+  gridMode: GridMode;
 }
 
 const STORAGE_KEY_PREFIX = 'aurapix.library.quick-view';
@@ -12,6 +15,7 @@ const DEFAULT_PREFERENCES: LibraryQuickViewPreferences = {
   quickCollection: 'all',
   activeTagFilter: '',
   cameraMakeFilter: '',
+  gridMode: 'medium',
 };
 
 function toStorageKey(libraryId: string) {
@@ -24,6 +28,14 @@ function normalizeQuickCollection(value: unknown): LibraryQuickCollectionSelecti
   }
 
   return DEFAULT_PREFERENCES.quickCollection;
+}
+
+function normalizeGridMode(value: unknown): GridMode {
+  if (value === 'small' || value === 'medium' || value === 'large') {
+    return value;
+  }
+
+  return DEFAULT_PREFERENCES.gridMode;
 }
 
 export function loadQuickViewPreferences(libraryId: string): LibraryQuickViewPreferences {
@@ -42,6 +54,7 @@ export function loadQuickViewPreferences(libraryId: string): LibraryQuickViewPre
       quickCollection: normalizeQuickCollection(parsed.quickCollection),
       activeTagFilter: typeof parsed.activeTagFilter === 'string' ? parsed.activeTagFilter : '',
       cameraMakeFilter: typeof parsed.cameraMakeFilter === 'string' ? parsed.cameraMakeFilter : '',
+      gridMode: normalizeGridMode(parsed.gridMode),
     };
   } catch {
     return DEFAULT_PREFERENCES;

--- a/src/pages/LibraryPage.tsx
+++ b/src/pages/LibraryPage.tsx
@@ -40,6 +40,7 @@ export function LibraryPage() {
   const [activeTagFilter, setActiveTagFilter] = useState<string>(
     initialQuickViewPreferences.activeTagFilter
   );
+  const [gridMode, setGridMode] = useState<GridMode>(initialQuickViewPreferences.gridMode);
   const metadataFilters = useMemo(
     () => ({
       metadata: cameraMakeFilter ? { cameraMake: cameraMakeFilter } : undefined,
@@ -55,8 +56,9 @@ export function LibraryPage() {
       quickCollection,
       activeTagFilter,
       cameraMakeFilter,
+      gridMode,
     });
-  }, [libraryId, quickCollection, activeTagFilter, cameraMakeFilter]);
+  }, [libraryId, quickCollection, activeTagFilter, cameraMakeFilter, gridMode]);
 
   const {
     photos,
@@ -85,7 +87,6 @@ export function LibraryPage() {
 
   const [isFilmstrip, setIsFilmstrip] = useState(false);
   const [showUploadModal, setShowUploadModal] = useState(false);
-  const [gridMode, setGridMode] = useState<GridMode>('medium');
   const [selectedPhotoIds, setSelectedPhotoIds] = useState<Set<string>>(new Set());
   const [bulkAlbumId, setBulkAlbumId] = useState<string>('');
   const [bulkTagInput, setBulkTagInput] = useState<string>('');


### PR DESCRIPTION
## Summary
- persist selected library grid mode (small/medium/large) with existing quick-view preferences
- initialize Library page grid mode from saved preferences on load
- add normalization + tests so invalid stored values safely fall back to medium

## Why
This is an incremental follow-on for #23 so quick-view state survives refresh/session changes, including tile density.

## Validation
- npm run lint
- npm run test
- npm run build
- npm run format:check