### PR TITLE
Issue #32: add share download probe controls in album sharing UI

### DIFF
--- a/src/features/sharing/useSharing.ts
+++ b/src/features/sharing/useSharing.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import type {
   ShareAccessEvent,
   ShareDownloadPolicy,
+  ShareDownloadResolution,
   ShareLink,
   SharePermission,
 } from '../../domain/sharing/types';
@@ -33,6 +34,11 @@ interface UseSharingReturn extends UseSharingState {
   revokeLink(linkId: string): Promise<void>;
   refreshAccessEvents(): Promise<void>;
   updateLinkPolicy(linkId: string, policy: Partial<ShareLink['policy']>): Promise<ShareLink>;
+  resolveDownload(
+    token: string,
+    assetKind: 'original' | 'derivative',
+    password?: string
+  ): Promise<ShareDownloadResolution | null>;
 }
 
 export function useSharing(resourceId: string): UseSharingReturn {
@@ -127,6 +133,13 @@ export function useSharing(resourceId: string): UseSharingReturn {
     [sharing]
   );
 
+  const resolveDownload = useCallback(
+    async (token: string, assetKind: 'original' | 'derivative', password?: string) => {
+      return sharing.resolveShareDownload({ token, assetKind, password });
+    },
+    [sharing]
+  );
+
   return {
     links,
     accessEvents,
@@ -138,5 +151,6 @@ export function useSharing(resourceId: string): UseSharingReturn {
     revokeLink,
     updateLinkPolicy,
     refreshAccessEvents,
+    resolveDownload,
   };
 }


### PR DESCRIPTION
## Summary
- add a share download probe action in the album sharing UI for both original and derivative assets
- wire a new useSharing resolveDownload helper to exercise download policy enforcement directly from the UI
- show per-link probe outcomes and refresh share access events after each probe

## Why
This adds a user-usable/demoable increment for issue #32 by letting creators validate download policy + watermark behavior from the same place they manage share links.

## Testing
- npm run -s test

Closes #32
