### PR TITLE
Phase 4a: add plugin manifest endpoint + edit recipe version contract

### DIFF
--- a/docs/features/plugin-editing-system.md
+++ b/docs/features/plugin-editing-system.md
@@ -9,8 +9,18 @@ Provide a modular, non-destructive editing framework for lightweight image adjus
 - Client preview and server-side render consistency
 - Plugin enable/disable controls by plan/workspace
 
+## Current implementation (incremental)
+- Recipe contract versioning (`recipeVersion: 1`) on apply-edits payloads
+- Plugin manifest endpoint (`GET /edits/plugins`) for client capability discovery
+- Initial non-destructive plugin set exposed in manifest:
+  - `crop`
+  - `rotate`
+  - `adjust` (brightness/contrast/saturation)
+  - `filter` (grayscale/sepia/blur/sharpen/negate)
+- Data model stores `recipeVersion` on every saved edit history entry
+
 ## Planned detail expansion
 - Plugin API contract (input, params, output)
-- Version compatibility strategy
-- Initial plugin set: crop, brightness, exposure, contrast
+- Workspace/plan-based plugin enable/disable policy
+- Additional plugin set: exposure/white-balance/highlights
 - Data storage model for edit versions/history

--- a/functions/src/handlers/edits/applyEdits.ts
+++ b/functions/src/handlers/edits/applyEdits.ts
@@ -6,6 +6,24 @@ import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
 import { ApplyEditsSchema } from '../../utils/validation.js';
 import { validateOperations } from '../../services/edits/EditProcessor.js';
