### PR TITLE
Phase 2: add library usage telemetry summary in UI

### DIFF
--- a/src/adapters/library/FirebaseLibraryService.ts
+++ b/src/adapters/library/FirebaseLibraryService.ts
@@ -26,6 +26,7 @@ import type {
   AddPhotoInput,
   BulkAddToAlbumInput,
   BulkAddToAlbumResult,
+  LibraryUsageSummary,
   ListPhotosInput,
   ListPhotosResult,
   Photo,
@@ -104,6 +105,21 @@ export class FirebaseLibraryService implements LibraryService {
     });
 
     return { photos, nextPageToken };
+  }
+
+  async getUsage(libraryId: string): Promise<LibraryUsageSummary> {
+    const photosRef = collection(this.db, COLLECTIONS.PHOTOS);
+    const snapshot = await getDocs(query(photosRef, where('libraryId', '==', libraryId)));
+    const photos = snapshot.docs.map((docSnap) => this.mapDocToPhoto(docSnap));
+
+    return {
+      libraryId,
+      totalPhotos: photos.length,
+      readyPhotos: photos.filter((photo) => photo.status === 'ready').length,
+      favoritePhotos: photos.filter((photo) => photo.isFavorite).length,
+      taggedPhotos: photos.filter((photo) => photo.tags.length > 0).length,
+      totalBytes: photos.reduce((total, photo) => total + (photo.metadata?.sizeBytes ?? 0), 0),
+    };
   }
 
   async getPhoto(photoId: string): Promise<Photo | null> {

--- a/src/adapters/library/inMemoryLibraryService.test.ts
+++ b/src/adapters/library/inMemoryLibraryService.test.ts
@@ -230,6 +230,35 @@ describe('InMemoryLibraryService', () => {
     ).rejects.toThrow('Storage quota exceeded');
   });
 
