### PR TITLE
feat(sharing): hash share-link passwords with legacy-safe verification

### DIFF
--- a/src/adapters/sharing/FirebaseSharingService.ts
+++ b/src/adapters/sharing/FirebaseSharingService.ts
@@ -11,6 +11,7 @@ import {
 } from 'firebase/firestore';
 import { nanoid } from 'nanoid';
 import type { SharingService } from '../../domain/sharing/contract';
+import { hashPassword, isVersionedPasswordHash, verifyPassword } from './passwordHash';
 import type {
   CreateShareLinkInput,
   ResolveShareDownloadInput,
@@ -59,8 +60,7 @@ export class FirebaseSharingService implements SharingService {
       ...shareLink,
     };
     if (input.password) {
-      // In production, hash the password before storing
-      docData.passwordHash = input.password; // TODO: Use bcrypt or similar
+      docData.passwordHash = await hashPassword(input.password);
     }
 
     const docRef = await addDoc(collection(this.db, 'shareLinks'), docData);
@@ -168,9 +168,16 @@ export class FirebaseSharingService implements SharingService {
         return null;
       }
 
-      // Verify password (in production, compare hashes)
       const linkData = linkDoc.data() as { passwordHash?: string };
-      if (linkData.passwordHash !== input.password) {
+      const storedPassword = linkData.passwordHash;
+      const isValidPassword =
+        typeof storedPassword === 'string'
+          ? isVersionedPasswordHash(storedPassword)
+            ? await verifyPassword(input.password, storedPassword)
+            : storedPassword === input.password // Backward compatibility for existing plaintext records
+          : false;
+
+      if (!isValidPassword) {
         await this.logAccessEvent(input.token, link.id, 'denied_invalid_password', 'link_resolve', link);
         return null;
       }

--- a/src/adapters/sharing/inMemorySharingService.ts
+++ b/src/adapters/sharing/inMemorySharingService.ts
@@ -1,4 +1,5 @@
 import type { SharingService } from '../../domain/sharing/contract';
+import { hashPassword, verifyPassword } from './passwordHash';
 import type {
   CreateShareLinkInput,
   ResolveShareDownloadInput,
@@ -47,7 +48,8 @@ export class InMemorySharingService implements SharingService {
     };
 
     if (input.password) {
-      this.linkPasswords.set(link.id, input.password);
+      const passwordHash = await hashPassword(input.password);
+      this.linkPasswords.set(link.id, passwordHash);
     }
 
     this.links = [link, ...this.links];
@@ -100,7 +102,7 @@ export class InMemorySharingService implements SharingService {
   }
 
   async resolveShareLink(input: ResolveShareLinkInput): Promise<ShareLink | null> {
-    const link = this.validateAccess(input, 'link_resolve');
+    const link = await this.validateAccess(input, 'link_resolve');
     if (!link) {
       return null;
     }
@@ -112,7 +114,7 @@ export class InMemorySharingService implements SharingService {
     input: ResolveShareDownloadInput
   ): Promise<ShareDownloadResolution | null> {
     const attempt = input.assetKind === 'original' ? 'download_original' : 'download_derivative';
-    const link = this.validateAccess(input, attempt);
+    const link = await this.validateAccess(input, attempt);
     if (!link) {
       return null;
     }
@@ -146,7 +148,10 @@ export class InMemorySharingService implements SharingService {
     };
   }
 
-  private validateAccess(input: ResolveShareLinkInput, attempt: ShareAccessEvent['attempt']): ShareLink | null {
+  private async validateAccess(
+    input: ResolveShareLinkInput,
+    attempt: ShareAccessEvent['attempt']
+  ): Promise<ShareLink | null> {
     const link = this.links.find((l) => l.token === input.token);
     if (!link) {
       this.recordEvent({ token: input.token, attempt, link: null, outcome: 'denied_not_found' });
@@ -170,7 +175,8 @@ export class InMemorySharingService implements SharingService {
 
     if (link.policy.passwordProtected) {
       const expected = this.linkPasswords.get(link.id);
-      if (!expected || input.password !== expected) {
+      const matches = input.password && expected ? await verifyPassword(input.password, expected) : false;
+      if (!matches) {
         this.recordEvent({
           token: input.token,
           attempt,

--- a/src/adapters/sharing/passwordHash.test.ts
+++ b/src/adapters/sharing/passwordHash.test.ts
@@ -1,0 +1,18 @@
+import { hashPassword, isVersionedPasswordHash, verifyPassword } from './passwordHash';
+
+describe('passwordHash', () => {
+  it('hashes and verifies password values', async () => {
+    const hash = await hashPassword('open-sesame');
+
+    expect(isVersionedPasswordHash(hash)).toBe(true);
+    await expect(verifyPassword('open-sesame', hash)).resolves.toBe(true);
+    await expect(verifyPassword('wrong-password', hash)).resolves.toBe(false);
+  });
+
+  it('uses unique salts per hash', async () => {
+    const first = await hashPassword('same-password');
+    const second = await hashPassword('same-password');
+
+    expect(first).not.toBe(second);
+  });
+});

--- a/src/adapters/sharing/passwordHash.ts
+++ b/src/adapters/sharing/passwordHash.ts
@@ -1,0 +1,50 @@
+const HASH_VERSION = 'v1';
+const SALT_BYTES = 16;
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function fromHex(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) {
+    throw new Error('Invalid hex string length');
+  }
+
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = Number.parseInt(hex.slice(i, i + 2), 16);
+  }
+
+  return bytes;
+}
+
+async function digestSha256(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return toHex(new Uint8Array(digest));
+}
+
+export async function hashPassword(password: string): Promise<string> {
+  const salt = new Uint8Array(SALT_BYTES);
+  crypto.getRandomValues(salt);
+  const saltHex = toHex(salt);
+  const digestHex = await digestSha256(`${saltHex}:${password}`);
+  return `${HASH_VERSION}:${saltHex}:${digestHex}`;
+}
+
+export async function verifyPassword(password: string, storedHash: string): Promise<boolean> {
+  const [version, saltHex, digestHex] = storedHash.split(':');
+  if (version !== HASH_VERSION || !saltHex || !digestHex) {
+    return false;
+  }
+
+  const normalizedSaltHex = toHex(fromHex(saltHex));
+  const expected = await digestSha256(`${normalizedSaltHex}:${password}`);
+  return expected === digestHex;
+}
+
+export function isVersionedPasswordHash(value: string): boolean {
+  return value.startsWith(`${HASH_VERSION}:`);
+}


### PR DESCRIPTION
## Summary\n- hash share-link passwords instead of storing plaintext in sharing adapters\n- add reusable password hash/verify utility with per-link random salt\n- preserve backward compatibility by allowing verification of existing legacy plaintext records\n\n## Testing\n- npm run lint\n- npm run test\n- npm run build:frontend\n\nCloses #10