### PR TITLE
Issue #20: improve album create UX with folder selection + validation

### DIFF
--- a/src/pages/AlbumsPage.test.tsx
+++ b/src/pages/AlbumsPage.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from '../App';
+
+describe('AlbumsPage', () => {
+  it('creates an album and updates the list without page reload', async () => {
+    window.history.pushState({}, '', '/albums');
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: 'Albums' })).toBeInTheDocument();
+
+    const albumInput = screen.getByPlaceholderText('New album name');
+    await user.type(albumInput, 'Road Trip 2026');
+    await user.click(screen.getByRole('button', { name: 'Create album' }));
+
+    expect((await screen.findAllByRole('link', { name: 'Road Trip 2026' })).length).toBeGreaterThan(0);
+  });
+
+  it('shows a validation error for duplicate album names', async () => {
+    window.history.pushState({}, '', '/albums');
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: 'Albums' })).toBeInTheDocument();
+
+    const albumInput = screen.getByPlaceholderText('New album name');
+    await user.type(albumInput, 'Sample Highlights');
+    await user.click(screen.getByRole('button', { name: 'Create album' }));
+
+    expect(await screen.findByText('An album with this name already exists.')).toBeInTheDocument();
+  });
+
+  it('supports selecting a folder during album creation', async () => {
+    window.history.pushState({}, '', '/albums');
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: 'Albums' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'New Folder' }));
+    await user.type(screen.getByPlaceholderText('Folder name'), 'Trips');
+    await user.click(screen.getByRole('button', { name: 'Create folder' }));
+
+    await user.type(screen.getByPlaceholderText('New album name'), 'Weekend Getaway');
+    await user.selectOptions(
+      screen.getByLabelText('Album folder'),
+      screen.getAllByRole('option', { name: 'Trips' })[0]
+    );
+    await user.click(screen.getByRole('button', { name: 'Create album' }));
+
+    const tripsSection = await screen.findByRole('link', { name: 'Trips' });
+    expect(tripsSection).toBeInTheDocument();
+    expect((await screen.findAllByRole('link', { name: 'Weekend Getaway' })).length).toBeGreaterThan(0);
+  });
+});

