### PR TITLE
feat(api): explicit edit version conflict handling for apply/revert

### DIFF
--- a/functions/src/handlers/edits/applyEdits.conflict.test.ts
+++ b/functions/src/handlers/edits/applyEdits.conflict.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AppError } from '../../middleware/errorHandler.js';
+import {
+  handleApplyEdits,
+  handleRevertVersion,
+} from './applyEdits.js';
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+import type { StorageAdapter } from '../../adapters/storage/StorageAdapter.js';
+import type { Photo } from '../../models/Photo.js';
+
+function createPhoto(): Photo {
+  return {
+    id: 'photo-1',
+    libraryId: 'lib-1',
+    albumIds: [],
+    originalName: 'test.jpg',
+    metadata: {
+      width: 100,
+      height: 100,
+      mimeType: 'image/jpeg',
+      sizeBytes: 123,
+    },
+    status: 'ready',
+    currentEditVersion: 3,
+    editHistory: [
+      {
+        version: 1,
+        recipeVersion: 1,
+        createdAt: new Date().toISOString(),
+        createdBy: 'u1',
+        operations: [],
+      },
+    ],
+    thumbnailsOutdated: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function createDataAdapter(photo: Photo): DataAdapter {
+  return {
+    storeData: vi.fn(),
+    fetchData: vi.fn(async () => photo),
+    queryData: vi.fn(async () => []),
+    updateData: vi.fn(),
+    deleteData: vi.fn(),
+    exists: vi.fn(async () => true),
+    listIds: vi.fn(async () => []),
+    getPhoto: vi.fn(async () => photo),
+  };
+}
+
+function createStorageAdapter(): StorageAdapter {
+  return {
+    storeFile: vi.fn(),
+    readFile: vi.fn(async () => Buffer.alloc(0)),
+    fileExists: vi.fn(async () => true),
+    deleteFile: vi.fn(),
+    listFiles: vi.fn(async () => []),
+    getFileSize: vi.fn(async () => 0),
+  };
+}
+
+function createRes() {
+  const res = {
+    status: vi.fn(),
+    json: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res;
+}
+
+describe('edit conflict handling', () => {
+  it('returns 409 when apply edits If-Match-Edit-Version does not match current version', async () => {
+    const dataAdapter = createDataAdapter(createPhoto());
+    const storageAdapter = createStorageAdapter();
+
+    const req: any = {
+      params: { libraryId: 'lib-1', photoId: 'photo-1' },
+      user: { uid: 'user-1' },
+      body: {
+        recipeVersion: 1,
+        operations: [{ type: 'rotate', params: { degrees: 90 }, order: 0 }],
+      },
+      header: (name: string) =>
+        name === 'If-Match-Edit-Version' ? '2' : undefined,
+      app: { locals: { dataAdapter, storageAdapter } },
+    };
+
+    const res = createRes();
+
+    await expect(handleApplyEdits(req, res as any)).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'EDIT_VERSION_CONFLICT',
+    } satisfies Partial<AppError>);
+    expect((dataAdapter.updateData as any).mock.calls.length).toBe(0);
+  });
+
+  it('returns 400 when If-Match-Edit-Version is invalid', async () => {
+    const req: any = {
+      params: { libraryId: 'lib-1', photoId: 'photo-1' },
+      user: { uid: 'user-1' },
+      body: {
+        recipeVersion: 1,
+        operations: [{ type: 'rotate', params: { degrees: 90 }, order: 0 }],
+      },
+      header: (name: string) =>
+        name === 'If-Match-Edit-Version' ? 'abc' : undefined,
+      app: { locals: { dataAdapter: createDataAdapter(createPhoto()), storageAdapter: createStorageAdapter() } },
+    };
+
+    await expect(handleApplyEdits(req, createRes() as any)).rejects.toMatchObject({
+      statusCode: 400,
+      code: 'INVALID_IF_MATCH_EDIT_VERSION',
+    } satisfies Partial<AppError>);
+  });
+
+  it('returns 409 when revert If-Match-Edit-Version does not match current version', async () => {
+    const dataAdapter = createDataAdapter(createPhoto());
+
+    const req: any = {
+      params: { libraryId: 'lib-1', photoId: 'photo-1' },
+      user: { uid: 'user-1' },
+      body: { targetVersion: 1 },
+      header: (name: string) =>
+        name === 'If-Match-Edit-Version' ? '99' : undefined,
+      app: {
+        locals: {
+          dataAdapter,
+          storageAdapter: createStorageAdapter(),
+        },
+      },
+    };
+
+    await expect(handleRevertVersion(req, createRes() as any)).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'EDIT_VERSION_CONFLICT',
+    } satisfies Partial<AppError>);
+    expect((dataAdapter.updateData as any).mock.calls.length).toBe(0);
+  });
+});

