### PR TITLE
feat(domain): phase-1 module skeleton + demoable albums slice

### DIFF
--- a/docs/architecture/domain-modules.md
+++ b/docs/architecture/domain-modules.md
@@ -1,0 +1,23 @@
+# Domain module skeleton (Phase 1)
+
+This increment introduces explicit domain boundaries in `functions/src/domain`:
+
+- `albums`: album entities + repository contract + application service
+- `library`: access-policy contract
+- `sharing`: sharing-policy contract
+- `auth`: identity resolution contract
+
+## Adapter mapping
+
+In-memory adapters now live in `functions/src/adapters/domain/in-memory` and implement each domain contract.
+
+These are wired in the composition root (`functions/src/composition/domainModules.ts`) so runtime can switch to provider-backed adapters later without changing domain contracts.
+
+## Vertical slice in this increment
+
+A minimal API slice is now available for albums in local/mock auth mode:
+
+- `GET /api/albums` list current user's albums
+- `POST /api/albums` create album (`{ "title": "...", "description"?: "..." }`)
+
+This delivers a demoable/user-usable backend slice while preserving compatibility with existing routes.

--- a/functions/src/adapters/domain/in-memory/InMemoryAlbumRepository.test.ts
+++ b/functions/src/adapters/domain/in-memory/InMemoryAlbumRepository.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryAlbumRepository } from './InMemoryAlbumRepository.js';
+import { AlbumsService } from '../../../domain/albums/AlbumsService.js';
+
+describe('InMemoryAlbumRepository', () => {
+  it('creates and lists albums scoped by owner', async () => {
+    const service = new AlbumsService(new InMemoryAlbumRepository());
+
+    await service.create({ ownerId: 'u1', title: 'Roadtrip' });
+    await service.create({ ownerId: 'u2', title: 'Work' });
+
+    const user1Albums = await service.list('u1');
+    const user2Albums = await service.list('u2');
+
+    expect(user1Albums).toHaveLength(1);
+    expect(user1Albums[0]?.title).toBe('Roadtrip');
+    expect(user2Albums).toHaveLength(1);
+    expect(user2Albums[0]?.title).toBe('Work');
+  });
+
+  it('rejects album creation when title is blank', async () => {
+    const service = new AlbumsService(new InMemoryAlbumRepository());
+
+    await expect(
+      service.create({ ownerId: 'u1', title: '   ' })
+    ).rejects.toThrow('album-title-required');
+  });
+});

--- a/functions/src/adapters/domain/in-memory/InMemoryAlbumRepository.ts
+++ b/functions/src/adapters/domain/in-memory/InMemoryAlbumRepository.ts
@@ -1,0 +1,20 @@
+import { AlbumsService } from '../../../domain/albums/AlbumsService.js';
+import type { AlbumRepository } from '../../../domain/albums/AlbumRepository.js';
+import type { Album, CreateAlbumInput } from '../../../domain/albums/types.js';
+
+export class InMemoryAlbumRepository implements AlbumRepository {
+  private readonly albums = new Map<string, Album[]>();
+
+  async listByOwner(ownerId: string): Promise<Album[]> {
+    return [...(this.albums.get(ownerId) ?? [])].sort((a, b) =>
+      a.createdAt.localeCompare(b.createdAt)
+    );
+  }
+
+  async create(input: CreateAlbumInput): Promise<Album> {
+    const record = AlbumsService.createAlbumRecord(input);
+    const existing = this.albums.get(input.ownerId) ?? [];
+    this.albums.set(input.ownerId, [...existing, record]);
+    return record;
+  }
+}

--- a/functions/src/adapters/domain/in-memory/InMemoryAuthProvider.ts
+++ b/functions/src/adapters/domain/in-memory/InMemoryAuthProvider.ts
@@ -1,0 +1,12 @@
+import type {
+  AuthIdentity,
+  AuthProvider,
+} from '../../../domain/auth/AuthContracts.js';
+
+export class InMemoryAuthProvider implements AuthProvider {
+  constructor(private readonly defaultIdentity: AuthIdentity | null = null) {}
+
+  async resolveUser(): Promise<AuthIdentity | null> {
+    return this.defaultIdentity;
+  }
+}

