### PR TITLE
feat(teams): enforce last-owner safeguard on member removal

### DIFF
--- a/src/features/teams/roleSafeguards.test.ts
+++ b/src/features/teams/roleSafeguards.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { canTransitionRole, countOwners, LAST_OWNER_BLOCK_MESSAGE } from './roleSafeguards';
+import {
+  canRemoveMember,
+  canTransitionRole,
+  countOwners,
+  LAST_OWNER_BLOCK_MESSAGE,
+  LAST_OWNER_REMOVAL_BLOCK_MESSAGE,
+} from './roleSafeguards';
 import type { TeamWorkspace } from './useTeams';
 
 function createWorkspace(): TeamWorkspace {
@@ -37,6 +43,28 @@ describe('roleSafeguards', () => {
     });
 
     const result = canTransitionRole(workspace, 'u1', 'admin');
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('blocks removing the last owner', () => {
+    const result = canRemoveMember(createWorkspace(), 'u1');
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe(LAST_OWNER_REMOVAL_BLOCK_MESSAGE);
+  });
+
+  it('allows removing an owner when another owner exists', () => {
+    const workspace = createWorkspace();
+    workspace.members.push({
+      id: 'u3',
+      name: 'Second Owner',
+      email: 'owner2@test.dev',
+      role: 'owner',
+      invited: false,
+    });
+
+    const result = canRemoveMember(workspace, 'u1');
 
     expect(result.ok).toBe(true);
   });

--- a/src/features/teams/roleSafeguards.ts
+++ b/src/features/teams/roleSafeguards.ts
@@ -2,6 +2,8 @@ import type { TeamRole, TeamWorkspace } from './useTeams';
 
 export const LAST_OWNER_BLOCK_MESSAGE =
   'Workspace must always have at least one owner. Assign another owner before changing this role.';
+export const LAST_OWNER_REMOVAL_BLOCK_MESSAGE =
+  'Cannot remove the last owner from the workspace. Promote another member to owner first.';
 
 export function countOwners(workspace: TeamWorkspace): number {
   return workspace.members.filter((member) => member.role === 'owner').length;
@@ -23,6 +25,19 @@ export function canTransitionRole(
 
   if (member.role === 'owner' && targetRole !== 'owner' && countOwners(workspace) <= 1) {
     return { ok: false, reason: LAST_OWNER_BLOCK_MESSAGE };
+  }
+
+  return { ok: true };
+}
+
+export function canRemoveMember(workspace: TeamWorkspace, memberId: string): { ok: boolean; reason?: string } {
+  const member = workspace.members.find((candidate) => candidate.id === memberId);
+  if (!member) {
+    return { ok: false, reason: 'Member not found.' };
+  }
+
+  if (member.role === 'owner' && countOwners(workspace) <= 1) {
+    return { ok: false, reason: LAST_OWNER_REMOVAL_BLOCK_MESSAGE };
   }
 
   return { ok: true };

--- a/src/features/teams/useTeams.test.tsx
+++ b/src/features/teams/useTeams.test.tsx
@@ -72,4 +72,33 @@ describe('useTeams invitation lifecycle', () => {
     expect(result.current.pendingInvitations).toHaveLength(0);
     expect(result.current.lastInviteError).toBe('Member is already in this workspace.');
   });
+
+  it('blocks removing the last owner', () => {
+    const { result } = renderHook(() => useTeams());
+    const ownerId = result.current.workspace.members.find((member) => member.role === 'owner')?.id;
+
+    expect(ownerId).toBeTruthy();
+
+    act(() => {
+      result.current.removeMember(ownerId!);
+    });
+
+    expect(result.current.workspace.members.some((member) => member.id === ownerId)).toBe(true);
+    expect(result.current.lastRoleChangeError).toBe(
+      'Cannot remove the last owner from the workspace. Promote another member to owner first.'
+    );
+  });
+
+  it('removes a non-owner member', () => {
+    const { result } = renderHook(() => useTeams());
+    const editorId = result.current.workspace.members.find((member) => member.role === 'editor')?.id;
+
+    expect(editorId).toBeTruthy();
+
+    act(() => {
+      result.current.removeMember(editorId!);
+    });
+
+    expect(result.current.workspace.members.some((member) => member.id === editorId)).toBe(false);
+  });
 });

--- a/src/features/teams/useTeams.ts
+++ b/src/features/teams/useTeams.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { canTransitionRole } from './roleSafeguards';
+import { canRemoveMember, canTransitionRole } from './roleSafeguards';
 
 export type TeamRole = 'owner' | 'admin' | 'editor' | 'contributor' | 'viewer';
 export type TeamInvitationStatus = 'pending' | 'accepted' | 'declined' | 'expired';
@@ -139,6 +139,28 @@ export function useTeams() {
       return {
         ...prev,
         members: prev.members.map((member) => (member.id === memberId ? { ...member, role } : member)),
+      };
+    });
+
+    if (updated) {
+      setLastRoleChangeError(null);
+    }
+  }, []);
+
+  const removeMember = useCallback((memberId: string) => {
+    let updated = false;
+
+    setWorkspace((prev) => {
+      const removal = canRemoveMember(prev, memberId);
+      if (!removal.ok) {
+        setLastRoleChangeError(removal.reason ?? 'Member removal blocked by workspace policy.');
+        return prev;
+      }
+
+      updated = true;
+      return {
+        ...prev,
+        members: prev.members.filter((member) => member.id !== memberId),
       };
     });
 
@@ -298,6 +320,7 @@ export function useTeams() {
     lastRoleChangeError,
     lastInviteError,
     updateRole,
+    removeMember,
     inviteMember,
     acceptInvitation,
     declineInvitation,

--- a/src/pages/TeamsPage.tsx
+++ b/src/pages/TeamsPage.tsx
@@ -24,6 +24,7 @@ export function TeamsPage() {
     lastRoleChangeError,
     lastInviteError,
     updateRole,
+    removeMember,
     inviteMember,
     acceptInvitation,
     declineInvitation,
@@ -110,19 +111,24 @@ export function TeamsPage() {
                     ))}
                   </div>
                 </div>
-                <label className="teams-role-select-wrap">
-                  <span className="sr-only">Role for {member.name}</span>
-                  <select
-                    value={member.role}
-                    onChange={(e) => updateRole(member.id, e.target.value as TeamRole)}
-                  >
-                    {ROLE_OPTIONS.map((role) => (
-                      <option key={role} value={role}>
-                        {role}
-                      </option>
-                    ))}
-                  </select>
-                </label>
+                <div className="teams-invite-actions">
+                  <label className="teams-role-select-wrap">
+                    <span className="sr-only">Role for {member.name}</span>
+                    <select
+                      value={member.role}
+                      onChange={(e) => updateRole(member.id, e.target.value as TeamRole)}
+                    >
+                      {ROLE_OPTIONS.map((role) => (
+                        <option key={role} value={role}>
+                          {role}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <button type="button" className="btn-secondary" onClick={() => removeMember(member.id)}>
+                    Remove
+                  </button>
+                </div>
               </li>
             );
           })}


### PR DESCRIPTION
## Summary
- add  safeguard logic to prevent removing the last workspace owner
- add  support to the teams hook with policy-aware error handling
- expose remove action in Teams UI for practical membership management
- add tests for removal safeguards and successful non-owner removal

## Validation
- npm test -- src/features/teams/useTeams.test.tsx src/features/teams/roleSafeguards.test.ts src/features/teams/permissions.test.ts

Closes #28