### PR TITLE
Issue #18: add architecture import guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ AuraPix follows a clean architecture approach with:
 - **Authentication**: Firebase Authentication
 - **Deployment**: Firebase App Hosting + Cloud Functions
 
-See [docs/](./docs/) for detailed architecture documentation.
+See [docs/](./docs/) for detailed architecture documentation, including [layer boundaries and import guardrails](./docs/ARCHITECTURE_BOUNDARIES.md).
 
 ## Contributing
 

--- a/docs/ARCHITECTURE_BOUNDARIES.md
+++ b/docs/ARCHITECTURE_BOUNDARIES.md
@@ -1,0 +1,53 @@
+# Architecture Boundaries
+
+AuraPix uses a layered architecture to keep core domain logic provider-agnostic and easy to evolve.
+
+## Layer order (inner → outer)
+
+1. **Domain (`src/domain`)**
+   - Pure business contracts and types
+   - No framework/runtime/provider coupling
+2. **Adapters (`src/adapters`)**
+   - Infrastructure implementations (Firebase, in-memory, etc.)
+   - Implement domain contracts
+3. **Features/UI (`src/features`, `src/components`, `src/pages`)**
+   - User-facing flows and presentation
+   - Consume services/contracts only through explicit boundaries
+
+## Allowed dependency direction
+
+- `domain` → `domain` (types/contracts only)
+- `adapters` → `domain`
+- `features/pages/components/services` → `domain` and `adapters`
+
+## Disallowed dependency direction
+
+- `domain` importing from:
+  - `adapters`
+  - `features`
+  - `components`
+  - `pages`
+  - `services`
+- `adapters` importing from UI layers (`features`, `components`, `pages`)
+
+## Guardrail enforcement
+
+ESLint enforces these rules via `no-restricted-imports` in `eslint.config.js`:
+
+- Domain modules cannot import outer-layer modules.
+- Adapters cannot import UI-layer modules.
+
+This catches architectural drift during normal CI lint runs.
+
+## Examples
+
+✅ Allowed
+
+- `src/adapters/auth/FirebaseAuthService.ts` imports from `src/domain/auth/*`
+- `src/features/auth/useAuth.ts` imports from `src/domain/auth/*`
+
+❌ Forbidden
+
+- `src/domain/albums/*` importing `src/adapters/albums/*`
+- `src/domain/*` importing `src/features/*`
+- `src/adapters/*` importing `src/pages/*`

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,5 +24,33 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
+  },
+  {
+    files: ['src/domain/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            '**/adapters/**',
+            '**/features/**',
+            '**/components/**',
+            '**/pages/**',
+            '**/services/**',
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['src/adapters/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: ['**/features/**', '**/components/**', '**/pages/**'],
+        },
+      ],
+    },
   }
 );


### PR DESCRIPTION
## Summary\n- add lint guardrails that enforce layer boundaries between domain/adapters/UI\n- document allowed and disallowed dependency directions in a dedicated architecture boundaries doc\n- link boundary doc from README architecture section\n\n## Validation\n- npm run lint\n- npm test -- --run\n\n## Issue\n- Closes #18