### PR TITLE
Issue #23: add one-tap library tag quick filters

### DIFF
--- a/src/pages/LibraryPage.tsx
+++ b/src/pages/LibraryPage.tsx
@@ -212,6 +212,7 @@ export function LibraryPage() {
     () => [...new Set(photos.flatMap((photo) => photo.tags))].sort((a, b) => a.localeCompare(b)),
     [photos]
   );
+  const topQuickTags = useMemo(() => availableTags.slice(0, 4), [availableTags]);
 
   const queuedDerivativeJobs = derivativeJobs.filter((job) => job.status === 'queued').length;
   const completedDerivativeJobs = derivativeJobs.filter((job) => job.status === 'completed').length;
@@ -318,6 +319,16 @@ export function LibraryPage() {
                 </option>
               ))}
             </select>
+            {topQuickTags.map((tag) => (
+              <button
+                key={tag}
+                className={`btn-ghost btn-sm${activeTagFilter === tag ? ' active' : ''}`}
+                title={`Filter by #${tag}`}
+                onClick={() => setActiveTagFilter(activeTagFilter === tag ? '' : tag)}
+              >
+                #{tag}
+              </button>
+            ))}
             <select
               className="btn-ghost btn-sm"
               aria-label="Filter by camera make"


### PR DESCRIPTION
## Summary\n- adds top tag quick-filter chips to the library title bar controls\n- lets users toggle a tag filter with one click (click again to clear)\n- keeps existing tag dropdown for full tag list selection\n\n## Why\nIssue #23 calls for better quick views around favorites/tags. This increment improves tag filtering ergonomics in a user-visible, demoable way while staying small and reversible.\n\n## Validation\n- npm run lint\n- npm run test -- --run\n- npm run build:frontend\n\nCloses #23