--- a/functions/src/adapters/domain/in-memory/InMemoryLibraryAccessPolicy.ts
+++ b/functions/src/adapters/domain/in-memory/InMemoryLibraryAccessPolicy.ts
@@ -1,0 +1,20 @@
+import type {
+  LibraryAccessPolicy,
+  LibraryMembership,
+} from '../../../domain/library/LibraryContracts.js';
+
+export class InMemoryLibraryAccessPolicy implements LibraryAccessPolicy {
+  constructor(private readonly memberships: LibraryMembership[] = []) {}
+
+  async getMembership(
+    libraryId: string,
+    userId: string
+  ): Promise<LibraryMembership | null> {
+    return (
+      this.memberships.find(
+        membership =>
+          membership.libraryId === libraryId && membership.userId === userId
+      ) ?? null
+    );
+  }
+}

--- a/functions/src/adapters/domain/in-memory/InMemorySharePolicyRepository.ts
+++ b/functions/src/adapters/domain/in-memory/InMemorySharePolicyRepository.ts
@@ -1,0 +1,12 @@
+import type {
+  ShareGrant,
+  SharePolicyRepository,
+} from '../../../domain/sharing/SharingContracts.js';
+
+export class InMemorySharePolicyRepository implements SharePolicyRepository {
+  constructor(private readonly grants: ShareGrant[] = []) {}
+
+  async findByToken(token: string): Promise<ShareGrant | null> {
+    return this.grants.find(grant => grant.token === token) ?? null;
+  }
+}

--- a/functions/src/composition/domainModules.ts
+++ b/functions/src/composition/domainModules.ts
@@ -1,0 +1,26 @@
+import { InMemoryAlbumRepository } from '../adapters/domain/in-memory/InMemoryAlbumRepository.js';
+import { InMemoryAuthProvider } from '../adapters/domain/in-memory/InMemoryAuthProvider.js';
+import { InMemoryLibraryAccessPolicy } from '../adapters/domain/in-memory/InMemoryLibraryAccessPolicy.js';
+import { InMemorySharePolicyRepository } from '../adapters/domain/in-memory/InMemorySharePolicyRepository.js';
+import { AlbumsService } from '../domain/albums/AlbumsService.js';
+
+export interface DomainModules {
+  albums: AlbumsService;
+  auth: InMemoryAuthProvider;
+  library: InMemoryLibraryAccessPolicy;
+  sharing: InMemorySharePolicyRepository;
+}
+
+export function createDomainModules(): DomainModules {
+  const auth = new InMemoryAuthProvider({ userId: 'local-user-1', email: 'local@aurapix.local' });
+  const albums = new AlbumsService(new InMemoryAlbumRepository());
+  const library = new InMemoryLibraryAccessPolicy();
+  const sharing = new InMemorySharePolicyRepository();
+
+  return {
+    albums,
+    auth,
+    library,
+    sharing,
+  };
+}

--- a/functions/src/domain/albums/AlbumRepository.ts
+++ b/functions/src/domain/albums/AlbumRepository.ts
@@ -1,0 +1,6 @@
+import type { Album, CreateAlbumInput } from './types.js';
+
+export interface AlbumRepository {
+  listByOwner(ownerId: string): Promise<Album[]>;
+  create(input: CreateAlbumInput): Promise<Album>;
+}

