### PR TITLE
Issue #11: add teams workspace role-management baseline UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { AlbumDetailPage } from './pages/AlbumDetailPage';
 import { AlbumsPage } from './pages/AlbumsPage';
 import { FolderDetailPage } from './pages/FolderDetailPage';
 import { LibraryPage } from './pages/LibraryPage';
+import { TeamsPage } from './pages/TeamsPage';
 import { createLocalServices } from './services/createLocalServices';
 import { ServiceProvider } from './services/ServiceContext';
 import { HealthBanner } from './components/HealthBanner';
@@ -44,6 +45,7 @@ export default function App() {
               <Route path="/albums" element={<AlbumsPage />} />
               <Route path="/albums/:albumId" element={<AlbumDetailPage />} />
               <Route path="/albums/folders/:folderId" element={<FolderDetailPage />} />
+              <Route path="/teams" element={<TeamsPage />} />
               {/* Catch-all: redirect unknown paths to library */}
               <Route path="*" element={<Navigate to="/library" replace />} />
             </Route>

--- a/src/features/teams/useTeams.ts
+++ b/src/features/teams/useTeams.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export type TeamRole = 'owner' | 'admin' | 'editor' | 'contributor' | 'viewer';
+
+export interface TeamMember {
+  id: string;
+  name: string;
+  email: string;
+  role: TeamRole;
+  invited: boolean;
+}
+
+export interface TeamWorkspace {
+  id: string;
+  name: string;
+  members: TeamMember[];
+}
+
+const STORAGE_KEY = 'aurapix.local.teams.v1';
+
+const DEFAULT_WORKSPACE: TeamWorkspace = {
+  id: 'team-local-1',
+  name: 'Studio Team',
+  members: [
+    {
+      id: 'member-1',
+      name: 'You',
+      email: 'you@local.aurapix',
+      role: 'owner',
+      invited: false,
+    },
+    {
+      id: 'member-2',
+      name: 'Assistant Editor',
+      email: 'assistant@local.aurapix',
+      role: 'editor',
+      invited: false,
+    },
+  ],
+};
+
+function readStoredWorkspace(): TeamWorkspace {
+  if (typeof window === 'undefined') return DEFAULT_WORKSPACE;
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return DEFAULT_WORKSPACE;
+
+  try {
+    const parsed = JSON.parse(raw) as TeamWorkspace;
+    if (!parsed || !parsed.id || !Array.isArray(parsed.members)) {
+      return DEFAULT_WORKSPACE;
+    }
+    return parsed;
+  } catch {
+    return DEFAULT_WORKSPACE;
+  }
+}
+
+export function useTeams() {
+  const [workspace, setWorkspace] = useState<TeamWorkspace>(() => readStoredWorkspace());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(workspace));
+  }, [workspace]);
+
+  const updateRole = useCallback((memberId: string, role: TeamRole) => {
+    setWorkspace((prev) => ({
+      ...prev,
+      members: prev.members.map((member) => (member.id === memberId ? { ...member, role } : member)),
+    }));
+  }, []);
+
+  const inviteMember = useCallback((name: string, email: string, role: TeamRole) => {
+    setWorkspace((prev) => ({
+      ...prev,
+      members: [
+        ...prev.members,
+        {
+          id: `member-${Date.now()}`,
+          name,
+          email,
+          role,
+          invited: true,
+        },
+      ],
+    }));
+  }, []);
+
+  const roleCounts = useMemo(() => {
+    return workspace.members.reduce<Record<TeamRole, number>>(
+      (acc, member) => {
+        acc[member.role] += 1;
+        return acc;
+      },
+      {
+        owner: 0,
+        admin: 0,
+        editor: 0,
+        contributor: 0,
+        viewer: 0,
+      }
+    );
+  }, [workspace.members]);
+
+  return {
+    workspace,
+    roleCounts,
+    updateRole,
+    inviteMember,
+  };
+}

