### PR TITLE
Issue #24: add upload App Check rollout gate baseline

### DIFF
--- a/functions/.env.example
+++ b/functions/.env.example
@@ -34,6 +34,9 @@ AUTH_MODE=mock
 # AUTH_MODE=firebase
 UPLOAD_RATE_LIMIT_WINDOW_MS=60000
 UPLOAD_RATE_LIMIT_MAX_REQUESTS=30
+APP_CHECK_ENFORCE_UPLOADS=false
+# Comma-separated temporary bypass tokens for controlled rollout/testing
+# APP_CHECK_BYPASS_TOKENS=dev-bypass-token
 
 # Logging
 LOG_LEVEL=info

--- a/functions/src/config/index.ts
+++ b/functions/src/config/index.ts
@@ -55,4 +55,8 @@ export const securityConfig = {
     windowMs: parseInt(process.env.UPLOAD_RATE_LIMIT_WINDOW_MS || '60000', 10),
     maxRequests: parseInt(process.env.UPLOAD_RATE_LIMIT_MAX_REQUESTS || '30', 10),
   },
+  appCheck: {
+    enforceUploads: process.env.APP_CHECK_ENFORCE_UPLOADS === 'true',
+    bypassTokens: process.env.APP_CHECK_BYPASS_TOKENS || '',
+  },
 } as const;

--- a/functions/src/middleware/appCheck.ts
+++ b/functions/src/middleware/appCheck.ts
@@ -1,0 +1,63 @@
+import type { NextFunction, Request, Response } from 'express';
+import { AppError } from './errorHandler.js';
+import { securityConfig } from '../config/index.js';
+
+const APP_CHECK_HEADER = 'x-firebase-appcheck';
+
+function getBypassTokens(): Set<string> {
+  const raw = securityConfig.appCheck.bypassTokens;
+  if (!raw) {
+    return new Set();
+  }
+
+  return new Set(
+    raw
+      .split(',')
+      .map((token) => token.trim())
+      .filter(Boolean)
+  );
+}
+
+/**
+ * Baseline App Check gate for upload endpoints.
+ *
+ * This intentionally starts as a conservative compatibility baseline:
+ * - Disabled by default (APP_CHECK_ENFORCE_UPLOADS=false)
+ * - Requires presence of X-Firebase-AppCheck when enabled
+ * - Supports explicit bypass tokens for local/testing rollout
+ *
+ * TODO: Replace structural validation with Firebase Admin appCheck().verifyToken()
+ * when deployment credentials and rollout policy are finalized.
+ */
+export function appCheckUploadMiddleware(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+): void {
+  if (!securityConfig.appCheck.enforceUploads) {
+    next();
+    return;
+  }
+
+  const token = req.header(APP_CHECK_HEADER);
+  if (!token) {
+    throw new AppError(
+      401,
+      'APP_CHECK_REQUIRED',
+      'App Check token required for upload operations'
+    );
+  }
+
+  const bypassTokens = getBypassTokens();
+  if (bypassTokens.has(token)) {
+    next();
+    return;
+  }
+
+  // Minimal structural check for baseline rollout.
+  if (token.trim().length < 20) {
+    throw new AppError(403, 'APP_CHECK_INVALID', 'Invalid App Check token');
+  }
+
+  next();
+}

--- a/functions/src/routes/images.ts
+++ b/functions/src/routes/images.ts
@@ -3,6 +3,7 @@ import { handleUpload, uploadMiddleware } from '../handlers/images/upload.js';
 import { handleServeImage } from '../handlers/images/serve.js';
 import { requireAuth } from '../middleware/auth.js';
 import { createSlidingWindowRateLimiter } from '../middleware/rateLimit.js';
+import { appCheckUploadMiddleware } from '../middleware/appCheck.js';
 import { securityConfig } from '../config/index.js';
 
 const router = Router();
@@ -16,7 +17,7 @@ const uploadRateLimiter = createSlidingWindowRateLimiter({
  * Upload a photo
  * POST /images/:libraryId
  */
-router.post('/:libraryId', requireAuth, uploadRateLimiter, uploadMiddleware, async (req, res, next) => {
+router.post('/:libraryId', requireAuth, appCheckUploadMiddleware, uploadRateLimiter, uploadMiddleware, async (req, res, next) => {
   try {
     await handleUpload(req, res);
   } catch (error) {

--- a/functions/test/middleware/appCheck.test.ts
+++ b/functions/test/middleware/appCheck.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const DEFAULT_ENV = {
+  APP_CHECK_ENFORCE_UPLOADS: process.env.APP_CHECK_ENFORCE_UPLOADS,
+  APP_CHECK_BYPASS_TOKENS: process.env.APP_CHECK_BYPASS_TOKENS,
+};
+
+function restoreEnv(): void {
+  process.env.APP_CHECK_ENFORCE_UPLOADS = DEFAULT_ENV.APP_CHECK_ENFORCE_UPLOADS;
+  process.env.APP_CHECK_BYPASS_TOKENS = DEFAULT_ENV.APP_CHECK_BYPASS_TOKENS;
+}
+
+describe('appCheckUploadMiddleware', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.APP_CHECK_ENFORCE_UPLOADS;
+    delete process.env.APP_CHECK_BYPASS_TOKENS;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    vi.resetModules();
+  });
+
+  it('passes through when enforcement is disabled', async () => {
+    const { appCheckUploadMiddleware } = await import('../../src/middleware/appCheck.js');
+    const next = vi.fn();
+
+    appCheckUploadMiddleware(
+      { header: () => undefined } as any,
+      {} as any,
+      next
+    );
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('rejects missing token when enforcement is enabled', async () => {
+    process.env.APP_CHECK_ENFORCE_UPLOADS = 'true';
+    const { appCheckUploadMiddleware } = await import('../../src/middleware/appCheck.js');
+
+    expect(() => {
+      appCheckUploadMiddleware(
+        { header: () => undefined } as any,
+        {} as any,
+        vi.fn()
+      );
+    }).toThrowError(/App Check token required/);
+  });
+
+  it('accepts configured bypass token', async () => {
+    process.env.APP_CHECK_ENFORCE_UPLOADS = 'true';
+    process.env.APP_CHECK_BYPASS_TOKENS = 'dev-bypass-token';
+    const { appCheckUploadMiddleware } = await import('../../src/middleware/appCheck.js');
+    const next = vi.fn();
+
+    appCheckUploadMiddleware(
+      { header: () => 'dev-bypass-token' } as any,
+      {} as any,
+      next
+    );
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated upload App Check middleware for upload endpoints
- gate enforcement behind `APP_CHECK_ENFORCE_UPLOADS=false` by default
- support explicit comma-delimited bypass tokens for controlled rollout/testing
- add middleware tests for disabled mode, missing-token rejection, and bypass acceptance
- document new env vars in `functions/.env.example`

## Why
Issue #24 tracks App Check + rate limits + auth lockout/recovery. Rate limiting baseline is already merged. This PR adds the App Check rollout baseline as the next incremental, reversible hardening step while preserving compatibility by default.

## Validation
- `npm --prefix functions test` ✅

## Notes
- `npm --prefix functions run build` currently fails from unrelated pre-existing TypeScript errors in other files.
