### PR TITLE
feat(edits): support exposure stop adjustments

### DIFF
--- a/functions/src/services/edits/EditProcessor.test.ts
+++ b/functions/src/services/edits/EditProcessor.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import sharp from 'sharp';
+import { applyEdits, validateOperations } from './EditProcessor.js';
+
+describe('EditProcessor adjust exposure', () => {
+  it('accepts numeric exposure values in validation', () => {
+    const result = validateOperations([
+      {
+        type: 'adjust',
+        order: 0,
+        params: { exposure: 1 },
+      },
+    ]);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects non-numeric exposure values in validation', () => {
+    const result = validateOperations([
+      {
+        type: 'adjust',
+        order: 0,
+        params: { exposure: 'high' },
+      },
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toContain('exposure');
+  });
+
+  it('applies exposure in stops (+EV brighter, -EV darker)', async () => {
+    const base = await sharp({
+      create: {
+        width: 1,
+        height: 1,
+        channels: 3,
+        background: { r: 100, g: 100, b: 100 },
+      },
+    })
+      .png()
+      .toBuffer();
+
+    const brighter = await applyEdits(base, [
+      {
+        type: 'adjust',
+        order: 0,
+        params: { exposure: 1 },
+      },
+    ]);
+
+    const darker = await applyEdits(base, [
+      {
+        type: 'adjust',
+        order: 0,
+        params: { exposure: -1 },
+      },
+    ]);
+
+    const [baseStats, brightStats, darkStats] = await Promise.all([
+      sharp(base).stats(),
+      sharp(brighter).stats(),
+      sharp(darker).stats(),
+    ]);
+
+    expect(brightStats.channels[0]?.mean ?? 0).toBeGreaterThan(baseStats.channels[0]?.mean ?? 0);
+    expect(darkStats.channels[0]?.mean ?? 0).toBeLessThan(baseStats.channels[0]?.mean ?? 0);
+  });
+});

--- a/functions/src/services/edits/EditProcessor.ts
+++ b/functions/src/services/edits/EditProcessor.ts
@@ -108,23 +108,38 @@ function applyRotate(
 
 /**
  * Adjust operation
- * Params: { brightness?: number, contrast?: number, saturation?: number }
- * Values are multipliers: 1.0 = no change, <1.0 = decrease, >1.0 = increase
+ * Params: { brightness?: number, contrast?: number, saturation?: number, exposure?: number }
+ * brightness/saturation are multipliers: 1.0 = no change, <1.0 = decrease, >1.0 = increase
+ * exposure is in stops (EV): +1 doubles light, -1 halves light
  */
 function applyAdjust(
   pipeline: sharp.Sharp,
   params: Record<string, any>
 ): sharp.Sharp {
-  const { brightness, contrast, saturation } = params;
+  const { brightness, contrast, saturation, exposure } = params;
 
-  logger.debug({ brightness, contrast, saturation }, 'Applying adjustments');
+  logger.debug({ brightness, contrast, saturation, exposure }, 'Applying adjustments');
+
+  const resolvedBrightness =
+    typeof brightness === 'number'
+      ? brightness * (typeof exposure === 'number' ? Math.pow(2, exposure) : 1)
+      : typeof exposure === 'number'
+        ? Math.pow(2, exposure)
+        : undefined;
 
   // Apply modulate for brightness and saturation
-  if (brightness !== undefined || saturation !== undefined) {
-    pipeline = pipeline.modulate({
-      brightness: typeof brightness === 'number' ? brightness : undefined,
-      saturation: typeof saturation === 'number' ? saturation : undefined,
-    });
+  if (resolvedBrightness !== undefined || saturation !== undefined) {
+    const modulateParams: { brightness?: number; saturation?: number } = {};
+
+    if (resolvedBrightness !== undefined) {
+      modulateParams.brightness = resolvedBrightness;
+    }
+
+    if (typeof saturation === 'number') {
+      modulateParams.saturation = saturation;
+    }
+
+    pipeline = pipeline.modulate(modulateParams);
   }
 
   // Apply linear for contrast
@@ -226,13 +241,14 @@ export function validateOperations(operations: EditOperation[]): {
         break;
 
       case 'adjust':
-        const { brightness, contrast, saturation } = op.params;
+        const { brightness, contrast, saturation, exposure } = op.params;
         if (
           brightness !== undefined && typeof brightness !== 'number' ||
           contrast !== undefined && typeof contrast !== 'number' ||
-          saturation !== undefined && typeof saturation !== 'number'
+          saturation !== undefined && typeof saturation !== 'number' ||
+          exposure !== undefined && typeof exposure !== 'number'
         ) {
-          errors.push('Adjust requires numeric brightness, contrast, or saturation');
+          errors.push('Adjust requires numeric brightness, contrast, saturation, or exposure');
         }
         break;
 

--- a/functions/src/services/edits/pluginRegistry.ts
+++ b/functions/src/services/edits/pluginRegistry.ts
@@ -35,10 +35,10 @@ export const EDIT_PLUGIN_MANIFEST: EditPluginManifest[] = [
   {
     id: 'adjust',
     displayName: 'Adjust',
-    version: '1.0.0',
+    version: '1.1.0',
     enabledByDefault: true,
     nonDestructive: true,
-    params: ['brightness', 'contrast', 'saturation'],
+    params: ['brightness', 'contrast', 'saturation', 'exposure'],
   },
   {
     id: 'filter',


### PR DESCRIPTION
## Summary
- add `exposure` (EV stops) to the adjust plugin contract
- apply exposure non-destructively via brightness multiplier (`2^exposure`)
- extend adjustment validation and add coverage for +EV/-EV behavior

## Why
Issue #12 calls for initial deterministic adjustment plugins. This increment adds explicit exposure support with tests while preserving existing brightness/contrast/saturation behavior.

## Testing
- npm test

Refs #12