--- a/src/pages/TeamsPage.tsx
+++ b/src/pages/TeamsPage.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { useTeams, type TeamRole } from '../features/teams/useTeams';
+
+const ROLE_OPTIONS: TeamRole[] = ['owner', 'admin', 'editor', 'contributor', 'viewer'];
+
+export function TeamsPage() {
+  const { workspace, roleCounts, updateRole, inviteMember } = useTeams();
+  const [inviteName, setInviteName] = useState('');
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState<TeamRole>('viewer');
+
+  function handleInviteSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const name = inviteName.trim();
+    const email = inviteEmail.trim().toLowerCase();
+    if (!name || !email) return;
+
+    inviteMember(name, email, inviteRole);
+    setInviteName('');
+    setInviteEmail('');
+    setInviteRole('viewer');
+  }
+
+  return (
+    <section className="page teams-page">
+      <header className="page-header">
+        <h1 className="page-title">Teams</h1>
+      </header>
+
+      <div className="teams-subtitle">
+        Workspace: <strong>{workspace.name}</strong>
+      </div>
+
+      <div className="teams-role-summary">
+        {ROLE_OPTIONS.map((role) => (
+          <div key={role} className="teams-role-chip">
+            <span className="teams-role-name">{role}</span>
+            <span className="teams-role-count">{roleCounts[role]}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="teams-panel">
+        <h2>Members</h2>
+        <ul className="teams-member-list">
+          {workspace.members.map((member) => (
+            <li key={member.id} className="teams-member-row">
+              <div className="teams-member-meta">
+                <div className="teams-member-name">{member.name}</div>
+                <div className="teams-member-email">
+                  {member.email}
+                  {member.invited ? ' · invited' : ''}
+                </div>
+              </div>
+              <label className="teams-role-select-wrap">
+                <span className="sr-only">Role for {member.name}</span>
+                <select
+                  value={member.role}
+                  onChange={(e) => updateRole(member.id, e.target.value as TeamRole)}
+                >
+                  {ROLE_OPTIONS.map((role) => (
+                    <option key={role} value={role}>
+                      {role}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <form className="teams-panel teams-invite-form" onSubmit={handleInviteSubmit}>
+        <h2>Invite member</h2>
+        <div className="teams-invite-grid">
+          <input
+            type="text"
+            placeholder="Name"
+            value={inviteName}
+            onChange={(e) => setInviteName(e.target.value)}
+          />
+          <input
+            type="email"
+            placeholder="Email"
+            value={inviteEmail}
+            onChange={(e) => setInviteEmail(e.target.value)}
+          />
+          <select value={inviteRole} onChange={(e) => setInviteRole(e.target.value as TeamRole)}>
+            {ROLE_OPTIONS.map((role) => (
+              <option key={role} value={role}>
+                {role}
+              </option>
+            ))}
+          </select>
+          <button type="submit" className="btn-primary">
+            Send invite
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1938,3 +1938,97 @@ input:focus {
   justify-content: flex-end;
   gap: 0.5rem;
 }
+
+.teams-page {
+  max-width: 980px;
+}
+
+.teams-subtitle {
+  color: #94a3b8;
+  margin-top: -0.5rem;
+}
+
+.teams-role-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.teams-role-chip {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+  border: 1px solid #334155;
+  border-radius: 999px;
+  padding: 0.25rem 0.625rem;
+  color: #cbd5e1;
+  font-size: 0.8rem;
+}
+
+.teams-role-count {
+  color: #818cf8;
+  font-weight: 600;
+}
+
+.teams-panel {
+  border: 1px solid #334155;
+  border-radius: 10px;
+  background: #0f172a;
+  padding: 1rem;
+}
+
+.teams-panel h2 {
+  font-size: 1rem;
+  color: #e2e8f0;
+  margin: 0 0 0.75rem;
+}
+
+.teams-member-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.teams-member-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid #1e293b;
+  border-radius: 8px;
+  padding: 0.625rem 0.75rem;
+}
+
+.teams-member-name {
+  color: #f8fafc;
+  font-weight: 600;
+}
+
+.teams-member-email {
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.teams-role-select-wrap select,
+.teams-invite-grid select {
+  min-width: 130px;
+}
+
+.teams-invite-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 1.4fr 0.9fr auto;
+  gap: 0.625rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add a new `/teams` page for local workspace membership management
- add local teams state hook with persisted members/roles in localStorage
- support member role updates and invite form for demoable team collaboration flow
- wire Teams route into app router and style the page for the existing shell

## Validation
- npm run lint
- npm run test -- --run
- npm run build

## Issue
Closes #11