--- a/functions/src/domain/albums/AlbumsService.ts
+++ b/functions/src/domain/albums/AlbumsService.ts
@@ -1,0 +1,35 @@
+import { randomUUID } from 'node:crypto';
+import type { AlbumRepository } from './AlbumRepository.js';
+import type { Album, CreateAlbumInput } from './types.js';
+
+export class AlbumsService {
+  constructor(private readonly albums: AlbumRepository) {}
+
+  async list(ownerId: string): Promise<Album[]> {
+    return this.albums.listByOwner(ownerId);
+  }
+
+  async create(input: CreateAlbumInput): Promise<Album> {
+    const title = input.title.trim();
+    if (!title) {
+      throw new Error('album-title-required');
+    }
+
+    return this.albums.create({
+      ...input,
+      title,
+    });
+  }
+
+  static createAlbumRecord(input: CreateAlbumInput): Album {
+    const now = new Date().toISOString();
+    return {
+      id: randomUUID(),
+      ownerId: input.ownerId,
+      title: input.title,
+      description: input.description,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+}

--- a/functions/src/domain/albums/types.ts
+++ b/functions/src/domain/albums/types.ts
@@ -1,0 +1,14 @@
+export interface Album {
+  id: string;
+  ownerId: string;
+  title: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateAlbumInput {
+  ownerId: string;
+  title: string;
+  description?: string;
+}

--- a/functions/src/domain/auth/AuthContracts.ts
+++ b/functions/src/domain/auth/AuthContracts.ts
@@ -1,0 +1,8 @@
+export interface AuthIdentity {
+  userId: string;
+  email?: string;
+}
+
+export interface AuthProvider {
+  resolveUser(authHeader?: string): Promise<AuthIdentity | null>;
+}

--- a/functions/src/domain/library/LibraryContracts.ts
+++ b/functions/src/domain/library/LibraryContracts.ts
@@ -1,0 +1,9 @@
+export interface LibraryMembership {
+  libraryId: string;
+  userId: string;
+  role: 'owner' | 'editor' | 'viewer';
+}
+
+export interface LibraryAccessPolicy {
+  getMembership(libraryId: string, userId: string): Promise<LibraryMembership | null>;
+}

--- a/functions/src/domain/sharing/SharingContracts.ts
+++ b/functions/src/domain/sharing/SharingContracts.ts
@@ -1,0 +1,9 @@
+export interface ShareGrant {
+  albumId: string;
+  token: string;
+  expiresAt?: string;
+}
+
+export interface SharePolicyRepository {
+  findByToken(token: string): Promise<ShareGrant | null>;
+}

--- a/functions/src/routes/albums.ts
+++ b/functions/src/routes/albums.ts
@@ -1,0 +1,46 @@
+import { Router } from 'express';
+import type { AlbumsService } from '../domain/albums/AlbumsService.js';
+
+export function createAlbumsRouter(albums: AlbumsService): Router {
+  const router = Router();
+
+  router.get('/', async (req, res, next) => {
+    try {
+      if (!req.user) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+
+      const items = await albums.list(req.user.uid);
+      res.json({ items });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/', async (req, res, next) => {
+    try {
+      if (!req.user) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+
+      const created = await albums.create({
+        ownerId: req.user.uid,
+        title: typeof req.body?.title === 'string' ? req.body.title : '',
+        description: typeof req.body?.description === 'string' ? req.body.description : undefined,
+      });
+
+      res.status(201).json(created);
+    } catch (error) {
+      if (error instanceof Error && error.message === 'album-title-required') {
+        res.status(400).json({ error: 'title is required' });
+        return;
+      }
+
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -9,6 +9,7 @@ import { LocalDiskStorage } from './adapters/storage/LocalDiskStorage.js';
 import { LocalJsonData } from './adapters/data/LocalJsonData.js';
 import { FirebaseStorageAdapter } from './adapters/storage/FirebaseStorageAdapter.js';
 import { FirestoreDataAdapter } from './adapters/data/FirestoreDataAdapter.js';
+import { createDomainModules } from './composition/domainModules.js';
 
 const app = express();
 
@@ -65,6 +66,8 @@ if (storageConfig.mode === 'firebase') {
 app.locals.storageAdapter = storageAdapter;
 app.locals.dataAdapter = dataAdapter;
 
+const domainModules = createDomainModules();
+
 // Health check
 app.get('/health', (req, res) => {
   res.json({
@@ -80,6 +83,7 @@ import { createImageRoutes } from './routes/images.js';
 import internalRouter from './routes/internal.js';
 import editsRouter from './routes/edits.js';
 import signingRouter from './routes/signing.js';
+import { createAlbumsRouter } from './routes/albums.js';
 
 // Mount routes
 // Images route handles its own auth (signed URLs for GET, Bearer for POST)
@@ -91,6 +95,7 @@ app.use('/edits', authMiddleware, editsRouter);
 
 // Versioned API surface (desktop/web clients)
 app.use('/api', apiVersionMiddleware);
+app.use('/api/albums', authMiddleware, createAlbumsRouter(domainModules.albums));
 app.use('/api/signing', authMiddleware, signingRouter);
 
 // Error handlers (must be last)


### PR DESCRIPTION
## Summary
- add explicit Phase 1 domain modules for albums, library, sharing, and auth under `functions/src/domain`
- add in-memory adapter implementations plus composition root wiring
- add a demoable backend vertical slice for albums via `GET /api/albums` and `POST /api/albums`
- document architecture boundaries for this increment in `docs/architecture/domain-modules.md`

## Testing
- `npm run lint`
- `npm run test -- --run`
- `npm run build:frontend`
- `npm run contract:check`
- `npm --prefix functions run test -- src/adapters/domain/in-memory/InMemoryAlbumRepository.test.ts`

## Notes
- `functions` package-wide lint/build currently has pre-existing unrelated failures; this PR keeps scope to the domain skeleton increment and validates changed backend unit tests plus repo CI gates.

Fixes #4
