### PR TITLE
feat: add library sort-order control for gallery browsing

### DIFF
--- a/src/adapters/library/FirebaseLibraryService.ts
+++ b/src/adapters/library/FirebaseLibraryService.ts
@@ -29,6 +29,7 @@ import type {
   LibraryUsageSummary,
   ListPhotosInput,
   ListPhotosResult,
+  LibrarySort,
   Photo,
   UpdatePhotoInput,
 } from '../../domain/library/types';
@@ -55,11 +56,27 @@ export class FirebaseLibraryService implements LibraryService {
     this.authorizer = authorizer;
   }
 
+  private toCreatedAtDirection(sort?: LibrarySort): 'asc' | 'desc' {
+    return sort === 'created_asc' ? 'asc' : 'desc';
+  }
+
+  private applyClientSort(photos: Photo[], sort?: LibrarySort): Photo[] {
+    if (sort === 'name_asc') {
+      return [...photos].sort((a, b) => a.originalName.localeCompare(b.originalName));
+    }
+
+    if (sort === 'name_desc') {
+      return [...photos].sort((a, b) => b.originalName.localeCompare(a.originalName));
+    }
+
+    return photos;
+  }
+
   async listPhotos(input: ListPhotosInput): Promise<ListPhotosResult> {
     const photosRef = collection(this.db, COLLECTIONS.PHOTOS);
     const constraints: QueryConstraint[] = [
       where('libraryId', '==', input.libraryId),
-      orderBy('createdAt', 'desc'),
+      orderBy('createdAt', this.toCreatedAtDirection(input.sort)),
     ];
 
     // Filter by album
@@ -104,7 +121,7 @@ export class FirebaseLibraryService implements LibraryService {
       }
     });
 
