### PR TITLE
feat: add retry action for albums load failures

### DIFF
--- a/src/features/albums/AlbumsContext.tsx
+++ b/src/features/albums/AlbumsContext.tsx
@@ -14,6 +14,7 @@ export interface AlbumsState {
   renameFolder(folderId: string, name: string): Promise<void>;
   deleteFolder(folderId: string): Promise<void>;
   moveAlbum(albumId: string, folderId: string | null): Promise<void>;
+  reload(): Promise<void>;
 }
 
 const AlbumsContext = createContext<AlbumsState | null>(null);
@@ -32,27 +33,23 @@ export function AlbumsProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
+  const load = useCallback(async () => {
     setLoading(true);
-    Promise.all([albumsService.listAlbums(), albumsService.listFolders()])
-      .then(([a, f]) => {
-        if (!cancelled) {
-          setAlbums(a);
-          setFolders(f);
-          setLoading(false);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setError('Unable to load albums.');
-          setLoading(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
+    setError(null);
+    try {
+      const [a, f] = await Promise.all([albumsService.listAlbums(), albumsService.listFolders()]);
+      setAlbums(a);
+      setFolders(f);
+    } catch {
+      setError('Unable to load albums.');
+    } finally {
+      setLoading(false);
+    }
   }, [albumsService]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
 
   const createAlbum = useCallback(
     async (name: string, folderId?: string | null): Promise<Album | null> => {
@@ -181,6 +178,7 @@ export function AlbumsProvider({ children }: { children: ReactNode }) {
         renameFolder,
         deleteFolder,
         moveAlbum,
+        reload: load,
       }}
     >
       {children}

--- a/src/pages/AlbumsPage.tsx
+++ b/src/pages/AlbumsPage.tsx
@@ -293,6 +293,7 @@ export function AlbumsPage() {
     createFolder,
     deleteFolder,
     moveAlbum,
+    reload,
   } = useAlbums();
   const { photos } = useLibrary(libraryId);
 
@@ -432,7 +433,14 @@ export function AlbumsPage() {
 
         {albumFormError && <p className="error">{albumFormError}</p>}
 
-        {error && <p className="error">{error}</p>}
+        {error && (
+          <div className="error" role="alert">
+            <span>{error}</span>{' '}
+            <button type="button" className="btn-ghost btn-sm" onClick={() => void reload()}>
+              Retry
+            </button>
+          </div>
+        )}
 
         {loading ? (
           <p className="state-message">Loading albums…</p>


### PR DESCRIPTION
## Summary
- add a `reload()` action to the albums state so album/folder data can be fetched again on demand
- refactor initial albums loading to use a shared loader with consistent loading/error reset behavior
- show an in-page Retry button when albums fail to load

## Why
This delivers a user-usable improvement for issue #6's loading/error UX states: users can recover from transient load failures without full page reload.

Closes #6

## Validation
- `npm run -s test -- src/pages/AlbumsPage.test.tsx`
- `npm run -s lint`
