### PR TITLE
feat(sharing): enforce authenticated-only share access mode

### DIFF
--- a/src/adapters/sharing/FirebaseSharingService.ts
+++ b/src/adapters/sharing/FirebaseSharingService.ts
@@ -42,6 +42,7 @@ export class FirebaseSharingService implements SharingService {
       expiresAt: input.policy.expiresAt ?? null,
       passwordProtected: !!input.password,
       maxUses: input.policy.maxUses ?? null,
+      accessMode: input.policy.accessMode ?? 'public',
       downloadPolicy: input.policy.downloadPolicy,
       watermarkEnabled: input.policy.watermarkEnabled,
     });
@@ -262,6 +263,11 @@ export class FirebaseSharingService implements SharingService {
       return null;
     }
 
+    if (link.policy.accessMode === 'authenticated' && !input.isAuthenticated) {
+      await this.logAccessEvent(input.token, link.id, 'denied_auth_required', attempt, link);
+      return null;
+    }
+
     if (link.policy.passwordProtected) {
       if (!input.password) {
         await this.logAccessEvent(input.token, link.id, 'denied_invalid_password', attempt, link);
@@ -305,6 +311,7 @@ export class FirebaseSharingService implements SharingService {
     expiresAt: SharePolicy['expiresAt'];
     passwordProtected: SharePolicy['passwordProtected'];
     maxUses: SharePolicy['maxUses'];
+    accessMode: SharePolicy['accessMode'];
     downloadPolicy?: SharePolicy['downloadPolicy'];
     watermarkEnabled?: SharePolicy['watermarkEnabled'];
   }): SharePolicy {
@@ -318,6 +325,7 @@ export class FirebaseSharingService implements SharingService {
       expiresAt: input.expiresAt,
       passwordProtected: input.passwordProtected,
       maxUses: input.maxUses,
+      accessMode: input.accessMode,
       downloadPolicy,
       watermarkEnabled:
         downloadPolicy === 'none' ? false : (input.watermarkEnabled ?? false),

--- a/src/adapters/sharing/inMemorySharingService.test.ts
+++ b/src/adapters/sharing/inMemorySharingService.test.ts
@@ -31,6 +31,25 @@ describe('InMemorySharingService', () => {
     expect(events.every((event) => event.resourceId === 'album-1')).toBe(true);
   });
 
+  it('enforces authenticated-only access mode and records audit denial', async () => {
+    const service = new InMemorySharingService();
+
+    const link = await service.createShareLink({
+      resourceType: 'album',
+      resourceId: 'album-auth-1',
+      policy: { accessMode: 'authenticated' },
+    });
+
+    const anonymous = await service.resolveShareLink({ token: link.token });
+    const authenticated = await service.resolveShareLink({ token: link.token, isAuthenticated: true });
+
+    expect(anonymous).toBeNull();
+    expect(authenticated?.id).toBe(link.id);
+
+    const events = await service.listAccessEvents('album-auth-1');
+    expect(events.map((event) => event.outcome)).toEqual(['granted', 'denied_auth_required']);
+  });
+
   it('blocks max-use links after quota and records denial', async () => {
     const service = new InMemorySharingService();
 

--- a/src/adapters/sharing/inMemorySharingService.ts
+++ b/src/adapters/sharing/inMemorySharingService.ts
@@ -36,6 +36,7 @@ export class InMemorySharingService implements SharingService {
         expiresAt: input.policy.expiresAt ?? null,
         passwordProtected: !!input.password,
         maxUses: input.policy.maxUses ?? null,
+        accessMode: input.policy.accessMode ?? 'public',
         downloadPolicy:
           input.policy.downloadPolicy ??
           (permission === 'download' ? 'original_and_derivative' : 'none'),
@@ -182,6 +183,11 @@ export class InMemorySharingService implements SharingService {
 
     if (link.policy.maxUses !== null && link.useCount >= link.policy.maxUses) {
       this.recordEvent({ token: input.token, attempt, link, outcome: 'denied_max_uses' });
+      return null;
+    }
+
+    if (link.policy.accessMode === 'authenticated' && !input.isAuthenticated) {
+      this.recordEvent({ token: input.token, attempt, link, outcome: 'denied_auth_required' });
       return null;
     }
 

--- a/src/domain/sharing/types.ts
+++ b/src/domain/sharing/types.ts
@@ -1,11 +1,14 @@
 export type SharePermission = 'view' | 'download' | 'collaborate';
 export type ShareDownloadPolicy = 'none' | 'derivative_only' | 'original_and_derivative';
 
+export type ShareAccessMode = 'public' | 'authenticated';
+
 export interface SharePolicy {
   permission: SharePermission;
   expiresAt: string | null;
   passwordProtected: boolean;
   maxUses: number | null;
+  accessMode: ShareAccessMode;
   downloadPolicy: ShareDownloadPolicy;
   watermarkEnabled: boolean;
 }
@@ -32,6 +35,7 @@ export interface CreateShareLinkInput {
 export interface ResolveShareLinkInput {
   token: string;
   password?: string;
+  isAuthenticated?: boolean;
 }
 
 export interface UpdateShareLinkPolicyInput {
@@ -58,7 +62,8 @@ export type ShareAccessOutcome =
   | 'denied_expired'
   | 'denied_max_uses'
   | 'denied_invalid_password'
-  | 'denied_download_disallowed';
+  | 'denied_download_disallowed'
+  | 'denied_auth_required';
 
 export type ShareAccessAttempt =
   | 'link_resolve'

--- a/src/features/sharing/useSharing.ts
+++ b/src/features/sharing/useSharing.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type {
   ShareAccessEvent,
+  ShareAccessMode,
   ShareDownloadPolicy,
   ShareDownloadResolution,
   ShareLink,
@@ -21,6 +22,7 @@ interface CreateShareLinkOptions {
   expiresAt?: string;
   password?: string;
   permission?: SharePermission;
+  accessMode?: ShareAccessMode;
   downloadPolicy?: ShareDownloadPolicy;
   watermarkEnabled?: boolean;
 }
@@ -105,6 +107,7 @@ export function useSharing(resourceId: string): UseSharingReturn {
         policy: {
           permission,
           expiresAt: options?.expiresAt ?? null,
+          accessMode: options?.accessMode ?? 'public',
           downloadPolicy: options?.downloadPolicy ?? defaultDownloadPolicy,
           watermarkEnabled: options?.watermarkEnabled ?? false,
         },


### PR DESCRIPTION
## Summary
- add `accessMode` to share link policy with backward-compatible default (`public`)
- enforce authenticated-only links in both in-memory and Firebase sharing adapters
- emit audit outcome `denied_auth_required` for denied anonymous access
- expose `accessMode` in the sharing hook create-link options

## Why
Issue #10 requires public + authenticated access modes with server-side enforcement and auditable outcomes.

## Validation
- `npm test`

## Compatibility
- existing links remain public by default
- no breaking API removals; new fields are additive

Closes #10