--- a/src/pages/AlbumsPage.tsx
+++ b/src/pages/AlbumsPage.tsx
@@ -297,6 +297,8 @@ export function AlbumsPage() {
   const { photos } = useLibrary(libraryId);
 
   const [albumName, setAlbumName] = useState('');
+  const [albumFolderId, setAlbumFolderId] = useState('');
+  const [albumFormError, setAlbumFormError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [folderName, setFolderName] = useState('');
   const [showFolderForm, setShowFolderForm] = useState(false);
@@ -307,13 +309,19 @@ export function AlbumsPage() {
   async function handleCreateAlbum(e: React.FormEvent) {
     e.preventDefault();
     const trimmedName = albumName.trim();
-    if (!trimmedName) return;
+    if (!trimmedName) {
+      setAlbumFormError('Album name is required.');
+      return;
+    }
 
+    setAlbumFormError(null);
     setCreating(true);
     setAlbumName('');
-    const created = await createAlbum(trimmedName);
+    const created = await createAlbum(trimmedName, albumFolderId || null);
     if (!created) {
       setAlbumName(trimmedName);
+    } else {
+      setAlbumFolderId('');
     }
     setCreating(false);
   }
@@ -395,13 +403,32 @@ export function AlbumsPage() {
             type="text"
             placeholder="New album name"
             value={albumName}
-            onChange={(e) => setAlbumName(e.target.value)}
+            onChange={(e) => {
+              setAlbumName(e.target.value);
+              if (albumFormError) setAlbumFormError(null);
+            }}
             disabled={creating}
           />
+          <select
+            value={albumFolderId}
+            onChange={(e) => setAlbumFolderId(e.target.value)}
+            disabled={creating}
+            aria-label="Album folder"
+            title="Place album in a folder"
+          >
+            <option value="">No folder</option>
+            {folders.map((folder) => (
+              <option key={folder.id} value={folder.id}>
+                {folder.name}
+              </option>
+            ))}
+          </select>
           <button type="submit" disabled={creating || !albumName.trim()}>
             {creating ? 'Creating…' : 'Create album'}
           </button>
         </form>
+
+        {albumFormError && <p className="error">{albumFormError}</p>}
 
         {error && <p className="error">{error}</p>}
 


### PR DESCRIPTION
## Summary\nImplements a user-visible increment for #20 by improving the Albums create flow in the existing contract-aligned stub experience.\n\n## What changed\n- Added album folder selection directly in the create album form (optional, defaults to no folder)\n- Added inline required-name validation message for album creation attempts\n- Kept create behavior non-blocking while preserving existing backward-compatible API usage\n- Added integration tests covering:\n  - create -> list update without reload\n  - duplicate-name error display\n  - folder selection during album creation\n\n## Validation\n- 
> aurapix@0.0.0 lint
> eslint .\n- 
> aurapix@0.0.0 test
> vitest --run


 RUN  v3.2.4 /Users/rwrife/.openclaw/workspace/aurapix

 ✓ src/features/library/quickViewPreferences.test.ts (3 tests) 2ms
 ✓ src/adapters/sharing/inMemorySharingService.test.ts (3 tests) 2ms
 ✓ src/features/uploads/supportedUploadFiles.test.ts (3 tests) 1ms
 ✓ src/adapters/uploads/inMemoryUploadSessionsService.test.ts (7 tests) 4ms
 ✓ src/adapters/auth/inMemoryAuthService.test.ts (9 tests) 5ms
 ✓ src/adapters/albums/inMemoryAlbumsService.test.ts (9 tests) 9ms
 ✓ src/adapters/library/inMemoryLibraryService.test.ts (14 tests) 11ms
stdout | src/pages/AlbumsPage.test.tsx > AlbumsPage > creates an album and updates the list without page reload
[HealthCheck] Starting health monitoring (checking every 30s)
[HealthCheck] Backend URL: http://localhost:3001
[HealthCheck] Checking endpoint: http://localhost:3001/internal/health
🩺 Health Debug Tools loaded. Try:
  __debugHealth.check()   - Run health check now
  __debugHealth.status()  - Get current status
  __debugHealth.subscribe() - Watch for changes

stdout | src/App.test.tsx > App > renders the app shell with navigation links
[HealthCheck] Starting health monitoring (checking every 30s)
[HealthCheck] Backend URL: http://localhost:3001
[HealthCheck] Checking endpoint: http://localhost:3001/internal/health
🩺 Health Debug Tools loaded. Try:
  __debugHealth.check()   - Run health check now
  __debugHealth.status()  - Get current status
  __debugHealth.subscribe() - Watch for changes

stdout | src/App.test.tsx > App > shows the library page by default
[HealthCheck] Starting health monitoring (checking every 30s)
[HealthCheck] Backend URL: http://localhost:3001
[HealthCheck] Checking endpoint: http://localhost:3001/internal/health
🩺 Health Debug Tools loaded. Try:
  __debugHealth.check()   - Run health check now
  __debugHealth.status()  - Get current status
  __debugHealth.subscribe() - Watch for changes

stdout | src/App.test.tsx > App > displays the current user in the header
[HealthCheck] Starting health monitoring (checking every 30s)
[HealthCheck] Backend URL: http://localhost:3001
[HealthCheck] Checking endpoint: http://localhost:3001/internal/health
🩺 Health Debug Tools loaded. Try:
  __debugHealth.check()   - Run health check now
  __debugHealth.status()  - Get current status
  __debugHealth.subscribe() - Watch for changes

 ✓ src/App.test.tsx (3 tests) 80ms
stdout | src/pages/AlbumsPage.test.tsx > AlbumsPage > shows a validation error for duplicate album names
[HealthCheck] Starting health monitoring (checking every 30s)
[HealthCheck] Backend URL: http://localhost:3001
[HealthCheck] Checking endpoint: http://localhost:3001/internal/health
🩺 Health Debug Tools loaded. Try:
  __debugHealth.check()   - Run health check now
  __debugHealth.status()  - Get current status
  __debugHealth.subscribe() - Watch for changes

stdout | src/pages/AlbumsPage.test.tsx > AlbumsPage > supports selecting a folder during album creation
[HealthCheck] Starting health monitoring (checking every 30s)
[HealthCheck] Backend URL: http://localhost:3001
[HealthCheck] Checking endpoint: http://localhost:3001/internal/health
🩺 Health Debug Tools loaded. Try:
  __debugHealth.check()   - Run health check now
  __debugHealth.status()  - Get current status
  __debugHealth.subscribe() - Watch for changes

 ✓ src/pages/AlbumsPage.test.tsx (3 tests) 306ms

 Test Files  9 passed (9)
      Tests  54 passed (54)
   Start at  19:09:28
   Duration  1.00s (transform 231ms, setup 332ms, collect 611ms, tests 419ms, environment 2.53s, prepare 339ms)\n- 
> aurapix@0.0.0 build
> npm-run-all build:frontend build:backend


> aurapix@0.0.0 build:frontend
> tsc -b && vite build

vite v6.4.1 building for production...
transforming...
✓ 67 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                   0.39 kB │ gzip:  0.27 kB
dist/assets/index-C4uzvzDV.css   25.13 kB │ gzip:  4.98 kB
dist/assets/index-Dz54cFfd.js   248.31 kB │ gzip: 76.02 kB
✓ built in 338ms

> aurapix@0.0.0 build:backend
> npm --prefix functions run build


> aurapix-functions@0.1.0 build
> tsc

src/adapters/storage/FirebaseStorageAdapter.ts(147,9): error TS2322: Type '{ [key: string]: string | number | boolean | null; }' is not assignable to type 'Record<string, string>'.
  'string' index signatures are incompatible.
    Type 'string | number | boolean | null' is not assignable to type 'string'.
      Type 'null' is not assignable to type 'string'.
src/handlers/edits/applyEdits.ts(27,11): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/edits/applyEdits.ts(35,11): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/edits/applyEdits.ts(40,64): error TS2345: Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/handlers/edits/applyEdits.ts(42,13): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/edits/applyEdits.ts(46,13): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/edits/applyEdits.ts(63,51): error TS2345: Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/handlers/edits/applyEdits.ts(101,11): error TS2345: Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/handlers/edits/applyEdits.ts(118,11): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/edits/applyEdits.ts(140,11): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/edits/applyEdits.ts(145,64): error TS2345: Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/handlers/edits/applyEdits.ts(147,13): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/edits/applyEdits.ts(151,13): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/edits/applyEdits.ts(156,13): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/edits/applyEdits.ts(170,51): error TS2345: Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/handlers/edits/applyEdits.ts(195,11): error TS2345: Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/handlers/edits/applyEdits.ts(212,11): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/images/serve.ts(29,11): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/images/serve.ts(39,64): error TS2345: Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/handlers/images/serve.ts(41,13): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/images/serve.ts(45,13): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/images/serve.ts(74,9): error TS2345: Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/handlers/images/serve.ts(90,11): error TS2345: Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/handlers/images/serve.ts(101,11): error TS2345: Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/handlers/images/serve.ts(127,13): error TS2345: Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/handlers/images/serve.ts(169,11): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/images/upload.ts(25,10): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/images/upload.ts(54,20): error TS2339: Property 'DateTimeOriginal' does not exist on type 'Buffer<ArrayBufferLike>'.
src/handlers/images/upload.ts(55,23): error TS2339: Property 'DateTimeOriginal' does not exist on type 'Buffer<ArrayBufferLike>'.
src/handlers/images/upload.ts(57,23): error TS2339: Property 'Make' does not exist on type 'Buffer<ArrayBufferLike>'.
src/handlers/images/upload.ts(58,24): error TS2339: Property 'Model' does not exist on type 'Buffer<ArrayBufferLike>'.
src/handlers/images/upload.ts(78,11): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/images/upload.ts(82,11): error TS2554: Expected 3-4 arguments, but got 2.
src/handlers/images/upload.ts(97,45): error TS2345: Argument of type 'string | string[]' is not assignable to parameter of type 'string'.
  Type 'string[]' is not assignable to type 'string'.
src/handlers/images/upload.ts(105,9): error TS2322: Type 'string | string[]' is not assignable to type 'string'.
  Type 'string[]' is not assignable to type 'string'.
src/handlers/images/upload.ts(113,7): error TS2345: Argument of type 'string | string[]' is not assignable to parameter of type 'string'.
  Type 'string[]' is not assignable to type 'string'.
src/handlers/images/upload.ts(151,11): error TS2345: Argument of type 'string | string[]' is not assignable to parameter of type 'string'.
  Type 'string[]' is not assignable to type 'string'.
src/handlers/images/upload.ts(164,11): error TS2554: Expected 3-4 arguments, but got 2.
src/middleware/auth.ts(102,66): error TS2769: No overload matches this call.
  Overload 1 of 3, '(obj: "Unauthenticated request to protected endpoint", msg?: undefined): void', gave the following error.
    Argument of type '{ path: string; method: string; }' is not assignable to parameter of type 'undefined'.
  Overload 2 of 3, '(obj: "Unauthenticated request to protected endpoint", msg?: undefined, ...args: unknown[]): void', gave the following error.
    Argument of type '{ path: string; method: string; }' is not assignable to parameter of type 'undefined'.
src/routes/internal.ts(43,9): error TS2345: Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/routes/internal.ts(57,9): error TS2554: Expected 3-4 arguments, but got 2. *(frontend succeeds; backend currently has pre-existing TypeScript errors unrelated to this PR)*\n\n## Notes\n- No contract/DB/API breaking changes\n- Scope intentionally limited to one sub-issue increment in #20\n\nCloses #20