### PR TITLE
feat(sharing): audit share link revocations

### DIFF
--- a/src/adapters/sharing/FirebaseSharingService.ts
+++ b/src/adapters/sharing/FirebaseSharingService.ts
@@ -88,10 +88,29 @@ export class FirebaseSharingService implements SharingService {
   }
 
   async revokeShareLink(linkId: string): Promise<void> {
+    const existing = await getDocs(
+      query(collection(this.db, 'shareLinks'), where('__name__', '==', linkId))
+    );
+
+    if (existing.empty) {
+      return;
+    }
+
+    const linkDoc = existing.docs[0];
+    const link = { id: linkDoc.id, ...linkDoc.data() } as ShareLink;
+    if (link.revoked) {
+      return;
+    }
+
     const docRef = doc(this.db, 'shareLinks', linkId);
     await updateDoc(docRef, {
       revoked: true,
       revokedAt: serverTimestamp(),
+    });
+
+    await this.logAccessEvent(link.token, link.id, 'revoked', 'link_revoke', {
+      ...link,
+      revoked: true,
     });
   }
 

--- a/src/adapters/sharing/inMemorySharingService.test.ts
+++ b/src/adapters/sharing/inMemorySharingService.test.ts
@@ -50,6 +50,25 @@ describe('InMemorySharingService', () => {
     expect(events.map((event) => event.outcome)).toEqual(['denied_max_uses', 'granted']);
   });
 
+  it('records a revoke audit event and denies future access', async () => {
+    const service = new InMemorySharingService();
+
+    const link = await service.createShareLink({
+      resourceType: 'album',
+      resourceId: 'album-9',
+      policy: { permission: 'view' },
+    });
+
+    await service.revokeShareLink(link.id);
+    const blocked = await service.resolveShareLink({ token: link.token });
+
+    expect(blocked).toBeNull();
+
+    const events = await service.listAccessEvents('album-9');
+    expect(events.map((event) => event.outcome)).toEqual(['denied_revoked', 'revoked']);
+    expect(events.map((event) => event.attempt)).toEqual(['link_resolve', 'link_revoke']);
+  });
+
   it('enforces download policies and deterministic watermark behavior', async () => {
     const service = new InMemorySharingService();
 

--- a/src/adapters/sharing/inMemorySharingService.ts
+++ b/src/adapters/sharing/inMemorySharingService.ts
@@ -67,7 +67,19 @@ export class InMemorySharingService implements SharingService {
   }
 
   async revokeShareLink(linkId: string): Promise<void> {
-    this.links = this.links.map((l) => (l.id === linkId ? { ...l, revoked: true } : l));
+    const link = this.links.find((l) => l.id === linkId);
+    if (!link || link.revoked) {
+      return;
+    }
+
+    const revokedLink = { ...link, revoked: true };
+    this.links = this.links.map((l) => (l.id === linkId ? revokedLink : l));
+    this.recordEvent({
+      token: revokedLink.token,
+      link: revokedLink,
+      attempt: 'link_revoke',
+      outcome: 'revoked',
+    });
   }
 
   async updateShareLinkPolicy(input: UpdateShareLinkPolicyInput): Promise<ShareLink> {

--- a/src/domain/sharing/types.ts
+++ b/src/domain/sharing/types.ts
@@ -52,6 +52,7 @@ export interface ShareDownloadResolution {
 export type ShareAccessOutcome =
   | 'granted'
   | 'granted_download'
+  | 'revoked'
   | 'denied_not_found'
   | 'denied_revoked'
   | 'denied_expired'
@@ -59,7 +60,11 @@ export type ShareAccessOutcome =
   | 'denied_invalid_password'
   | 'denied_download_disallowed';
 
-export type ShareAccessAttempt = 'link_resolve' | 'download_original' | 'download_derivative';
+export type ShareAccessAttempt =
+  | 'link_resolve'
+  | 'link_revoke'
+  | 'download_original'
+  | 'download_derivative';
 
 export interface ShareAccessEvent {
   id: string;


### PR DESCRIPTION
## Summary
Add explicit share-link revocation audit events so revokes are visible in the sharing activity trail.

## Changes
- extend sharing event enums with `link_revoke` attempt + `revoked` outcome
- record a revocation audit event in `InMemorySharingService.revokeShareLink`
- record a revocation audit event in `FirebaseSharingService.revokeShareLink`
- add test coverage for revoke event + post-revoke access denial

## Testing
- npm test -- --run src/adapters/sharing/inMemorySharingService.test.ts src/adapters/sharing/passwordHash.test.ts

Part of #10