+import {
+  EDIT_PLUGIN_MANIFEST,
+  EDIT_RECIPE_VERSION,
+} from '../../services/edits/pluginRegistry.js';
+
+/**
+ * List edit plugins and recipe contract version
+ * GET /edits/plugins
+ */
+export async function handleListPlugins(
+  _req: Request,
+  res: Response
+): Promise<void> {
+  res.json({
+    recipeVersion: EDIT_RECIPE_VERSION,
+    plugins: EDIT_PLUGIN_MANIFEST,
+  });
+}
 
 /**
  * Apply edits to a photo
@@ -28,7 +46,15 @@ export async function handleApplyEdits(
     throw new AppError(400, 'INVALID_REQUEST', `Invalid request: ${validation.error.message}`);
   }
 
-  const { operations, description } = validation.data;
+  const { recipeVersion, operations, description } = validation.data;
+
+  if (recipeVersion !== EDIT_RECIPE_VERSION) {
+    throw new AppError(
+      400,
+      'UNSUPPORTED_RECIPE_VERSION',
+      `Unsupported recipe version ${recipeVersion}. Supported version: ${EDIT_RECIPE_VERSION}`
+    );
+  }
 
   // Validate operations
   const opsValidation = validateOperations(operations);
@@ -52,6 +78,7 @@ export async function handleApplyEdits(
     // Create new edit version
     const newVersion: EditVersion = {
       version: photo.currentEditVersion + 1,
+      recipeVersion,
       createdAt: new Date().toISOString(),
       createdBy: userId,
       operations,
@@ -86,6 +113,7 @@ export async function handleApplyEdits(
       message: 'Edits applied, thumbnails are being regenerated',
       edit: {
         version: newVersion.version,
+        recipeVersion: newVersion.recipeVersion,
         operations: newVersion.operations,
         description: newVersion.description,
         createdAt: newVersion.createdAt,

--- a/functions/src/models/Photo.ts
+++ b/functions/src/models/Photo.ts
@@ -26,6 +26,7 @@ export interface EditOperation {
 
 export interface EditVersion {
   version: number;
+  recipeVersion: number;
   createdAt: string;
   createdBy: string;
   operations: EditOperation[];

--- a/functions/src/routes/edits.ts
+++ b/functions/src/routes/edits.ts
@@ -1,8 +1,15 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth.js';
-import { handleApplyEdits, handleRevertVersion } from '../handlers/edits/applyEdits.js';
+import {
+  handleApplyEdits,
+  handleListPlugins,
+  handleRevertVersion,
+} from '../handlers/edits/applyEdits.js';
 
 const router = Router();
+
+// Plugin contract and manifest
+router.get('/plugins', requireAuth, handleListPlugins);
 
 // Apply edits to a photo (creates new version)
 router.post('/:libraryId/:photoId', requireAuth, handleApplyEdits);

--- a/functions/src/services/edits/EditProcessor.ts
+++ b/functions/src/services/edits/EditProcessor.ts
@@ -1,6 +1,7 @@
 import sharp from 'sharp';
 import type { EditOperation } from '../../models/Photo.js';
 import { logger } from '../../utils/logger.js';
+import { isPluginEnabled } from './pluginRegistry.js';
 
 /**
  * Apply a sequence of edit operations to an image buffer
@@ -189,8 +190,8 @@ export function validateOperations(operations: EditOperation[]): {
   const errors: string[] = [];
 
   for (const op of operations) {
-    if (!op.type || !['crop', 'rotate', 'adjust', 'filter'].includes(op.type)) {
-      errors.push(`Invalid operation type: ${op.type}`);
+    if (!op.type || !isPluginEnabled(op.type)) {
+      errors.push(`Invalid or disabled operation type: ${op.type}`);
     }
 
     if (typeof op.order !== 'number' || op.order < 0) {

--- a/functions/src/services/edits/pluginRegistry.ts
+++ b/functions/src/services/edits/pluginRegistry.ts
@@ -1,0 +1,57 @@
+export type EditOperationType = 'crop' | 'rotate' | 'adjust' | 'filter';
+
+export interface EditPluginManifest {
+  id: EditOperationType;
+  displayName: string;
+  version: string;
+  enabledByDefault: boolean;
+  nonDestructive: boolean;
+  params: string[];
+}
+
+export const EDIT_RECIPE_VERSION = 1;
+
+export const EDIT_PLUGIN_MANIFEST: EditPluginManifest[] = [
+  {
+    id: 'crop',
+    displayName: 'Crop',
+    version: '1.0.0',
+    enabledByDefault: true,
+    nonDestructive: true,
+    params: ['x', 'y', 'width', 'height'],
+  },
+  {
+    id: 'rotate',
+    displayName: 'Rotate',
+    version: '1.0.0',
+    enabledByDefault: true,
+    nonDestructive: true,
+    params: ['degrees'],
+  },
+  {
+    id: 'adjust',
+    displayName: 'Adjust',
+    version: '1.0.0',
+    enabledByDefault: true,
+    nonDestructive: true,
+    params: ['brightness', 'contrast', 'saturation'],
+  },
+  {
+    id: 'filter',
+    displayName: 'Filter',
+    version: '1.0.0',
+    enabledByDefault: true,
+    nonDestructive: true,
+    params: ['filterName', 'sigma'],
+  },
+];
+
+const ENABLED_PLUGIN_IDS = new Set(
+  EDIT_PLUGIN_MANIFEST.filter((plugin) => plugin.enabledByDefault).map(
+    (plugin) => plugin.id
+  )
+);
+
+export function isPluginEnabled(type: string): type is EditOperationType {
+  return ENABLED_PLUGIN_IDS.has(type as EditOperationType);
+}

--- a/functions/src/utils/validation.ts
+++ b/functions/src/utils/validation.ts
@@ -26,6 +26,7 @@ export const GenerateThumbnailsSchema = z.object({
 });
 
 export const ApplyEditsSchema = z.object({
+  recipeVersion: z.number().int().min(1).default(1),
   operations: z.array(
     z.object({
       type: z.enum(['crop', 'rotate', 'adjust', 'filter']),


### PR DESCRIPTION
## Summary
- add an edit plugin registry with recipe version constants
- expose `GET /edits/plugins` for client capability discovery
- require `recipeVersion` on apply-edits payloads (default v1 for backward compatibility)
- persist `recipeVersion` in edit history and include it in apply-edits response
- validate operation types against enabled plugin registry

## Why
Implements a concrete, user-usable slice of issue #29 by shipping manifest + versioning contract for non-destructive editing workflows.

## Validation
- `npm --prefix functions run build`
- `npm --prefix functions run test`

Closes #29