-    return { photos, nextPageToken };
+    return { photos: this.applyClientSort(photos, input.sort), nextPageToken };
   }
 
   async getUsage(libraryId: string): Promise<LibraryUsageSummary> {

--- a/src/adapters/library/inMemoryLibraryService.test.ts
+++ b/src/adapters/library/inMemoryLibraryService.test.ts
@@ -150,6 +150,30 @@ describe('InMemoryLibraryService', () => {
     expect(favorites.photos.map((photo) => photo.id)).toEqual([untaggedFavorite.id]);
   });
 
+  it('supports explicit sort conventions', async () => {
+    const svc = new InMemoryLibraryService();
+
+    await svc.addPhoto({
+      libraryId: LIBRARY_ID,
+      originalName: 'bravo.jpg',
+      dataUrl: 'data:image/jpeg;base64,b',
+    });
+    await svc.addPhoto({
+      libraryId: LIBRARY_ID,
+      originalName: 'alpha.jpg',
+      dataUrl: 'data:image/jpeg;base64,a',
+    });
+
+    const byNameAsc = await svc.listPhotos({ libraryId: LIBRARY_ID, sort: 'name_asc' });
+    expect(byNameAsc.photos.map((photo) => photo.originalName)).toEqual(['alpha.jpg', 'bravo.jpg']);
+
+    const byNameDesc = await svc.listPhotos({ libraryId: LIBRARY_ID, sort: 'name_desc' });
+    expect(byNameDesc.photos.map((photo) => photo.originalName)).toEqual(['bravo.jpg', 'alpha.jpg']);
+
+    const byCreatedAsc = await svc.listPhotos({ libraryId: LIBRARY_ID, sort: 'created_asc' });
+    expect(byCreatedAsc.photos).toHaveLength(2);
+  });
+
   it('paginates results using nextPageToken', async () => {
     const svc = new InMemoryLibraryService();
 

--- a/src/adapters/library/inMemoryLibraryService.ts
+++ b/src/adapters/library/inMemoryLibraryService.ts
@@ -7,6 +7,7 @@ import type {
   ListPhotosInput,
   ListPhotosResult,
   LibraryQuickCollection,
+  LibrarySort,
   Photo,
   UpdatePhotoInput,
 } from '../../domain/library/types';
@@ -65,6 +66,24 @@ function applyCollectionFilter(photos: Photo[], collection?: LibraryQuickCollect
     const createdAt = Date.parse(photo.createdAt);
     return !Number.isNaN(createdAt) && createdAt >= thirtyDaysAgo;
   });
+}
+
+function sortPhotos(photos: Photo[], sort: LibrarySort = 'created_desc'): Photo[] {
+  const sorted = [...photos];
+
+  if (sort === 'created_asc') {
+    return sorted.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  }
+
+  if (sort === 'name_asc') {
+    return sorted.sort((a, b) => a.originalName.localeCompare(b.originalName));
+  }
+
+  if (sort === 'name_desc') {
+    return sorted.sort((a, b) => b.originalName.localeCompare(a.originalName));
+  }
+
+  return sorted.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
 }
 
 export class InMemoryLibraryService implements LibraryService {
@@ -131,8 +150,7 @@ export class InMemoryLibraryService implements LibraryService {
       }
     }
 
-    // Sort newest-first
-    results = results.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    results = sortPhotos(results, input.sort);
 
     const pageSize = input.pageSize ?? results.length;
     const startIndex = input.pageToken

--- a/src/domain/library/types.ts
+++ b/src/domain/library/types.ts
@@ -36,6 +36,8 @@ export interface MetadataFilterInput {
 
 export type LibraryQuickCollection = 'favorites' | 'tagged' | 'untagged' | 'recent';
 
+export type LibrarySort = 'created_desc' | 'created_asc' | 'name_asc' | 'name_desc';
+
 export interface ListPhotosInput {
   libraryId: string;
   albumId?: string;
@@ -49,6 +51,10 @@ export interface ListPhotosInput {
   collection?: LibraryQuickCollection;
   tags?: string[];
   metadata?: MetadataFilterInput;
+  /**
+   * Stable sort conventions for API/UI parity. Defaults to `created_desc`.
+   */
+  sort?: LibrarySort;
   pageSize?: number;
   pageToken?: string;
 }

--- a/src/features/library/useLibrary.ts
+++ b/src/features/library/useLibrary.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import type {
   BulkAddToAlbumResult,
   LibraryQuickCollection,
+  LibrarySort,
   MetadataFilterInput,
   Photo,
 } from '../../domain/library/types';
@@ -43,6 +44,7 @@ export function useLibrary(
     favoritesOnly?: boolean;
     collection?: LibraryQuickCollection;
     tags?: string[];
+    sort?: LibrarySort;
   }
 ): UseLibraryReturn {
   const { library } = useServices();
@@ -66,6 +68,7 @@ export function useLibrary(
         favoritesOnly: filters?.favoritesOnly,
         collection: filters?.collection,
         tags: filters?.tags,
+        sort: filters?.sort,
         pageSize: 24,
       })
       .then(({ photos: p, nextPageToken: token }) => {
@@ -93,6 +96,7 @@ export function useLibrary(
     filters?.favoritesOnly,
     filters?.collection,
     filters?.tags,
+    filters?.sort,
   ]);
 
   const addPhoto = useCallback(
@@ -196,6 +200,7 @@ export function useLibrary(
         favoritesOnly: filters?.favoritesOnly,
         collection: filters?.collection,
         tags: filters?.tags,
+        sort: filters?.sort,
         pageSize: 24,
         pageToken: nextPageToken,
       });
@@ -215,6 +220,7 @@ export function useLibrary(
     filters?.favoritesOnly,
     filters?.collection,
     filters?.tags,
+    filters?.sort,
   ]);
 
   return {

--- a/src/pages/LibraryPage.tsx
+++ b/src/pages/LibraryPage.tsx
@@ -21,7 +21,7 @@ import {
 } from '../features/library/quickViewPreferences';
 import { useUploadSessions } from '../features/uploads/useUploadSessions';
 import { useServices } from '../services/useServices';
-import type { LibraryUsageSummary } from '../domain/library/types';
+import type { LibrarySort, LibraryUsageSummary } from '../domain/library/types';
 
 function toLibraryId(userId: string) {
   return `library-${userId}`;
@@ -45,6 +45,7 @@ export function LibraryPage() {
   const [activeTagFilter, setActiveTagFilter] = useState<string>(
     initialQuickViewPreferences.activeTagFilter
   );
+  const [sortOrder, setSortOrder] = useState<LibrarySort>('created_desc');
   const [gridMode, setGridMode] = useState<GridMode>(initialQuickViewPreferences.gridMode);
   const [savedQuickViews, setSavedQuickViews] = useState<LibrarySavedQuickViewPreset[]>(() =>
     loadSavedQuickViewPresets(libraryId)
@@ -57,8 +58,9 @@ export function LibraryPage() {
       favoritesOnly: quickCollection === 'favorites',
       collection: quickCollection === 'all' ? undefined : quickCollection,
       tags: activeTagFilter ? [activeTagFilter] : undefined,
+      sort: sortOrder,
     }),
-    [cameraMakeFilter, quickCollection, activeTagFilter]
+    [cameraMakeFilter, quickCollection, activeTagFilter, sortOrder]
   );
 
   useEffect(() => {
@@ -484,6 +486,17 @@ export function LibraryPage() {
                   </option>
                 )
               )}
+            </select>
+            <select
+              className="btn-ghost btn-sm"
+              aria-label="Sort photos"
+              value={sortOrder}
+              onChange={(e) => setSortOrder(e.target.value as LibrarySort)}
+            >
+              <option value="created_desc">Newest first</option>
+              <option value="created_asc">Oldest first</option>
+              <option value="name_asc">Name A–Z</option>
+              <option value="name_desc">Name Z–A</option>
             </select>
             <button
               className="btn-ghost btn-sm"


### PR DESCRIPTION
## Summary
- add explicit `sort` conventions to the library list contract (`created_desc`, `created_asc`, `name_asc`, `name_desc`)
- wire sort handling through in-memory + Firebase library adapters with backward-compatible default behavior
- expose a user-facing sort dropdown on the Library page so the gallery can be sorted without reload
- add adapter tests that validate deterministic name-based sorting behavior

## Validation
- npm test -- --run src/adapters/library/inMemoryLibraryService.test.ts
- npm test -- --run

Closes #9
