### PR TITLE
feat(api): idempotency keys for edit apply/revert endpoints

### DIFF
--- a/functions/src/handlers/edits/applyEdits.ts
+++ b/functions/src/handlers/edits/applyEdits.ts
@@ -10,6 +10,14 @@ import {
   EDIT_PLUGIN_MANIFEST,
   EDIT_RECIPE_VERSION,
 } from '../../services/edits/pluginRegistry.js';
+import {
+  createApplyEditsFingerprint,
+  createRevertFingerprint,
+  editFingerprintMatches,
+  getEditIdempotencyRecord,
+  getNormalizedIdempotencyKey,
+  storeEditIdempotencyRecord,
+} from './editIdempotency.js';
 
 /**
  * List edit plugins and recipe contract version
@@ -40,6 +48,17 @@ export async function handleApplyEdits(
   const photoId = req.params.photoId as string;
   const userId = req.user?.uid || 'anonymous';
 
+  let idempotencyKey: string | null;
+  try {
+    idempotencyKey = getNormalizedIdempotencyKey(req.header('Idempotency-Key'));
+  } catch (error) {
+    throw new AppError(
+      400,
+      'INVALID_IDEMPOTENCY_KEY',
+      error instanceof Error ? error.message : 'Invalid idempotency key'
+    );
+  }
+
   // Validate request body
   const validation = ApplyEditsSchema.safeParse(req.body);
   if (!validation.success) {
@@ -60,6 +79,41 @@ export async function handleApplyEdits(
   const opsValidation = validateOperations(operations);
   if (!opsValidation.valid) {
     throw new AppError(400, 'INVALID_OPERATIONS', `Invalid operations: ${opsValidation.errors.join(', ')}`);
+  }
+
+  const requestFingerprint = createApplyEditsFingerprint({
+    recipeVersion,
+    operations,
+    description,
+  });
+
+  if (idempotencyKey) {
+    const existingRecord = await getEditIdempotencyRecord(
+      dataAdapter,
+      userId,
+      libraryId,
+      photoId,
+      idempotencyKey
+    );
+
+    if (existingRecord) {
+      if (!editFingerprintMatches(existingRecord.request, requestFingerprint)) {
+        throw new AppError(
+          409,
+          'IDEMPOTENCY_KEY_REUSE_MISMATCH',
+          'Idempotency key was already used with a different edit request payload'
+        );
+      }
+
+      res.status(200).json({
+        ...(existingRecord.responseBody as Record<string, unknown>),
+        idempotency: {
+          key: idempotencyKey,
+          replayed: true,
+        },
+      });
+      return;
+    }
   }
 
   try {
@@ -105,8 +159,7 @@ export async function handleApplyEdits(
       'Edits applied successfully'
     );
 
-    // Return response
-    res.status(202).json({
+    const responseBody = {
       photoId,
       version: newVersion.version,
       status: 'processing',
@@ -118,6 +171,31 @@ export async function handleApplyEdits(
         description: newVersion.description,
         createdAt: newVersion.createdAt,
       },
+    };
+
+    if (idempotencyKey) {
+      await storeEditIdempotencyRecord(dataAdapter, {
+        key: idempotencyKey,
+        userId,
+        libraryId,
+        photoId,
+        request: requestFingerprint,
+        responseBody,
+        createdAt: new Date().toISOString(),
+      });
+    }
+
+    // Return response
+    res.status(202).json({
+      ...responseBody,
+      ...(idempotencyKey
+        ? {
+            idempotency: {
+              key: idempotencyKey,
+              replayed: false,
+            },
+          }
+        : {}),
     });
 
     // Trigger thumbnail regeneration in background
@@ -165,10 +243,53 @@ export async function handleRevertVersion(
 
   const libraryId = req.params.libraryId as string;
   const photoId = req.params.photoId as string;
+  const userId = req.user?.uid || 'anonymous';
   const { targetVersion } = req.body;
 
   if (typeof targetVersion !== 'number' || targetVersion < 0) {
     throw new AppError(400, 'INVALID_VERSION', 'Invalid target version');
+  }
+
+  let idempotencyKey: string | null;
+  try {
+    idempotencyKey = getNormalizedIdempotencyKey(req.header('Idempotency-Key'));
+  } catch (error) {
+    throw new AppError(
+      400,
+      'INVALID_IDEMPOTENCY_KEY',
+      error instanceof Error ? error.message : 'Invalid idempotency key'
+    );
+  }
+
+  const requestFingerprint = createRevertFingerprint(targetVersion);
+
+  if (idempotencyKey) {
+    const existingRecord = await getEditIdempotencyRecord(
+      dataAdapter,
+      userId,
+      libraryId,
+      photoId,
+      idempotencyKey
+    );
+
+    if (existingRecord) {
+      if (!editFingerprintMatches(existingRecord.request, requestFingerprint)) {
+        throw new AppError(
+          409,
+          'IDEMPOTENCY_KEY_REUSE_MISMATCH',
+          'Idempotency key was already used with a different revert request payload'
+        );
+      }
+
+      res.status(200).json({
+        ...(existingRecord.responseBody as Record<string, unknown>),
+        idempotency: {
+          key: idempotencyKey,
+          replayed: true,
+        },
+      });
+      return;
+    }
   }
 
   try {
@@ -189,10 +310,34 @@ export async function handleRevertVersion(
 
     // Version 0 is the original (no edits)
     if (targetVersion === photo.currentEditVersion) {
-      res.json({
+      const responseBody = {
         message: 'Already at target version',
         photoId,
         version: targetVersion,
+      };
+
+      if (idempotencyKey) {
+        await storeEditIdempotencyRecord(dataAdapter, {
+          key: idempotencyKey,
+          userId,
+          libraryId,
+          photoId,
+          request: requestFingerprint,
+          responseBody,
+          createdAt: new Date().toISOString(),
+        });
+      }
+
+      res.json({
+        ...responseBody,
+        ...(idempotencyKey
+          ? {
+              idempotency: {
+                key: idempotencyKey,
+                replayed: false,
+              },
+            }
+          : {}),
       });
       return;
     }
@@ -209,11 +354,35 @@ export async function handleRevertVersion(
       'Reverted to previous version'
     );
 
-    res.status(202).json({
+    const responseBody = {
       photoId,
       version: targetVersion,
       status: 'processing',
       message: 'Reverted to version, thumbnails are being regenerated',
+    };
+
+    if (idempotencyKey) {
+      await storeEditIdempotencyRecord(dataAdapter, {
+        key: idempotencyKey,
+        userId,
+        libraryId,
+        photoId,
+        request: requestFingerprint,
+        responseBody,
+        createdAt: new Date().toISOString(),
+      });
+    }
+
+    res.status(202).json({
+      ...responseBody,
+      ...(idempotencyKey
+        ? {
+            idempotency: {
+              key: idempotencyKey,
+              replayed: false,
+            },
+          }
+        : {}),
     });
 
     // Trigger thumbnail regeneration

--- a/functions/src/handlers/edits/editIdempotency.test.ts
+++ b/functions/src/handlers/edits/editIdempotency.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createApplyEditsFingerprint,
+  createRevertFingerprint,
+  editFingerprintMatches,
+  getNormalizedIdempotencyKey,
+} from './editIdempotency.js';
+
+describe('editIdempotency', () => {
+  it('normalizes idempotency key and rejects too-long values', () => {
+    expect(getNormalizedIdempotencyKey('  abc-123  ')).toBe('abc-123');
+    expect(getNormalizedIdempotencyKey('')).toBeNull();
+    expect(getNormalizedIdempotencyKey(undefined)).toBeNull();
+
+    expect(() => getNormalizedIdempotencyKey('x'.repeat(129))).toThrow(
+      'Idempotency key exceeds 128 characters.'
+    );
+  });
+
+  it('matches apply fingerprints only for identical payloads', () => {
+    const one = createApplyEditsFingerprint({
+      recipeVersion: 1,
+      operations: [{ plugin: 'brightness', params: { amount: 10 } }],
+      description: 'brighten',
+    });
+
+    const same = createApplyEditsFingerprint({
+      recipeVersion: 1,
+      operations: [{ plugin: 'brightness', params: { amount: 10 } }],
+      description: 'brighten',
+    });
+
+    const different = createApplyEditsFingerprint({
+      recipeVersion: 1,
+      operations: [{ plugin: 'brightness', params: { amount: 20 } }],
+      description: 'brighten',
+    });
+
+    expect(editFingerprintMatches(one, same)).toBe(true);
+    expect(editFingerprintMatches(one, different)).toBe(false);
+  });
+
+  it('matches revert fingerprints for same target version only', () => {
+    const one = createRevertFingerprint(2);
+    const same = createRevertFingerprint(2);
+    const different = createRevertFingerprint(3);
+
+    expect(editFingerprintMatches(one, same)).toBe(true);
+    expect(editFingerprintMatches(one, different)).toBe(false);
+  });
+
+  it('never matches apply vs revert fingerprints', () => {
+    const apply = createApplyEditsFingerprint({
+      recipeVersion: 1,
+      operations: [{ plugin: 'contrast', params: { amount: 5 } }],
+    });
+    const revert = createRevertFingerprint(1);
+
+    expect(editFingerprintMatches(apply, revert)).toBe(false);
+  });
+});

--- a/functions/src/handlers/edits/editIdempotency.ts
+++ b/functions/src/handlers/edits/editIdempotency.ts
@@ -1,0 +1,121 @@
+import { createHash } from 'node:crypto';
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+
+const IDEMPOTENCY_COLLECTION = 'edit_idempotency';
+const MAX_IDEMPOTENCY_KEY_LENGTH = 128;
+
+export interface ApplyEditsFingerprint {
+  kind: 'apply';
+  recipeVersion: number;
+  operationsHash: string;
+  description: string | null;
+}
+
+export interface RevertEditsFingerprint {
+  kind: 'revert';
+  targetVersion: number;
+}
+
+export type EditRequestFingerprint = ApplyEditsFingerprint | RevertEditsFingerprint;
+
+export interface EditIdempotencyRecord {
+  key: string;
+  userId: string;
+  libraryId: string;
+  photoId: string;
+  request: EditRequestFingerprint;
+  responseBody: unknown;
+  createdAt: string;
+}
+
+export function getNormalizedIdempotencyKey(
+  headerValue: string | string[] | undefined
+): string | null {
+  if (typeof headerValue !== 'string') {
+    return null;
+  }
+
+  const normalized = headerValue.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized.length > MAX_IDEMPOTENCY_KEY_LENGTH) {
+    throw new Error(`Idempotency key exceeds ${MAX_IDEMPOTENCY_KEY_LENGTH} characters.`);
+  }
+
+  return normalized;
+}
+
+export function createApplyEditsFingerprint(input: {
+  recipeVersion: number;
+  operations: unknown;
+  description?: string;
+}): ApplyEditsFingerprint {
+  return {
+    kind: 'apply',
+    recipeVersion: input.recipeVersion,
+    operationsHash: createHash('sha256').update(JSON.stringify(input.operations)).digest('hex'),
+    description: input.description ?? null,
+  };
+}
+
+export function createRevertFingerprint(targetVersion: number): RevertEditsFingerprint {
+  return {
+    kind: 'revert',
+    targetVersion,
+  };
+}
+
+function buildRecordId(
+  userId: string,
+  libraryId: string,
+  photoId: string,
+  key: string
+): string {
+  return createHash('sha256')
+    .update(`${userId}:${libraryId}:${photoId}:${key}`)
+    .digest('hex');
+}
+
+export async function getEditIdempotencyRecord(
+  dataAdapter: DataAdapter,
+  userId: string,
+  libraryId: string,
+  photoId: string,
+  key: string
+): Promise<EditIdempotencyRecord | null> {
+  const recordId = buildRecordId(userId, libraryId, photoId, key);
+  return dataAdapter.fetchData<EditIdempotencyRecord>(IDEMPOTENCY_COLLECTION, recordId);
+}
+
+export async function storeEditIdempotencyRecord(
+  dataAdapter: DataAdapter,
+  record: EditIdempotencyRecord
+): Promise<void> {
+  const recordId = buildRecordId(record.userId, record.libraryId, record.photoId, record.key);
+  await dataAdapter.storeData(IDEMPOTENCY_COLLECTION, recordId, record);
+}
+
+export function editFingerprintMatches(
+  expected: EditRequestFingerprint,
+  actual: EditRequestFingerprint
+): boolean {
+  if (expected.kind !== actual.kind) {
+    return false;
+  }
+
+  if (expected.kind === 'apply' && actual.kind === 'apply') {
+    return (
+      expected.recipeVersion === actual.recipeVersion &&
+      expected.operationsHash === actual.operationsHash &&
+      expected.description === actual.description
+    );
+  }
+
+  if (expected.kind === 'revert' && actual.kind === 'revert') {
+    return expected.targetVersion === actual.targetVersion;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary\n- add Idempotency-Key support to POST /edits/:libraryId/:photoId and POST /edits/:libraryId/:photoId/revert\n- replay prior responses for matching requests and return 409 on payload mismatch\n- persist edit idempotency records keyed by user+library+photo+key\n- include idempotency metadata in fresh/replayed responses\n- add tests for edit idempotency fingerprint and key normalization behavior\n\n## Why\nImplements a concrete slice of #13 (API hardening for multi-client compatibility) by making edit mutations safe to retry across flaky networks and client reconnects.\n\n## Validation\n- npm --prefix functions run test\n- npm --prefix functions run build\n\n## Notes\n- Existing functions lint baseline currently fails on unrelated pre-existing files; no new lint failures introduced by this PR.