### PR TITLE
Phase 1b: add versioned albums API contract artifact + CI breaking-change gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,11 @@ jobs:
       - name: Build Frontend
         run: npm run build:frontend
 
+      - name: Fetch base branch for contract diff
+        run: git fetch --no-tags --depth=1 origin main
+
+      - name: Contract check
+        run: npm run contract:check
+
       - name: Format Check (temporarily informational)
         run: npm run format:check || true

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ npm --prefix functions test
 
 # Run with coverage
 npm run test:coverage
+
+# Validate API contract + breaking-change gate
+npm run contract:check
 ```
 
 ## Architecture

--- a/contracts/openapi/albums.openapi.json
+++ b/contracts/openapi/albums.openapi.json
@@ -1,0 +1,221 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AuraPix Albums API",
+    "version": "1.0.0",
+    "description": "Contract artifact for albums list/create endpoints."
+  },
+  "servers": [
+    {
+      "url": "https://api.aurapix.example"
+    }
+  ],
+  "paths": {
+    "/api/v1/albums": {
+      "get": {
+        "operationId": "listAlbums",
+        "summary": "List albums",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 24
+            }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["createdAt", "updatedAt", "name"],
+              "default": "updatedAt"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["asc", "desc"],
+              "default": "desc"
+            }
+          },
+          {
+            "name": "nameContains",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "maxLength": 120
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Albums page",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAlbumsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ErrorResponse"
+          },
+          "401": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createAlbum",
+        "summary": "Create album",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAlbumRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Album created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateAlbumResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ErrorResponse"
+          },
+          "401": {
+            "$ref": "#/components/responses/ErrorResponse"
+          },
+          "409": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "ErrorResponse": {
+        "description": "Error response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Album": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name", "createdAt", "updatedAt", "photoIds"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+          "description": { "type": ["string", "null"], "maxLength": 500 },
+          "folderId": { "type": ["string", "null"] },
+          "photoIds": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "CreateAlbumRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+          "description": { "type": "string", "maxLength": 500 },
+          "folderId": { "type": "string" }
+        }
+      },
+      "CreateAlbumResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["album"],
+        "properties": {
+          "album": { "$ref": "#/components/schemas/Album" }
+        }
+      },
+      "Pagination": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["page", "pageSize", "total", "hasNextPage", "sortBy", "sortOrder", "filters"],
+        "properties": {
+          "page": { "type": "integer", "minimum": 1 },
+          "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+          "total": { "type": "integer", "minimum": 0 },
+          "hasNextPage": { "type": "boolean" },
+          "sortBy": { "type": "string" },
+          "sortOrder": { "type": "string", "enum": ["asc", "desc"] },
+          "filters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": ["string", "number", "boolean", "null"]
+            }
+          }
+        }
+      },
+      "ListAlbumsResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["albums", "pagination"],
+        "properties": {
+          "albums": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Album" }
+          },
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
+        }
+      },
+      "ErrorEnvelope": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["code", "message", "requestId"],
+            "properties": {
+              "code": { "type": "string" },
+              "message": { "type": "string" },
+              "requestId": { "type": "string" },
+              "details": { "type": ["object", "null"], "additionalProperties": true }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -1,0 +1,25 @@
+# API Contract Versioning Policy
+
+AuraPix API contracts are versioned with semantic versioning in each OpenAPI artifact (`info.version`).
+
+## Contract artifacts
+
+- `contracts/openapi/albums.openapi.json`
+
+## Versioning rules
+
+- **PATCH** (`x.y.Z`): non-breaking clarifications (description/examples only)
+- **MINOR** (`x.Y.z`): additive, backward-compatible changes (new optional fields, new endpoints)
+- **MAJOR** (`X.y.z`): breaking changes (removed endpoints, stricter request requirements, removed response fields/status codes)
+
+## CI gate
+
+CI compares the PR contract artifact against `origin/main` and fails when breaking changes are detected without a **major** version bump.
+
+Run locally:
+
+```bash
+npm run contract:check
+```
+
+If you intentionally introduce a breaking change, increment `info.version` major in the artifact and include migration notes in the PR description.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
+    "contract:validate": "node scripts/validate-contract.mjs",
+    "contract:breaking": "node scripts/check-contract-breaking.mjs",
+    "contract:check": "npm run contract:validate && npm run contract:breaking",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/scripts/check-contract-breaking.mjs
+++ b/scripts/check-contract-breaking.mjs
@@ -1,0 +1,99 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+
+const CONTRACT_PATH = 'contracts/openapi/albums.openapi.json';
+
+function readCurrentSpec() {
+  return JSON.parse(fs.readFileSync(CONTRACT_PATH, 'utf8'));
+}
+
+function readBaseSpec() {
+  try {
+    const raw = execSync(`git show origin/main:${CONTRACT_PATH}`, { encoding: 'utf8' });
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function major(version) {
+  const [m] = String(version ?? '0').split('.');
+  return Number.parseInt(m, 10) || 0;
+}
+
+function getOperationMap(spec) {
+  const map = new Map();
+  for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+    for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
+      if (pathItem?.[method]) {
+        map.set(`${method.toUpperCase()} ${path}`, pathItem[method]);
+      }
+    }
+  }
+  return map;
+}
+
+function findBreakingChanges(baseSpec, headSpec) {
+  const breaking = [];
+  const baseOps = getOperationMap(baseSpec);
+  const headOps = getOperationMap(headSpec);
+
+  for (const key of baseOps.keys()) {
+    if (!headOps.has(key)) {
+      breaking.push(`Removed operation: ${key}`);
+    }
+  }
+
+  for (const [key, baseOp] of baseOps.entries()) {
+    const headOp = headOps.get(key);
+    if (!headOp) continue;
+
+    const baseReqRequired = Boolean(baseOp.requestBody?.required);
+    const headReqRequired = Boolean(headOp.requestBody?.required);
+    if (!baseReqRequired && headReqRequired) {
+      breaking.push(`Request body became required: ${key}`);
+    }
+
+    const baseResponses = Object.keys(baseOp.responses ?? {});
+    const headResponses = new Set(Object.keys(headOp.responses ?? {}));
+    for (const status of baseResponses) {
+      if (!headResponses.has(status)) {
+        breaking.push(`Removed response status ${status}: ${key}`);
+      }
+    }
+  }
+
+  return breaking;
+}
+
+const headSpec = readCurrentSpec();
+const baseSpec = readBaseSpec();
+
+if (!baseSpec) {
+  console.log('No base contract found on origin/main; skipping breaking-change gate for first artifact introduction.');
+  process.exit(0);
+}
+
+const breaking = findBreakingChanges(baseSpec, headSpec);
+if (breaking.length === 0) {
+  console.log('No breaking API contract changes detected.');
+  process.exit(0);
+}
+
+const baseMajor = major(baseSpec.info?.version);
+const headMajor = major(headSpec.info?.version);
+
+if (headMajor > baseMajor) {
+  console.log('Breaking changes detected, and major version bump is present.');
+  for (const change of breaking) {
+    console.log(`- ${change}`);
+  }
+  process.exit(0);
+}
+
+console.error('Breaking API contract changes detected without major version bump.');
+for (const change of breaking) {
+  console.error(`- ${change}`);
+}
+console.error(`Base version: ${baseSpec.info?.version ?? 'unknown'}, Head version: ${headSpec.info?.version ?? 'unknown'}`);
+process.exit(1);

--- a/scripts/validate-contract.mjs
+++ b/scripts/validate-contract.mjs
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+
+const path = 'contracts/openapi/albums.openapi.json';
+const spec = JSON.parse(fs.readFileSync(path, 'utf8'));
+
+const errors = [];
+
+if (!spec.openapi) errors.push('Missing openapi version.');
+if (!spec.info?.version) errors.push('Missing info.version.');
+if (!spec.paths?.['/api/v1/albums']?.get) errors.push('Missing GET /api/v1/albums.');
+if (!spec.paths?.['/api/v1/albums']?.post) errors.push('Missing POST /api/v1/albums.');
+if (!spec.components?.schemas?.ErrorEnvelope) errors.push('Missing ErrorEnvelope schema.');
+if (!spec.components?.schemas?.Pagination) errors.push('Missing Pagination schema.');
+
+if (errors.length > 0) {
+  console.error('Contract validation failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('Contract validation passed.');


### PR DESCRIPTION
## Summary
- add initial OpenAPI contract artifact for albums list/create (`contracts/openapi/albums.openapi.json`)
- define shared error envelope plus pagination/sort/filter conventions in the artifact
- add contract versioning policy docs (`docs/API_VERSIONING.md`)
- add CI contract gate (`npm run contract:check`) that validates artifact and blocks breaking changes without a major version bump

## Validation
- npm run contract:check
- npm run lint
- npm run test -- --run

Closes #19
