### PR TITLE
feat(teams): add invite guardrails for duplicate/member emails

### DIFF
--- a/src/features/teams/useTeams.test.tsx
+++ b/src/features/teams/useTeams.test.tsx
@@ -42,4 +42,34 @@ describe('useTeams invitation lifecycle', () => {
     expect(result.current.pendingInvitations).toHaveLength(0);
     expect(result.current.workspace.members.some((member) => member.email === 'jamie@example.com')).toBe(false);
   });
+
+  it('refreshes an existing pending invite instead of creating duplicates', () => {
+    const { result } = renderHook(() => useTeams());
+
+    act(() => {
+      result.current.inviteMember('Casey', 'casey@example.com', 'viewer');
+    });
+
+    const firstInviteId = result.current.pendingInvitations[0].id;
+
+    act(() => {
+      result.current.inviteMember('Casey Updated', 'casey@example.com', 'admin');
+    });
+
+    expect(result.current.pendingInvitations).toHaveLength(1);
+    expect(result.current.pendingInvitations[0].id).toBe(firstInviteId);
+    expect(result.current.pendingInvitations[0].role).toBe('admin');
+    expect(result.current.pendingInvitations[0].name).toBe('Casey Updated');
+  });
+
+  it('blocks invites when the email is already a member', () => {
+    const { result } = renderHook(() => useTeams());
+
+    act(() => {
+      result.current.inviteMember('You Again', 'you@local.aurapix', 'viewer');
+    });
+
+    expect(result.current.pendingInvitations).toHaveLength(0);
+    expect(result.current.lastInviteError).toBe('Member is already in this workspace.');
+  });
 });

--- a/src/features/teams/useTeams.ts
+++ b/src/features/teams/useTeams.ts
@@ -111,6 +111,7 @@ function readStoredWorkspace(): TeamWorkspace {
 export function useTeams() {
   const [workspace, setWorkspace] = useState<TeamWorkspace>(() => readStoredWorkspace());
   const [lastRoleChangeError, setLastRoleChangeError] = useState<string | null>(null);
+  const [lastInviteError, setLastInviteError] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -149,26 +150,68 @@ export function useTeams() {
   const inviteMember = useCallback((name: string, email: string, role: TeamRole) => {
     const nowMs = Date.now();
     const nowIso = new Date(nowMs).toISOString();
+    const normalizedEmail = email.trim().toLowerCase();
 
-    setWorkspace((prev) => ({
-      ...prev,
-      invitations: [
-        {
-          id: `invite-${nowMs}`,
-          name,
-          email,
-          role,
-          status: 'pending',
-          invitedAt: nowIso,
-          expiresAt: new Date(nowMs + INVITE_TTL_MS).toISOString(),
-        },
-        ...prev.invitations,
-      ],
-    }));
+    let blockedByDuplicateMember = false;
+
+    setWorkspace((prev) => {
+      const memberExists = prev.members.some((member) => member.email.trim().toLowerCase() === normalizedEmail);
+      if (memberExists) {
+        blockedByDuplicateMember = true;
+        return prev;
+      }
+
+      const existingPendingInvite = prev.invitations.find(
+        (invitation) => invitation.status === 'pending' && invitation.email.trim().toLowerCase() === normalizedEmail
+      );
+
+      if (existingPendingInvite) {
+        return {
+          ...prev,
+          invitations: [
+            {
+              ...existingPendingInvite,
+              name,
+              email: normalizedEmail,
+              role,
+              invitedAt: nowIso,
+              expiresAt: new Date(nowMs + INVITE_TTL_MS).toISOString(),
+              status: 'pending',
+              decidedAt: undefined,
+            },
+            ...prev.invitations.filter((invitation) => invitation.id !== existingPendingInvite.id),
+          ],
+        };
+      }
+
+      return {
+        ...prev,
+        invitations: [
+          {
+            id: `invite-${nowMs}`,
+            name,
+            email: normalizedEmail,
+            role,
+            status: 'pending',
+            invitedAt: nowIso,
+            expiresAt: new Date(nowMs + INVITE_TTL_MS).toISOString(),
+          },
+          ...prev.invitations,
+        ],
+      };
+    });
+
+    if (blockedByDuplicateMember) {
+      setLastInviteError('Member is already in this workspace.');
+      return;
+    }
+
+    setLastInviteError(null);
     setLastRoleChangeError(null);
   }, []);
 
   const acceptInvitation = useCallback((invitationId: string) => {
+    setLastInviteError(null);
     setWorkspace((prev) => {
       const nowMs = Date.now();
       const nowIso = new Date(nowMs).toISOString();
@@ -213,6 +256,7 @@ export function useTeams() {
   }, []);
 
   const declineInvitation = useCallback((invitationId: string) => {
+    setLastInviteError(null);
     setWorkspace((prev) => {
       const nowIso = new Date().toISOString();
       return {
@@ -252,6 +296,7 @@ export function useTeams() {
     roleCounts,
     pendingInvitations,
     lastRoleChangeError,
+    lastInviteError,
     updateRole,
     inviteMember,
     acceptInvitation,

--- a/src/pages/TeamsPage.tsx
+++ b/src/pages/TeamsPage.tsx
@@ -15,6 +15,7 @@ export function TeamsPage() {
     roleCounts,
     pendingInvitations,
     lastRoleChangeError,
+    lastInviteError,
     updateRole,
     inviteMember,
     acceptInvitation,
@@ -112,6 +113,7 @@ export function TeamsPage() {
 
       <form className="teams-panel teams-invite-form" onSubmit={handleInviteSubmit}>
         <h2>Invite member</h2>
+        {lastInviteError ? <p className="teams-inline-error">{lastInviteError}</p> : null}
         <div className="teams-invite-grid">
           <input
             type="text"


### PR DESCRIPTION
## Summary\n- prevent sending invitations to emails that are already workspace members\n- refresh existing pending invite records instead of creating duplicate pending invitations\n- surface inline invite errors in Teams UI for blocked duplicate-member invites\n\n## Testing\n- npm test -- src/features/teams/useTeams.test.tsx src/features/teams/roleSafeguards.test.ts\n- npm run lint\n\nRefs #28