### PR TITLE
feat(teams): add role permission matrix baseline

### DIFF
--- a/src/features/teams/permissions.test.ts
+++ b/src/features/teams/permissions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { canRolePerform, roleCapabilitySummary } from './permissions';
+
+describe('team permissions matrix', () => {
+  it('enforces expected upload/edit/share/delete permissions by role', () => {
+    expect(roleCapabilitySummary('viewer')).toEqual({
+      upload: false,
+      edit: false,
+      share: false,
+      delete: false,
+    });
+
+    expect(roleCapabilitySummary('contributor')).toEqual({
+      upload: true,
+      edit: false,
+      share: false,
+      delete: false,
+    });
+
+    expect(roleCapabilitySummary('editor')).toEqual({
+      upload: true,
+      edit: true,
+      share: false,
+      delete: false,
+    });
+
+    expect(roleCapabilitySummary('admin')).toEqual({
+      upload: true,
+      edit: true,
+      share: true,
+      delete: true,
+    });
+
+    expect(roleCapabilitySummary('owner')).toEqual({
+      upload: true,
+      edit: true,
+      share: true,
+      delete: true,
+    });
+  });
+
+  it('exposes action checks for UI/API guardrails', () => {
+    expect(canRolePerform('editor', 'edit')).toBe(true);
+    expect(canRolePerform('editor', 'share')).toBe(false);
+    expect(canRolePerform('contributor', 'upload')).toBe(true);
+    expect(canRolePerform('viewer', 'upload')).toBe(false);
+  });
+});

--- a/src/features/teams/permissions.ts
+++ b/src/features/teams/permissions.ts
@@ -1,0 +1,31 @@
+import type { TeamRole } from './useTeams';
+
+export type TeamAction = 'upload' | 'edit' | 'share' | 'delete';
+
+const ACTION_WEIGHT: Record<TeamAction, number> = {
+  upload: 1,
+  edit: 2,
+  share: 3,
+  delete: 4,
+};
+
+const ROLE_MAX_ACTION_WEIGHT: Record<TeamRole, number> = {
+  viewer: 0,
+  contributor: ACTION_WEIGHT.upload,
+  editor: ACTION_WEIGHT.edit,
+  admin: ACTION_WEIGHT.delete,
+  owner: ACTION_WEIGHT.delete,
+};
+
+export function canRolePerform(role: TeamRole, action: TeamAction): boolean {
+  return ROLE_MAX_ACTION_WEIGHT[role] >= ACTION_WEIGHT[action];
+}
+
+export function roleCapabilitySummary(role: TeamRole): Record<TeamAction, boolean> {
+  return {
+    upload: canRolePerform(role, 'upload'),
+    edit: canRolePerform(role, 'edit'),
+    share: canRolePerform(role, 'share'),
+    delete: canRolePerform(role, 'delete'),
+  };
+}

--- a/src/pages/TeamsPage.tsx
+++ b/src/pages/TeamsPage.tsx
@@ -1,7 +1,14 @@
 import { useState } from 'react';
+import { roleCapabilitySummary, type TeamAction } from '../features/teams/permissions';
 import { useTeams, type TeamRole } from '../features/teams/useTeams';
 
 const ROLE_OPTIONS: TeamRole[] = ['owner', 'admin', 'editor', 'contributor', 'viewer'];
+const ACTION_LABELS: Record<TeamAction, string> = {
+  upload: 'Upload',
+  edit: 'Edit',
+  share: 'Share',
+  delete: 'Delete',
+};
 
 function formatExpiration(iso: string): string {
   const date = new Date(iso);
@@ -87,27 +94,38 @@ export function TeamsPage() {
       <div className="teams-panel">
         <h2>Members</h2>
         <ul className="teams-member-list">
-          {workspace.members.map((member) => (
-            <li key={member.id} className="teams-member-row">
-              <div className="teams-member-meta">
-                <div className="teams-member-name">{member.name}</div>
-                <div className="teams-member-email">{member.email}</div>
-              </div>
-              <label className="teams-role-select-wrap">
-                <span className="sr-only">Role for {member.name}</span>
-                <select
-                  value={member.role}
-                  onChange={(e) => updateRole(member.id, e.target.value as TeamRole)}
-                >
-                  {ROLE_OPTIONS.map((role) => (
-                    <option key={role} value={role}>
-                      {role}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            </li>
-          ))}
+          {workspace.members.map((member) => {
+            const capabilities = roleCapabilitySummary(member.role);
+
+            return (
+              <li key={member.id} className="teams-member-row">
+                <div className="teams-member-meta">
+                  <div className="teams-member-name">{member.name}</div>
+                  <div className="teams-member-email">{member.email}</div>
+                  <div className="teams-member-email">
+                    {(['upload', 'edit', 'share', 'delete'] as TeamAction[]).map((action) => (
+                      <span key={action}>
+                        {ACTION_LABELS[action]} {capabilities[action] ? '✓' : '—'}{' '}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <label className="teams-role-select-wrap">
+                  <span className="sr-only">Role for {member.name}</span>
+                  <select
+                    value={member.role}
+                    onChange={(e) => updateRole(member.id, e.target.value as TeamRole)}
+                  >
+                    {ROLE_OPTIONS.map((role) => (
+                      <option key={role} value={role}>
+                        {role}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </li>
+            );
+          })}
         </ul>
       </div>
 


### PR DESCRIPTION
## Summary\n- add a centralized role permission matrix helper for upload/edit/share/delete actions\n- add unit tests covering all TeamRole capabilities and spot-check policy checks\n- surface effective permissions in Teams UI so role changes are immediately demoable\n\n## Testing\n- npm test -- --run src/features/teams/roleSafeguards.test.ts src/features/teams/useTeams.test.tsx src/features/teams/permissions.test.ts\n\nCloses #28 (incremental progress toward role matrix acceptance criteria).