### PR TITLE
Phase 1d: add provider-agnostic OAuth sign-in boundary + local demo users

### DIFF
--- a/src/adapters/auth/FirebaseAuthService.ts
+++ b/src/adapters/auth/FirebaseAuthService.ts
@@ -1,6 +1,9 @@
 import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
+  signInWithPopup,
+  GithubAuthProvider,
+  GoogleAuthProvider,
   signOut as firebaseSignOut,
   onAuthStateChanged,
   updateProfile,
@@ -8,7 +11,7 @@ import {
   type User as FirebaseUser,
 } from 'firebase/auth';
 import type { AuthService } from '../../domain/auth/contract';
-import type { Session, SignInInput, SignUpInput, User } from '../../domain/auth/types';
+import type { OAuthSignInInput, Session, SignInInput, SignUpInput, User } from '../../domain/auth/types';
 
 /**
  * Firebase implementation of AuthService.
@@ -40,6 +43,19 @@ export class FirebaseAuthService implements AuthService {
       input.email,
       input.password
     );
+
+    const user = this.mapFirebaseUserToUser(credential.user);
+    const session = await this.createSession(credential.user);
+
+    this.currentUser = user;
+    this.currentSession = session;
+
+    return session;
+  }
+
+  async signInWithOAuth(input: OAuthSignInInput): Promise<Session> {
+    const provider = this.createOAuthProvider(input.provider);
+    const credential = await signInWithPopup(this.auth, provider);
 
     const user = this.mapFirebaseUserToUser(credential.user);
     const session = await this.createSession(credential.user);
@@ -114,6 +130,21 @@ export class FirebaseAuthService implements AuthService {
         }
       });
     });
+  }
+
+  /**
+   * Create OAuth provider adapter without leaking Firebase provider details
+   * beyond this boundary.
+   */
+  private createOAuthProvider(provider: OAuthSignInInput['provider']) {
+    switch (provider) {
+      case 'google':
+        return new GoogleAuthProvider();
+      case 'github':
+        return new GithubAuthProvider();
+      default:
+        throw new Error(`Unsupported OAuth provider: ${provider}`);
+    }
   }
 
   /**

--- a/src/adapters/auth/inMemoryAuthService.test.ts
+++ b/src/adapters/auth/inMemoryAuthService.test.ts
@@ -92,6 +92,22 @@ describe('InMemoryAuthService', () => {
     expect(session.user.displayName).toBe('New User');
   });
 
+  it('supports provider-agnostic OAuth demo sign-in in local mode', async () => {
+    const svc = new InMemoryAuthService();
+    const session = await svc.signInWithOAuth({ provider: 'google' });
+
+    expect(session.user.email).toBe('google.demo@aurapix.local');
+    expect(session.user.displayName).toBe('Google Demo');
+  });
+
+  it('reuses the same OAuth demo profile on repeated sign-ins', async () => {
+    const svc = new InMemoryAuthService();
+    const first = await svc.signInWithOAuth({ provider: 'github' });
+    const second = await svc.signInWithOAuth({ provider: 'github' });
+
+    expect(second.user.id).toBe(first.user.id);
+  });
+
   it('rejects duplicate email on signUp', async () => {
     const svc = new InMemoryAuthService();
     await svc.signUp({ email: 'dup@example.com', password: 'abc' });

--- a/src/adapters/auth/inMemoryAuthService.ts
+++ b/src/adapters/auth/inMemoryAuthService.ts
@@ -1,5 +1,5 @@
 import type { AuthService } from '../../domain/auth/contract';
-import type { Session, SignInInput, SignUpInput, User } from '../../domain/auth/types';
+import type { OAuthSignInInput, Session, SignInInput, SignUpInput, User } from '../../domain/auth/types';
 
 // ---------------------------------------------------------------------------
 // Single-user in-memory auth service.
@@ -96,6 +96,31 @@ export class InMemoryAuthService implements AuthService {
 
     this.signInAttempts.delete(input.email);
     this.session = makeSession(entry.user);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(this.session));
+    return this.session;
+  }
+
+  async signInWithOAuth(input: OAuthSignInInput): Promise<Session> {
+    const normalizedProvider = input.provider.toLowerCase();
+    const oauthEmail = `${normalizedProvider}.demo@aurapix.local`;
+    const existing = this.users.get(oauthEmail);
+
+    if (existing) {
+      this.session = makeSession(existing.user);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.session));
+      return this.session;
+    }
+
+    const user: User = {
+      id: `local-${normalizedProvider}-user`,
+      email: oauthEmail,
+      displayName: `${normalizedProvider[0].toUpperCase()}${normalizedProvider.slice(1)} Demo`,
+      photoUrl: null,
+      createdAt: new Date().toISOString(),
+    };
+
+    this.users.set(oauthEmail, { user, password: '' });
+    this.session = makeSession(user);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(this.session));
     return this.session;
   }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -63,7 +63,7 @@ function SearchIcon() {
 
 // ── Inner shell (needs AlbumsProvider above it) ──────────────────────────
 function LayoutShell() {
-  const { user, signOut } = useAuth();
+  const { user, signOut, signInWithOAuth } = useAuth();
   const { albums, folders } = useAlbums();
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
@@ -235,9 +235,16 @@ function LayoutShell() {
                     </button>
                   )}
                   {isLocalMode && (
-                    <div className="user-menu-note">
-                      Authentication is not available in local mode. When deployed with Firebase,
-                      user sign-in and sign-out will be enabled here.
+                    <div className="user-menu-local-auth-actions">
+                      <div className="user-menu-note">
+                        Local mode supports demo OAuth identities for testing auth-aware UI.
+                      </div>
+                      <button className="user-menu-item" onClick={() => signInWithOAuth('google')}>
+                        Continue as Google Demo User
+                      </button>
+                      <button className="user-menu-item" onClick={() => signInWithOAuth('github')}>
+                        Continue as GitHub Demo User
+                      </button>
                     </div>
                   )}
                 </div>

--- a/src/domain/auth/contract.ts
+++ b/src/domain/auth/contract.ts
@@ -1,7 +1,8 @@
-import type { Session, SignInInput, SignUpInput, User } from './types';
+import type { OAuthSignInInput, Session, SignInInput, SignUpInput, User } from './types';
 
 export interface AuthService {
   signIn(input: SignInInput): Promise<Session>;
+  signInWithOAuth(input: OAuthSignInInput): Promise<Session>;
   signUp(input: SignUpInput): Promise<Session>;
   signOut(): Promise<void>;
   getCurrentUser(): Promise<User | null>;

--- a/src/domain/auth/types.ts
+++ b/src/domain/auth/types.ts
@@ -22,3 +22,9 @@ export interface SignUpInput {
   password: string;
   displayName?: string;
 }
+
+export type OAuthProvider = 'google' | 'github';
+
+export interface OAuthSignInInput {
+  provider: OAuthProvider;
+}

--- a/src/features/auth/useAuth.ts
+++ b/src/features/auth/useAuth.ts
@@ -10,6 +10,7 @@ interface UseAuthState {
 
 interface UseAuthReturn extends UseAuthState {
   signIn(email: string, password: string): Promise<void>;
+  signInWithOAuth(provider: 'google' | 'github'): Promise<void>;
   signUp(email: string, password: string, displayName?: string): Promise<void>;
   signOut(): Promise<void>;
 }
@@ -49,6 +50,23 @@ export function useAuth(): UseAuthReturn {
     [auth]
   );
 
+  const signInWithOAuth = useCallback(
+    async (provider: 'google' | 'github') => {
+      setState((s) => ({ ...s, loading: true, error: null }));
+      try {
+        const session = await auth.signInWithOAuth({ provider });
+        setState({ user: session.user, loading: false, error: null });
+      } catch (err) {
+        setState((s) => ({
+          ...s,
+          loading: false,
+          error: err instanceof Error ? err.message : 'OAuth sign-in failed.',
+        }));
+      }
+    },
+    [auth]
+  );
+
   const signUp = useCallback(
     async (email: string, password: string, displayName?: string) => {
       setState((s) => ({ ...s, loading: true, error: null }));
@@ -80,5 +98,5 @@ export function useAuth(): UseAuthReturn {
     }
   }, [auth]);
 
-  return { ...state, signIn, signUp, signOut };
+  return { ...state, signIn, signInWithOAuth, signUp, signOut };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -323,6 +323,12 @@ body {
   border-radius: 6px;
 }
 
+.user-menu-local-auth-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 /* ── App body (sidebar + main) ─────────────────────────────────────────── */
 .app-body {
   display: flex;


### PR DESCRIPTION
## Summary
- add a provider-agnostic OAuth sign-in contract (`signInWithOAuth`) for auth services
- implement Firebase adapter support for Google and GitHub OAuth providers
- add local-mode OAuth demo sign-in identities so auth-aware UI can be exercised without Firebase
- expose OAuth sign-in through `useAuth` and wire user-menu actions for local testing
- add tests covering OAuth demo sign-in behavior and profile reuse

## Validation
- `npm run test -- src/adapters/auth/inMemoryAuthService.test.ts --run`
- `npm run build:frontend`

Closes #25
