### PR TITLE
feat(host-integrations): add upload policy webhook gate

### DIFF
--- a/functions/.env.example
+++ b/functions/.env.example
@@ -42,6 +42,11 @@ UPLOAD_RATE_LIMIT_MAX_REQUESTS=30
 APP_CHECK_ENFORCE_UPLOADS=false
 APP_CHECK_BYPASS_TOKENS=
 
+# Optional host integration policy hook for upload allow/deny decisions
+# If unset, uploads are allowed by default (backward-compatible behavior)
+# HOST_UPLOAD_POLICY_WEBHOOK_URL=https://host.example/hooks/upload-policy
+HOST_UPLOAD_POLICY_TIMEOUT_MS=1500
+
 # Edit plugin controls (optional, comma-separated plugin IDs: crop,rotate,adjust,filter)
 # If AURAPIX_EDIT_ENABLED_PLUGINS is set, only listed plugins are enabled.
 # AURAPIX_EDIT_DISABLED_PLUGINS always wins and removes listed plugins.

--- a/functions/src/config/index.ts
+++ b/functions/src/config/index.ts
@@ -60,6 +60,10 @@ export const securityConfig = {
     enforceUploads: process.env.APP_CHECK_ENFORCE_UPLOADS === 'true',
     bypassTokens: process.env.APP_CHECK_BYPASS_TOKENS || '',
   },
+  hostPolicy: {
+    uploadWebhookUrl: process.env.HOST_UPLOAD_POLICY_WEBHOOK_URL,
+    timeoutMs: parseInt(process.env.HOST_UPLOAD_POLICY_TIMEOUT_MS || '1500', 10),
+  },
 } as const;
 
 // Signing configuration for HMAC-signed URLs

--- a/functions/src/handlers/images/upload.ts
+++ b/functions/src/handlers/images/upload.ts
@@ -15,8 +15,10 @@ import {
   uploadFingerprintMatches,
 } from './uploadIdempotency.js';
 import { generatePhotoPaths } from '../../config/storage-paths.js';
+import { securityConfig } from '../../config/index.js';
 import { createPhotoDocument } from '../../models/Photo.js';
 import type { PhotoMetadata } from '../../models/Photo.js';
+import { evaluateUploadPolicy } from '../../services/host/uploadPolicy.js';
 
 // Configure multer for memory storage
 const upload = multer({
@@ -102,6 +104,28 @@ export async function handleUpload(
 
   // TODO: Verify user has access to this library
   const userId = req.user?.uid || 'anonymous';
+
+  const policyDecision = await evaluateUploadPolicy(
+    {
+      userId,
+      libraryId,
+      sizeBytes: file.size,
+      mimeType: file.mimetype,
+      originalName: file.originalname,
+    },
+    {
+      webhookUrl: securityConfig.hostPolicy.uploadWebhookUrl,
+      timeoutMs: securityConfig.hostPolicy.timeoutMs,
+    }
+  );
+
+  if (!policyDecision.allow) {
+    throw new AppError(
+      403,
+      'UPLOAD_BLOCKED_BY_HOST_POLICY',
+      policyDecision.reason || 'Upload denied by host integration policy'
+    );
+  }
 
   let idempotencyKey: string | null;
   try {

--- a/functions/src/services/host/uploadPolicy.test.ts
+++ b/functions/src/services/host/uploadPolicy.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { evaluateUploadPolicy } from './uploadPolicy.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('evaluateUploadPolicy', () => {
+  const payload = {
+    userId: 'u1',
+    libraryId: 'lib1',
+    sizeBytes: 1024,
+    mimeType: 'image/jpeg',
+    originalName: 'photo.jpg',
+  };
+
+  it('allows upload when host webhook is disabled', async () => {
+    const result = await evaluateUploadPolicy(payload, { timeoutMs: 100 });
+    expect(result.allow).toBe(true);
+    expect(result.reason).toBe('host-policy-disabled');
+  });
+
+  it('denies upload when host webhook explicitly denies', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ allow: false, reason: 'quota exceeded' }),
+      })
+    );
+
+    const result = await evaluateUploadPolicy(payload, {
+      webhookUrl: 'https://host.example/hooks/upload-policy',
+      timeoutMs: 100,
+    });
+
+    expect(result).toEqual({ allow: false, reason: 'quota exceeded' });
+  });
+
+  it('fails open when webhook is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+
+    const result = await evaluateUploadPolicy(payload, {
+      webhookUrl: 'https://host.example/hooks/upload-policy',
+      timeoutMs: 100,
+    });
+
+    expect(result.allow).toBe(true);
+    expect(result.reason).toBe('host-policy-webhook-unavailable');
+  });
+});

--- a/functions/src/services/host/uploadPolicy.ts
+++ b/functions/src/services/host/uploadPolicy.ts
@@ -1,0 +1,75 @@
+import { logger } from '../../utils/logger.js';
+
+export interface UploadPolicyPayload {
+  userId: string;
+  libraryId: string;
+  sizeBytes: number;
+  mimeType: string;
+  originalName: string;
+}
+
+export interface UploadPolicyDecision {
+  allow: boolean;
+  reason?: string;
+}
+
+interface UploadPolicyConfig {
+  webhookUrl?: string;
+  timeoutMs: number;
+}
+
+export async function evaluateUploadPolicy(
+  payload: UploadPolicyPayload,
+  config: UploadPolicyConfig
+): Promise<UploadPolicyDecision> {
+  if (!config.webhookUrl) {
+    return { allow: true, reason: 'host-policy-disabled' };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
+
+  try {
+    const response = await fetch(config.webhookUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      logger.warn(
+        {
+          status: response.status,
+          webhookUrl: config.webhookUrl,
+        },
+        'Host upload policy webhook returned non-2xx; allowing upload for compatibility'
+      );
+      return { allow: true, reason: 'host-policy-webhook-non-2xx' };
+    }
+
+    const data = (await response.json()) as Partial<UploadPolicyDecision>;
+    if (typeof data.allow !== 'boolean') {
+      logger.warn(
+        { webhookUrl: config.webhookUrl, data },
+        'Host upload policy webhook returned invalid payload; allowing upload for compatibility'
+      );
+      return { allow: true, reason: 'host-policy-webhook-invalid-payload' };
+    }
+
+    return {
+      allow: data.allow,
+      reason: data.reason,
+    };
+  } catch (error) {
+    logger.warn(
+      { err: error, webhookUrl: config.webhookUrl },
+      'Host upload policy webhook unavailable; allowing upload for compatibility'
+    );
+    return { allow: true, reason: 'host-policy-webhook-unavailable' };
+  } finally {
+    clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
## Summary
Adds an optional host integration webhook that can allow/deny uploads before persistence.

## What changed
- Added `evaluateUploadPolicy` service (`functions/src/services/host/uploadPolicy.ts`)
- Integrated policy check into upload flow (`functions/src/handlers/images/upload.ts`)
- Added config/env controls:
  - `HOST_UPLOAD_POLICY_WEBHOOK_URL`
  - `HOST_UPLOAD_POLICY_TIMEOUT_MS`
- Added tests for allow/deny/fail-open behavior

## Safety / compatibility
- Backward-compatible by default: if webhook is unset/unavailable/invalid/non-2xx, uploads are allowed.
- Denial behavior is explicit only when webhook returns `{ "allow": false }`.

## Testing
- `npm test -- --run src/services/host/uploadPolicy.test.ts` (functions)

Fixes #15
