### PR TITLE
Issue #10: enforce share permission/download policy guardrails

### DIFF
--- a/src/adapters/sharing/inMemorySharingService.test.ts
+++ b/src/adapters/sharing/inMemorySharingService.test.ts
@@ -103,25 +103,44 @@ describe('InMemorySharingService', () => {
 });
 
 
-  it('updates share link download policy with safe defaults', async () => {
-    const service = new InMemorySharingService();
+it('updates share link download policy with safe defaults', async () => {
+  const service = new InMemorySharingService();
 
-    const link = await service.createShareLink({
-      resourceType: 'album',
-      resourceId: 'album-2',
-      policy: { permission: 'download', downloadPolicy: 'derivative_only', watermarkEnabled: true },
-    });
-
-    const disabledDownloads = await service.updateShareLinkPolicy({
-      linkId: link.id,
-      policy: { downloadPolicy: 'none' },
-    });
-    expect(disabledDownloads.policy.downloadPolicy).toBe('none');
-    expect(disabledDownloads.policy.watermarkEnabled).toBe(false);
-
-    const restored = await service.updateShareLinkPolicy({
-      linkId: link.id,
-      policy: { permission: 'download' },
-    });
-    expect(restored.policy.downloadPolicy).toBe('original_and_derivative');
+  const link = await service.createShareLink({
+    resourceType: 'album',
+    resourceId: 'album-2',
+    policy: { permission: 'download', downloadPolicy: 'derivative_only', watermarkEnabled: true },
   });
+
+  const disabledDownloads = await service.updateShareLinkPolicy({
+    linkId: link.id,
+    policy: { downloadPolicy: 'none' },
+  });
+  expect(disabledDownloads.policy.downloadPolicy).toBe('none');
+  expect(disabledDownloads.policy.watermarkEnabled).toBe(false);
+
+  const restored = await service.updateShareLinkPolicy({
+    linkId: link.id,
+    policy: { permission: 'download' },
+  });
+  expect(restored.policy.downloadPolicy).toBe('original_and_derivative');
+});
+
+it('forces view-only links to disable downloads', async () => {
+  const service = new InMemorySharingService();
+
+  const link = await service.createShareLink({
+    resourceType: 'album',
+    resourceId: 'album-3',
+    policy: { permission: 'download', downloadPolicy: 'original_and_derivative', watermarkEnabled: true },
+  });
+
+  const viewOnly = await service.updateShareLinkPolicy({
+    linkId: link.id,
+    policy: { permission: 'view' },
+  });
+
+  expect(viewOnly.policy.permission).toBe('view');
+  expect(viewOnly.policy.downloadPolicy).toBe('none');
+  expect(viewOnly.policy.watermarkEnabled).toBe(false);
+});

--- a/src/pages/AlbumDetailPage.tsx
+++ b/src/pages/AlbumDetailPage.tsx
@@ -210,6 +210,27 @@ export function AlbumDetailPage() {
     }
   }
 
+  async function toggleSharePermission(link: (typeof shareLinks)[number]) {
+    const nextPermission: SharePermission =
+      link.policy.permission === 'download' ? 'view' : 'download';
+
+    setShareError(null);
+    try {
+      await updateLinkPolicy(link.id, {
+        permission: nextPermission,
+        downloadPolicy:
+          nextPermission === 'download'
+            ? link.policy.downloadPolicy === 'none'
+              ? 'original_and_derivative'
+              : link.policy.downloadPolicy
+            : 'none',
+        watermarkEnabled: nextPermission === 'download' ? link.policy.watermarkEnabled : false,
+      });
+    } catch (error) {
+      setShareError(error instanceof Error ? error.message : 'Failed to update share permission.');
+    }
+  }
+
   async function handleCreateShareLink() {
     if (!albumId) return;
     setShareError(null);
@@ -442,6 +463,13 @@ export function AlbumDetailPage() {
                   <div style={{ marginTop: 6, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
                     <button
                       className="btn-ghost btn-sm"
+                      onClick={() => void toggleSharePermission(link)}
+                    >
+                      {link.policy.permission === 'download' ? 'Set view-only' : 'Allow downloads'}
+                    </button>
+                    <button
+                      className="btn-ghost btn-sm"
+                      disabled={link.policy.permission !== 'download'}
                       onClick={() => void cycleShareDownloadPolicy(link)}
                     >
                       Cycle download policy


### PR DESCRIPTION
## Summary
- enforce share policy normalization in Firebase sharing adapter so view-only links always disable downloads/watermark
- add quick per-link permission toggle in Album Detail sharing panel (view-only ↔ allow downloads)
- extend in-memory sharing tests to verify permission downgrade disables download policy safely

## Why
Issue #10 requires server-side policy enforcement and safer sharing controls. This increment hardens policy compatibility and makes permission changes user-usable from the UI.

## Validation
- npm run lint
- npm run test -- --run
- npm run build:frontend