+  it('reports usage summary for telemetry foundations', async () => {
+    const svc = new InMemoryLibraryService();
+    const favorite = await svc.addPhoto({
+      libraryId: LIBRARY_ID,
+      originalName: 'favorite.jpg',
+      dataUrl: 'data:image/jpeg;base64,favorite',
+      metadata: { sizeBytes: 1200 },
+    });
+    const tagged = await svc.addPhoto({
+      libraryId: LIBRARY_ID,
+      originalName: 'tagged.jpg',
+      dataUrl: 'data:image/jpeg;base64,tagged',
+      metadata: { sizeBytes: 800 },
+    });
+
+    await svc.updatePhoto(favorite.id, { isFavorite: true });
+    await svc.updatePhoto(tagged.id, { tags: ['trip'] });
+
+    const usage = await svc.getUsage(LIBRARY_ID);
+    expect(usage).toMatchObject({
+      libraryId: LIBRARY_ID,
+      totalPhotos: 2,
+      readyPhotos: 2,
+      favoritePhotos: 1,
+      taggedPhotos: 1,
+      totalBytes: 2000,
+    });
+  });
+
   it('deletes a photo', async () => {
     const svc = new InMemoryLibraryService();
     const photo = await svc.addPhoto({

--- a/src/adapters/library/inMemoryLibraryService.ts
+++ b/src/adapters/library/inMemoryLibraryService.ts
@@ -3,6 +3,7 @@ import type {
   AddPhotoInput,
   BulkAddToAlbumInput,
   BulkAddToAlbumResult,
+  LibraryUsageSummary,
   ListPhotosInput,
   ListPhotosResult,
   LibraryQuickCollection,
@@ -148,6 +149,19 @@ export class InMemoryLibraryService implements LibraryService {
       startIndex + pageSize < results.length ? results[startIndex + pageSize].id : null;
 
     return { photos: page, nextPageToken };
+  }
+
+  async getUsage(libraryId: string): Promise<LibraryUsageSummary> {
+    const libraryPhotos = this.photos.filter((photo) => photo.libraryId === libraryId);
+
+    return {
+      libraryId,
+      totalPhotos: libraryPhotos.length,
+      readyPhotos: libraryPhotos.filter((photo) => photo.status === 'ready').length,
+      favoritePhotos: libraryPhotos.filter((photo) => photo.isFavorite).length,
+      taggedPhotos: libraryPhotos.filter((photo) => photo.tags.length > 0).length,
+      totalBytes: libraryPhotos.reduce((total, photo) => total + (photo.metadata?.sizeBytes ?? 0), 0),
+    };
   }
 
   async getPhoto(photoId: string): Promise<Photo | null> {

--- a/src/domain/library/contract.ts
+++ b/src/domain/library/contract.ts
@@ -2,6 +2,7 @@ import type {
   AddPhotoInput,
   BulkAddToAlbumInput,
   BulkAddToAlbumResult,
+  LibraryUsageSummary,
   ListPhotosInput,
   ListPhotosResult,
   Photo,
@@ -10,6 +11,7 @@ import type {
 
 export interface LibraryService {
   listPhotos(input: ListPhotosInput): Promise<ListPhotosResult>;
+  getUsage(libraryId: string): Promise<LibraryUsageSummary>;
   getPhoto(photoId: string): Promise<Photo | null>;
   addPhoto(input: AddPhotoInput): Promise<Photo>;
   updatePhoto(photoId: string, input: UpdatePhotoInput): Promise<Photo>;

--- a/src/domain/library/types.ts
+++ b/src/domain/library/types.ts
@@ -58,6 +58,15 @@ export interface ListPhotosResult {
   nextPageToken: string | null;
 }
 
+export interface LibraryUsageSummary {
+  libraryId: string;
+  totalPhotos: number;
+  readyPhotos: number;
+  favoritePhotos: number;
+  taggedPhotos: number;
+  totalBytes: number;
+}
+
 export interface AddPhotoInput {
   libraryId: string;
   originalName: string;

--- a/src/pages/LibraryPage.tsx
+++ b/src/pages/LibraryPage.tsx
@@ -21,6 +21,7 @@ import {
 } from '../features/library/quickViewPreferences';
 import { useUploadSessions } from '../features/uploads/useUploadSessions';
 import { useServices } from '../services/useServices';
+import type { LibraryUsageSummary } from '../domain/library/types';
 
 function toLibraryId(userId: string) {
   return `library-${userId}`;
@@ -90,7 +91,7 @@ export function LibraryPage() {
     deletePhoto,
   } = useLibrary(libraryId, metadataFilters);
   const { albums } = useAlbums();
-  const { uploads: uploadSessionsService } = useServices();
+  const { library: libraryService, uploads: uploadSessionsService } = useServices();
   const {
     pendingSession,
     metadata: uploadedMetadata,
@@ -106,6 +107,7 @@ export function LibraryPage() {
   const [bulkAlbumId, setBulkAlbumId] = useState<string>('');
   const [bulkTagInput, setBulkTagInput] = useState<string>('');
   const [bulkActionMessage, setBulkActionMessage] = useState<string | null>(null);
+  const [usageSummary, setUsageSummary] = useState<LibraryUsageSummary | null>(null);
   const viewerStateRef = useRef<ViewerState | null>(null);
   const [viewerState, setViewerState] = useState<ViewerState | null>(null);
 
@@ -245,6 +247,34 @@ export function LibraryPage() {
   const queuedDerivativeJobs = derivativeJobs.filter((job) => job.status === 'queued').length;
   const completedDerivativeJobs = derivativeJobs.filter((job) => job.status === 'completed').length;
 
+  useEffect(() => {
+    let cancelled = false;
+    libraryService
+      .getUsage(libraryId)
+      .then((summary) => {
+        if (!cancelled) {
+          setUsageSummary(summary);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setUsageSummary(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [libraryService, libraryId, photos.length]);
+
+  const formattedUsageBytes = useMemo(() => {
+    if (!usageSummary) return '';
+    if (usageSummary.totalBytes < 1024 * 1024) {
+      return `${Math.max(1, Math.round(usageSummary.totalBytes / 1024))} KB`;
+    }
+    return `${(usageSummary.totalBytes / (1024 * 1024)).toFixed(1)} MB`;
+  }, [usageSummary]);
+
   // Gallery toolbar configuration
   const galleryToolbarButtons = useMemo<ToolbarButton[]>(() => {
     return [
@@ -337,6 +367,12 @@ export function LibraryPage() {
     <>
       <div className="page-titlebar">
         <h1 className="page-title">Library</h1>
+        {usageSummary && !isFilmstrip && (
+          <p className="state-message" role="status" aria-live="polite">
+            Usage: {usageSummary.totalPhotos} photo(s) · {formattedUsageBytes} ·{' '}
+            {usageSummary.favoritePhotos} favorites · {usageSummary.taggedPhotos} tagged
+          </p>
+        )}
         {!isFilmstrip && photos.length > 0 && (
           <div className="titlebar-controls">
             <button


### PR DESCRIPTION
## Summary\n- adds a  contract to the library service for Phase 2 telemetry foundations\n- implements usage aggregation in both in-memory and Firebase library adapters\n- surfaces usage in Library UI (photo count, storage used, favorites, tagged)\n- adds adapter test coverage for usage summary aggregation\n\n## Why\nIssue #9 calls for gallery pagination/filtering/telemetry MVP. This increment adds a user-visible and reusable usage telemetry foundation without breaking existing list/photo APIs.\n\n## Validation\n- 
> aurapix@0.0.0 test
> vitest src/adapters/library/inMemoryLibraryService.test.ts


 RUN  v3.2.4 /Users/rwrife/.openclaw/workspace/aurapix

 ✓ src/adapters/library/inMemoryLibraryService.test.ts (15 tests) 9ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  21:03:56
   Duration  338ms (transform 24ms, setup 21ms, collect 18ms, tests 9ms, environment 126ms, prepare 26ms)\n- 
> aurapix@0.0.0 lint
> eslint .\n- 
> aurapix@0.0.0 build
> npm-run-all build:frontend build:backend


> aurapix@0.0.0 build:frontend
> tsc -b && vite build

vite v6.4.1 building for production...
transforming...
✓ 74 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                   0.39 kB │ gzip:  0.27 kB
dist/assets/index-DA_GgeEK.css   26.46 kB │ gzip:  5.28 kB
dist/assets/index-BvIJipSD.js   272.37 kB │ gzip: 82.72 kB
✓ built in 349ms

> aurapix@0.0.0 build:backend
> npm --prefix functions run build


> aurapix-functions@0.1.0 build
> tsc\n\nCloses #9