### PR TITLE
feat(compliance): add v1 export request API behind feature flag

### DIFF
--- a/contracts/openapi/compliance.openapi.json
+++ b/contracts/openapi/compliance.openapi.json
@@ -1,0 +1,108 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AuraPix Compliance API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/v1/compliance/exports": {
+      "post": {
+        "summary": "Create a data export request for the authenticated user",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "format": {
+                    "type": "string",
+                    "enum": ["json"]
+                  },
+                  "includeAssets": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Export request queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportRequestEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature disabled"
+          }
+        }
+      }
+    },
+    "/api/v1/compliance/exports/{id}": {
+      "get": {
+        "summary": "Get export request status",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current export request status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportRequestEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ExportRequest": {
+        "type": "object",
+        "required": ["id", "userId", "status", "format", "includeAssets", "createdAt", "updatedAt"],
+        "properties": {
+          "id": { "type": "string" },
+          "userId": { "type": "string" },
+          "status": {
+            "type": "string",
+            "enum": ["pending", "processing", "completed", "failed", "cancelled"]
+          },
+          "format": { "type": "string", "enum": ["json"] },
+          "includeAssets": { "type": "boolean" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "ExportRequestEnvelope": {
+        "type": "object",
+        "required": ["exportRequest"],
+        "properties": {
+          "exportRequest": {
+            "$ref": "#/components/schemas/ExportRequest"
+          }
+        }
+      }
+    }
+  }
+}

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -36,6 +36,9 @@ WEBP_QUALITY=80
 # Authentication Mode: 'mock' or 'firebase'
 AUTH_MODE=mock
 
+# Backend feature flags (disabled by default for backward compatibility)
+FEATURE_COMPLIANCE_EXPORTS_ENABLED=false
+
 # Security
 UPLOAD_RATE_LIMIT_WINDOW_MS=60000
 UPLOAD_RATE_LIMIT_MAX_REQUESTS=30

--- a/functions/src/config/index.ts
+++ b/functions/src/config/index.ts
@@ -51,6 +51,10 @@ export const authConfig = {
   mode: (process.env.AUTH_MODE || 'mock') as 'mock' | 'firebase',
 } as const;
 
+export const featureConfig = {
+  complianceExportsEnabled: process.env.FEATURE_COMPLIANCE_EXPORTS_ENABLED === 'true',
+} as const;
+
 export const securityConfig = {
   uploadRateLimit: {
     windowMs: parseInt(process.env.UPLOAD_RATE_LIMIT_WINDOW_MS || '60000', 10),

--- a/functions/src/routes/complianceV1.ts
+++ b/functions/src/routes/complianceV1.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from 'node:crypto';
+import { Router } from 'express';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import { featureConfig } from '../config/index.js';
+
+export type ExportRequestStatus = 'pending' | 'processing' | 'completed' | 'failed' | 'cancelled';
+
+export interface ExportRequestRecord {
+  id: string;
+  userId: string;
+  status: ExportRequestStatus;
+  format: 'json';
+  includeAssets: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ApiErrorPayload {
+  error: {
+    code: string;
+    message: string;
+    requestId: string;
+    details: Record<string, unknown> | null;
+  };
+}
+
+function sendError(
+  res: { status: (code: number) => { json: (payload: ApiErrorPayload) => void } },
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> | null = null
+): void {
+  res.status(status).json({
+    error: {
+      code,
+      message,
+      requestId: randomUUID(),
+      details,
+    },
+  });
+}
+
+function toBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    if (value.toLowerCase() === 'true') return true;
+    if (value.toLowerCase() === 'false') return false;
+  }
+  return fallback;
+}
+
+export function createComplianceV1Router(dataAdapter: DataAdapter): Router {
+  const router = Router();
+
+  router.post('/exports', async (req, res, next) => {
+    try {
+      if (!featureConfig.complianceExportsEnabled) {
+        sendError(res, 404, 'FEATURE_DISABLED', 'Compliance exports API is disabled');
+        return;
+      }
+
+      if (!req.user) {
+        sendError(res, 401, 'AUTH_REQUIRED', 'Authentication required');
+        return;
+      }
+
+      const format = req.body?.format;
+      if (format !== undefined && format !== 'json') {
+        sendError(res, 400, 'INVALID_BODY', 'format must be "json"');
+        return;
+      }
+
+      const exportRequestId = randomUUID();
+      const now = new Date().toISOString();
+      const includeAssets = toBoolean(req.body?.includeAssets, false);
+
+      const exportRequest: ExportRequestRecord = {
+        id: exportRequestId,
+        userId: req.user.uid,
+        status: 'pending',
+        format: 'json',
+        includeAssets,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      await dataAdapter.storeData<ExportRequestRecord>('complianceExportRequests', exportRequestId, exportRequest);
+
+      await dataAdapter.storeData('auditEvents', randomUUID(), {
+        eventType: 'compliance.export.requested',
+        actorId: req.user.uid,
+        targetId: exportRequestId,
+        createdAt: now,
+        metadata: {
+          format: exportRequest.format,
+          includeAssets: exportRequest.includeAssets,
+        },
+      });
+
+      res.status(201).json({ exportRequest });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/exports/:id', async (req, res, next) => {
+    try {
+      if (!featureConfig.complianceExportsEnabled) {
+        sendError(res, 404, 'FEATURE_DISABLED', 'Compliance exports API is disabled');
+        return;
+      }
+
+      if (!req.user) {
+        sendError(res, 401, 'AUTH_REQUIRED', 'Authentication required');
+        return;
+      }
+
+      const exportRequest = await dataAdapter.fetchData<ExportRequestRecord>(
+        'complianceExportRequests',
+        req.params.id
+      );
+
+      if (!exportRequest || exportRequest.userId !== req.user.uid) {
+        sendError(res, 404, 'NOT_FOUND', 'Export request not found');
+        return;
+      }
+
+      res.json({ exportRequest });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -85,6 +85,7 @@ import editsRouter from './routes/edits.js';
 import signingRouter from './routes/signing.js';
 import { createAlbumsRouter } from './routes/albums.js';
 import { createAlbumsV1Router } from './routes/albumsV1.js';
+import { createComplianceV1Router } from './routes/complianceV1.js';
 
 // Mount routes
 // Images route handles its own auth (signed URLs for GET, Bearer for POST)
@@ -98,6 +99,7 @@ app.use('/edits', authMiddleware, editsRouter);
 app.use('/api', apiVersionMiddleware);
 app.use('/api/albums', authMiddleware, createAlbumsRouter(domainModules.albums));
 app.use('/api/v1/albums', authMiddleware, createAlbumsV1Router(domainModules.albums));
+app.use('/api/v1/compliance', authMiddleware, createComplianceV1Router(dataAdapter));
 app.use('/api/signing', authMiddleware, signingRouter);
 
 // Error handlers (must be last)


### PR DESCRIPTION
## Summary
- add `/api/v1/compliance/exports` POST endpoint to queue a user export request
- add `/api/v1/compliance/exports/:id` GET endpoint for requester-owned status lookup
- persist `complianceExportRequests` records and emit `auditEvents` entries for traceability
- gate the API behind `FEATURE_COMPLIANCE_EXPORTS_ENABLED=false` by default for safe rollout
- add OpenAPI contract for the new compliance export endpoints

## Issue
- Closes #31

## Validation
- `npm run lint`
- `npm run test -- --run`
- `npm run build:frontend`
- `npm run contract:check`

## Notes
- `npm run build:backend` currently fails due to pre-existing TypeScript errors unrelated to this change in existing files (`applyEdits.conflict.test.ts`, `serve.ts`, `generate.ts`, `regenerate.ts`).
