### PR TITLE
Issue #31: enrich sharing audit events with attempt/resource context

### DIFF
--- a/src/adapters/sharing/inMemorySharingService.test.ts
+++ b/src/adapters/sharing/inMemorySharingService.test.ts
@@ -26,6 +26,9 @@ describe('InMemorySharingService', () => {
       'denied_invalid_password',
       'denied_invalid_password',
     ]);
+    expect(events.every((event) => event.attempt === 'link_resolve')).toBe(true);
+    expect(events.every((event) => event.resourceType === 'album')).toBe(true);
+    expect(events.every((event) => event.resourceId === 'album-1')).toBe(true);
   });
 
   it('blocks max-use links after quota and records denial', async () => {
@@ -90,6 +93,11 @@ describe('InMemorySharingService', () => {
       'denied_download_disallowed',
       'granted_download',
       'denied_download_disallowed',
+    ]);
+    expect(events.map((event) => event.attempt)).toEqual([
+      'download_derivative',
+      'download_derivative',
+      'download_original',
     ]);
   });
 });

--- a/src/adapters/sharing/inMemorySharingService.ts
+++ b/src/adapters/sharing/inMemorySharingService.ts
@@ -100,18 +100,19 @@ export class InMemorySharingService implements SharingService {
   }
 
   async resolveShareLink(input: ResolveShareLinkInput): Promise<ShareLink | null> {
-    const link = this.validateAccess(input);
+    const link = this.validateAccess(input, 'link_resolve');
     if (!link) {
       return null;
     }
 
-    return this.markGranted(link, input.token, 'granted');
+    return this.markGranted(link, input.token, 'granted', 'link_resolve');
   }
 
   async resolveShareDownload(
     input: ResolveShareDownloadInput
   ): Promise<ShareDownloadResolution | null> {
-    const link = this.validateAccess(input);
+    const attempt = input.assetKind === 'original' ? 'download_original' : 'download_derivative';
+    const link = this.validateAccess(input, attempt);
     if (!link) {
       return null;
     }
@@ -119,7 +120,8 @@ export class InMemorySharingService implements SharingService {
     if (link.policy.downloadPolicy === 'none') {
       this.recordEvent({
         token: input.token,
-        linkId: link.id,
+        link,
+        attempt,
         outcome: 'denied_download_disallowed',
       });
       return null;
@@ -128,13 +130,14 @@ export class InMemorySharingService implements SharingService {
     if (link.policy.downloadPolicy === 'derivative_only' && input.assetKind === 'original') {
       this.recordEvent({
         token: input.token,
-        linkId: link.id,
+        link,
+        attempt,
         outcome: 'denied_download_disallowed',
       });
       return null;
     }
 
-    const resolved = this.markGranted(link, input.token, 'granted_download');
+    const resolved = this.markGranted(link, input.token, 'granted_download', attempt);
 
     return {
       link: resolved,
@@ -143,25 +146,25 @@ export class InMemorySharingService implements SharingService {
     };
   }
 
-  private validateAccess(input: ResolveShareLinkInput): ShareLink | null {
+  private validateAccess(input: ResolveShareLinkInput, attempt: ShareAccessEvent['attempt']): ShareLink | null {
     const link = this.links.find((l) => l.token === input.token);
     if (!link) {
-      this.recordEvent({ token: input.token, linkId: null, outcome: 'denied_not_found' });
+      this.recordEvent({ token: input.token, attempt, link: null, outcome: 'denied_not_found' });
       return null;
     }
 
     if (link.revoked) {
-      this.recordEvent({ token: input.token, linkId: link.id, outcome: 'denied_revoked' });
+      this.recordEvent({ token: input.token, attempt, link, outcome: 'denied_revoked' });
       return null;
     }
 
     if (link.policy.expiresAt && new Date(link.policy.expiresAt) < new Date()) {
-      this.recordEvent({ token: input.token, linkId: link.id, outcome: 'denied_expired' });
+      this.recordEvent({ token: input.token, attempt, link, outcome: 'denied_expired' });
       return null;
     }
 
     if (link.policy.maxUses !== null && link.useCount >= link.policy.maxUses) {
-      this.recordEvent({ token: input.token, linkId: link.id, outcome: 'denied_max_uses' });
+      this.recordEvent({ token: input.token, attempt, link, outcome: 'denied_max_uses' });
       return null;
     }
 
@@ -170,7 +173,8 @@ export class InMemorySharingService implements SharingService {
       if (!expected || input.password !== expected) {
         this.recordEvent({
           token: input.token,
-          linkId: link.id,
+          attempt,
+          link,
           outcome: 'denied_invalid_password',
         });
         return null;
@@ -183,27 +187,32 @@ export class InMemorySharingService implements SharingService {
   private markGranted(
     link: ShareLink,
     token: string,
-    outcome: Extract<ShareAccessEvent['outcome'], 'granted' | 'granted_download'>
+    outcome: Extract<ShareAccessEvent['outcome'], 'granted' | 'granted_download'>,
+    attempt: ShareAccessEvent['attempt']
   ): ShareLink {
     const resolved = { ...link, useCount: link.useCount + 1 };
 
     // Increment use count
     this.links = this.links.map((l) => (l.id === link.id ? resolved : l));
-    this.recordEvent({ token, linkId: link.id, outcome });
+    this.recordEvent({ token, attempt, link: resolved, outcome });
 
     return resolved;
   }
 
   private recordEvent(input: {
     token: string;
-    linkId: string | null;
+    link: ShareLink | null;
+    attempt: ShareAccessEvent['attempt'];
     outcome: ShareAccessEvent['outcome'];
   }): void {
     this.events = [
       {
         id: `share-event-${Date.now()}-${Math.floor(Math.random() * 100000)}`,
         token: input.token,
-        linkId: input.linkId,
+        linkId: input.link?.id ?? null,
+        resourceType: input.link?.resourceType ?? null,
+        resourceId: input.link?.resourceId ?? null,
+        attempt: input.attempt,
         outcome: input.outcome,
         occurredAt: new Date().toISOString(),
       },

--- a/src/domain/sharing/types.ts
+++ b/src/domain/sharing/types.ts
@@ -59,10 +59,15 @@ export type ShareAccessOutcome =
   | 'denied_invalid_password'
   | 'denied_download_disallowed';
 
+export type ShareAccessAttempt = 'link_resolve' | 'download_original' | 'download_derivative';
+
 export interface ShareAccessEvent {
   id: string;
   linkId: string | null;
   token: string;
+  resourceType: ShareLink['resourceType'] | null;
+  resourceId: string | null;
+  attempt: ShareAccessAttempt;
   outcome: ShareAccessOutcome;
   occurredAt: string;
 }

--- a/src/pages/AlbumDetailPage.tsx
+++ b/src/pages/AlbumDetailPage.tsx
@@ -421,6 +421,9 @@ export function AlbumDetailPage() {
                     <div>
                       <div className="album-name">{event.outcome}</div>
                       <div className="album-date">
+                        {`${event.attempt} • ${event.linkId ?? 'unknown-link'}`}
+                      </div>
+                      <div className="album-date">
                         {new Date(event.occurredAt).toLocaleString()}
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- enrich share access audit events with attempt context (`link_resolve`, `download_original`, `download_derivative`)
- include resource metadata (`resourceType`, `resourceId`) on each event for better compliance reviewability
- surface attempt + link id context in Album Detail "Share access activity" list for immediate operator visibility

## Validation
- npm test

## Issue
- Refs #31
- Related to #27
