### PR TITLE
feat(edits): allow-list adjust capabilities via env controls

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -112,6 +112,9 @@ firebase deploy --only functions
 - `STORAGE_MODE`: Storage backend ('local' or 'firebase')
 - `SIGNING_KEY_EXPIRATION`: Key lifetime in seconds (default: 3600 = 1 hour)
 - `SIGNED_URL_EXPIRATION`: URL lifetime in seconds (default: 600 = 10 minutes)
+- `AURAPIX_EDIT_ENABLED_PLUGINS`: Optional comma-separated allow-list of edit plugins (`crop,rotate,adjust,filter`)
+- `AURAPIX_EDIT_DISABLED_PLUGINS`: Optional comma-separated deny-list of edit plugins (applied after allow-list)
+- `AURAPIX_EDIT_ADJUST_CAPABILITIES`: Optional comma-separated allow-list for adjust params (`brightness,contrast,saturation,exposure`)
 
 See `.env.example` for complete list.
 

--- a/functions/src/services/edits/EditProcessor.ts
+++ b/functions/src/services/edits/EditProcessor.ts
@@ -1,7 +1,7 @@
 import sharp from 'sharp';
 import type { EditOperation } from '../../models/Photo.js';
 import { logger } from '../../utils/logger.js';
-import { isPluginEnabled } from './pluginRegistry.js';
+import { isAdjustCapabilityEnabled, isPluginEnabled } from './pluginRegistry.js';
 
 /**
  * Apply a sequence of edit operations to an image buffer
@@ -240,7 +240,7 @@ export function validateOperations(operations: EditOperation[]): {
         }
         break;
 
-      case 'adjust':
+      case 'adjust': {
         const { brightness, contrast, saturation, exposure } = op.params;
         if (
           brightness !== undefined && typeof brightness !== 'number' ||
@@ -250,7 +250,21 @@ export function validateOperations(operations: EditOperation[]): {
         ) {
           errors.push('Adjust requires numeric brightness, contrast, saturation, or exposure');
         }
+
+        if (brightness !== undefined && !isAdjustCapabilityEnabled('brightness')) {
+          errors.push('Adjust brightness is currently disabled by configuration');
+        }
+        if (contrast !== undefined && !isAdjustCapabilityEnabled('contrast')) {
+          errors.push('Adjust contrast is currently disabled by configuration');
+        }
+        if (saturation !== undefined && !isAdjustCapabilityEnabled('saturation')) {
+          errors.push('Adjust saturation is currently disabled by configuration');
+        }
+        if (exposure !== undefined && !isAdjustCapabilityEnabled('exposure')) {
+          errors.push('Adjust exposure is currently disabled by configuration');
+        }
         break;
+      }
 
       case 'filter':
         if (!op.params.filterName || typeof op.params.filterName !== 'string') {

--- a/functions/src/services/edits/pluginRegistry.test.ts
+++ b/functions/src/services/edits/pluginRegistry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveEnabledPluginIdsForTest } from './pluginRegistry.js';
+import { resolveAdjustCapabilitiesForTest, resolveEnabledPluginIdsForTest } from './pluginRegistry.js';
 
 describe('pluginRegistry env controls', () => {
   it('uses defaults when no env overrides are set', () => {
@@ -31,5 +31,29 @@ describe('pluginRegistry env controls', () => {
     });
 
     expect(enabled).toEqual(new Set(['crop', 'adjust']));
+  });
+});
+
+describe('adjust capability env controls', () => {
+  it('enables all adjust params by default', () => {
+    const enabled = resolveAdjustCapabilitiesForTest({});
+
+    expect(enabled).toEqual(new Set(['brightness', 'contrast', 'saturation', 'exposure']));
+  });
+
+  it('supports allow-list mode via AURAPIX_EDIT_ADJUST_CAPABILITIES', () => {
+    const enabled = resolveAdjustCapabilitiesForTest({
+      AURAPIX_EDIT_ADJUST_CAPABILITIES: 'brightness,exposure',
+    });
+
+    expect(enabled).toEqual(new Set(['brightness', 'exposure']));
+  });
+
+  it('falls back to safe defaults when env value is invalid', () => {
+    const enabled = resolveAdjustCapabilitiesForTest({
+      AURAPIX_EDIT_ADJUST_CAPABILITIES: 'not-a-real-capability',
+    });
+
+    expect(enabled).toEqual(new Set(['brightness', 'contrast', 'saturation', 'exposure']));
   });
 });

--- a/functions/src/services/edits/pluginRegistry.ts
+++ b/functions/src/services/edits/pluginRegistry.ts
@@ -1,4 +1,5 @@
 export type EditOperationType = 'crop' | 'rotate' | 'adjust' | 'filter';
+export type AdjustCapability = 'brightness' | 'contrast' | 'saturation' | 'exposure';
 
 export interface EditPluginManifest {
   id: EditOperationType;
@@ -35,7 +36,7 @@ export const EDIT_PLUGIN_MANIFEST: EditPluginManifest[] = [
   {
     id: 'adjust',
     displayName: 'Adjust',
-    version: '1.1.0',
+    version: '1.2.0',
     enabledByDefault: true,
     nonDestructive: true,
     params: ['brightness', 'contrast', 'saturation', 'exposure'],
@@ -51,6 +52,13 @@ export const EDIT_PLUGIN_MANIFEST: EditPluginManifest[] = [
 ];
 
 const ALL_PLUGIN_IDS = new Set(EDIT_PLUGIN_MANIFEST.map((plugin) => plugin.id));
+const ALL_ADJUST_CAPABILITIES: AdjustCapability[] = [
+  'brightness',
+  'contrast',
+  'saturation',
+  'exposure',
+];
+const ALL_ADJUST_CAPABILITY_SET = new Set(ALL_ADJUST_CAPABILITIES);
 
 function parsePluginList(value: string | undefined): Set<EditOperationType> {
   if (!value) return new Set();
@@ -61,6 +69,23 @@ function parsePluginList(value: string | undefined): Set<EditOperationType> {
       .map((token) => token.trim().toLowerCase())
       .filter((token): token is EditOperationType => ALL_PLUGIN_IDS.has(token as EditOperationType))
   );
+}
+
+function parseAdjustCapabilityList(value: string | undefined): Set<AdjustCapability> {
+  if (!value) return new Set(ALL_ADJUST_CAPABILITIES);
+
+  const parsed = value
+    .split(',')
+    .map((token) => token.trim().toLowerCase())
+    .filter((token): token is AdjustCapability =>
+      ALL_ADJUST_CAPABILITY_SET.has(token as AdjustCapability)
+    );
+
+  if (parsed.length === 0) {
+    return new Set(ALL_ADJUST_CAPABILITIES);
+  }
+
+  return new Set(parsed);
 }
 
 function buildEnabledPluginIds(env: NodeJS.ProcessEnv = process.env): Set<EditOperationType> {
@@ -82,10 +107,17 @@ function buildEnabledPluginIds(env: NodeJS.ProcessEnv = process.env): Set<EditOp
 }
 
 const ENABLED_PLUGIN_IDS = buildEnabledPluginIds();
+const ENABLED_ADJUST_CAPABILITIES = parseAdjustCapabilityList(
+  process.env.AURAPIX_EDIT_ADJUST_CAPABILITIES
+);
 
 export function listPlugins(): RuntimeEditPluginManifest[] {
   return EDIT_PLUGIN_MANIFEST.map((plugin) => ({
     ...plugin,
+    params:
+      plugin.id === 'adjust'
+        ? ALL_ADJUST_CAPABILITIES.filter((capability) => ENABLED_ADJUST_CAPABILITIES.has(capability))
+        : plugin.params,
     enabled: ENABLED_PLUGIN_IDS.has(plugin.id),
   }));
 }
@@ -94,8 +126,18 @@ export function isPluginEnabled(type: string): type is EditOperationType {
   return ENABLED_PLUGIN_IDS.has(type as EditOperationType);
 }
 
+export function isAdjustCapabilityEnabled(capability: AdjustCapability): boolean {
+  return ENABLED_ADJUST_CAPABILITIES.has(capability);
+}
+
 export function resolveEnabledPluginIdsForTest(
   env: NodeJS.ProcessEnv = process.env
 ): Set<EditOperationType> {
   return buildEnabledPluginIds(env);
+}
+
+export function resolveAdjustCapabilitiesForTest(
+  env: NodeJS.ProcessEnv = process.env
+): Set<AdjustCapability> {
+  return parseAdjustCapabilityList(env.AURAPIX_EDIT_ADJUST_CAPABILITIES);
 }


### PR DESCRIPTION
## Summary
- add `AURAPIX_EDIT_ADJUST_CAPABILITIES` to selectively enable adjust params (brightness/contrast/saturation/exposure)
- expose only enabled adjust params in `/edits/plugins` manifest response
- reject edit requests that use disabled adjust params with explicit validation errors
- add plugin registry tests for capability controls and document env vars in backend README

## Why
This is a narrow Phase 4 increment for issue #12 that adds safer rollout controls for editing behavior while preserving default backward compatibility.

## Testing
- `npm test -- --run src/services/edits/pluginRegistry.test.ts src/services/edits/EditProcessor.test.ts` (from `functions/`)

Closes #12