--- a/functions/src/handlers/edits/applyEdits.ts
+++ b/functions/src/handlers/edits/applyEdits.ts
@@ -19,6 +19,41 @@ import {
   storeEditIdempotencyRecord,
 } from './editIdempotency.js';
 
+function parseExpectedCurrentVersion(headerValue: string | undefined): number | null {
+  if (!headerValue) return null;
+
+  const parsed = Number.parseInt(headerValue, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new AppError(
+      400,
+      'INVALID_IF_MATCH_EDIT_VERSION',
+      'If-Match-Edit-Version must be a non-negative integer'
+    );
+  }
+
+  return parsed;
+}
+
+function assertEditVersionMatch(
+  expectedCurrentVersion: number | null,
+  actualCurrentVersion: number
+): void {
+  if (expectedCurrentVersion === null) return;
+
+  if (expectedCurrentVersion !== actualCurrentVersion) {
+    throw new AppError(
+      409,
+      'EDIT_VERSION_CONFLICT',
+      `Edit version conflict: expected current version ${expectedCurrentVersion}, actual version ${actualCurrentVersion}`,
+      {
+        expectedCurrentVersion,
+        actualCurrentVersion,
+      }
+    );
+  }
+}
+
+
 /**
  * List edit plugins and recipe contract version
  * GET /edits/plugins
@@ -47,6 +82,9 @@ export async function handleApplyEdits(
   const libraryId = req.params.libraryId as string;
   const photoId = req.params.photoId as string;
   const userId = req.user?.uid || 'anonymous';
+  const expectedCurrentVersion = parseExpectedCurrentVersion(
+    req.header('If-Match-Edit-Version') ?? undefined
+  );
 
   let idempotencyKey: string | null;
   try {
@@ -128,6 +166,8 @@ export async function handleApplyEdits(
     }
 
     // TODO: Check user has edit permission
+
+    assertEditVersionMatch(expectedCurrentVersion, photo.currentEditVersion);
 
     // Create new edit version
     const newVersion: EditVersion = {
@@ -244,6 +284,9 @@ export async function handleRevertVersion(
   const libraryId = req.params.libraryId as string;
   const photoId = req.params.photoId as string;
   const userId = req.user?.uid || 'anonymous';
+  const expectedCurrentVersion = parseExpectedCurrentVersion(
+    req.header('If-Match-Edit-Version') ?? undefined
+  );
   const { targetVersion } = req.body;
 
   if (typeof targetVersion !== 'number' || targetVersion < 0) {
@@ -302,6 +345,8 @@ export async function handleRevertVersion(
     if (photo.libraryId !== libraryId) {
       throw new AppError(404, 'PHOTO_NOT_FOUND', 'Photo not found in this library');
     }
+
+    assertEditVersionMatch(expectedCurrentVersion, photo.currentEditVersion);
 
     // Validate target version exists
     if (targetVersion > photo.editHistory.length) {


### PR DESCRIPTION
## Summary
- add optimistic concurrency guard via If-Match-Edit-Version on edit apply/revert endpoints
- return explicit 409 EDIT_VERSION_CONFLICT responses with expected/actual version details
- reject invalid version headers with 400 INVALID_IF_MATCH_EDIT_VERSION
- add handler tests covering conflict + invalid header behavior

## Why
This delivers a concrete Phase 4 (#13) increment for conflict handling semantics needed by multi-client sync flows.

## Testing
- npm test

Refs #13
