### PR TITLE
feat(compliance): expose audit events + log signing key requests

### DIFF
--- a/functions/src/routes/complianceV1.ts
+++ b/functions/src/routes/complianceV1.ts
@@ -2,6 +2,8 @@ import { randomUUID } from 'node:crypto';
 import { Router } from 'express';
 import type { DataAdapter } from '../adapters/data/DataAdapter.js';
 import { featureConfig } from '../config/index.js';
+import type { AuditEventRecord } from '../services/audit/AuditService.js';
+import { recordAuditEvent } from '../services/audit/AuditService.js';
 
 export type ExportRequestStatus = 'pending' | 'processing' | 'completed' | 'failed' | 'cancelled';
 
@@ -50,6 +52,19 @@ function toBoolean(value: unknown, fallback: boolean): boolean {
   return fallback;
 }
 
+function parseLimit(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.min(100, Math.max(1, Math.floor(value)));
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      return Math.min(100, Math.max(1, parsed));
+    }
+  }
+  return fallback;
+}
+
 export function createComplianceV1Router(dataAdapter: DataAdapter): Router {
   const router = Router();
 
@@ -87,7 +102,7 @@ export function createComplianceV1Router(dataAdapter: DataAdapter): Router {
 
       await dataAdapter.storeData<ExportRequestRecord>('complianceExportRequests', exportRequestId, exportRequest);
 
-      await dataAdapter.storeData('auditEvents', randomUUID(), {
+      await recordAuditEvent(dataAdapter, {
         eventType: 'compliance.export.requested',
         actorId: req.user.uid,
         targetId: exportRequestId,
@@ -127,6 +142,38 @@ export function createComplianceV1Router(dataAdapter: DataAdapter): Router {
       }
 
       res.json({ exportRequest });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/audit-events', async (req, res, next) => {
+    try {
+      if (!featureConfig.complianceExportsEnabled) {
+        sendError(res, 404, 'FEATURE_DISABLED', 'Compliance exports API is disabled');
+        return;
+      }
+
+      if (!req.user) {
+        sendError(res, 401, 'AUTH_REQUIRED', 'Authentication required');
+        return;
+      }
+
+      const limit = parseLimit(req.query.limit, 25);
+
+      const auditEvents = await dataAdapter.queryData<AuditEventRecord>('auditEvents', [
+        { field: 'actorId', operator: '==', value: req.user.uid },
+      ]);
+
+      const sortedEvents = auditEvents
+        .slice()
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+        .slice(0, limit);
+
+      res.json({
+        auditEvents: sortedEvents,
+        total: sortedEvents.length,
+      });
     } catch (error) {
       next(error);
     }

--- a/functions/src/routes/signing.ts
+++ b/functions/src/routes/signing.ts
@@ -5,8 +5,8 @@ import { authMiddleware, requireAuth } from '../middleware/auth.js';
 import { signingConfig } from '../config/index.js';
 import { logger } from '../utils/logger.js';
 import { AppError } from '../middleware/errorHandler.js';
-
-const router = Router();
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import { recordAuditEvent } from '../services/audit/AuditService.js';
 
 // Initialize signing key service
 const signingKeyService = new SigningKeyService(
@@ -14,49 +14,76 @@ const signingKeyService = new SigningKeyService(
   signingConfig.keyExpirationSeconds
 );
 
-/**
- * Get signing key for authenticated user
- * POST /api/signing/key
- */
-router.post('/key', authMiddleware, requireAuth, async (req: Request, res: Response, next) => {
-  try {
-    const userId = req.user?.uid;
-    if (!userId) {
-      throw new AppError(401, 'UNAUTHORIZED', 'User ID not found in request');
+export function createSigningRouter(dataAdapter: DataAdapter): Router {
+  const router = Router();
+
+  /**
+   * Get signing key for authenticated user
+   * POST /api/signing/key
+   */
+  router.post('/key', authMiddleware, requireAuth, async (req: Request, res: Response, next) => {
+    try {
+      const userId = req.user?.uid;
+      if (!userId) {
+        throw new AppError(401, 'UNAUTHORIZED', 'User ID not found in request');
+      }
+
+      logger.debug({ userId }, 'Generating signing key for user');
+
+      const signingKey = await signingKeyService.generateSigningKey(userId);
+
+      await recordAuditEvent(dataAdapter, {
+        eventType: 'auth.signing_key.requested',
+        actorId: userId,
+        targetId: userId,
+        metadata: {
+          keyFingerprint: signingKey.key.slice(0, 12),
+          expiresAt: signingKey.expiresAt,
+        },
+      });
+
+      res.status(200).json(signingKey);
+    } catch (error) {
+      next(error);
     }
+  });
 
-    logger.debug({ userId }, 'Generating signing key for user');
+  /**
+   * Get signing key for share token
+   * POST /api/signing/key/share/:token
+   */
+  router.post('/key/share/:token', async (req: Request, res: Response, next) => {
+    try {
+      const token = req.params.token as string;
+      const actorId = req.user?.uid;
 
-    const signingKey = await signingKeyService.generateSigningKey(userId);
+      if (!token || typeof token !== 'string') {
+        throw new AppError(400, 'INVALID_REQUEST', 'Share token is required');
+      }
 
-    res.status(200).json(signingKey);
-  } catch (error) {
-    next(error);
-  }
-});
+      logger.debug({ token: token.substring(0, 8), actorId }, 'Generating signing key for share token');
 
-/**
- * Get signing key for share token (public endpoint)
- * POST /api/signing/key/share/:token
- */
-router.post('/key/share/:token', async (req: Request, res: Response, next) => {
-  try {
-    const token = req.params.token as string;
+      // TODO: Validate share token exists and is not revoked/expired
+      // For now, generate key for any token
+      const signingKey = await signingKeyService.generateSigningKey(undefined, token);
 
-    if (!token || typeof token !== 'string') {
-      throw new AppError(400, 'INVALID_REQUEST', 'Share token is required');
+      if (actorId) {
+        await recordAuditEvent(dataAdapter, {
+          eventType: 'sharing.signing_key.requested',
+          actorId,
+          targetId: token.substring(0, 12),
+          metadata: {
+            keyId: signingKey.keyId,
+            expiresAt: signingKey.expiresAt,
+          },
+        });
+      }
+
+      res.status(200).json(signingKey);
+    } catch (error) {
+      next(error);
     }
+  });
 
-    logger.debug({ token: token.substring(0, 8) }, 'Generating signing key for share token');
-
-    // TODO: Validate share token exists and is not revoked/expired
-    // For now, generate key for any token
-    const signingKey = await signingKeyService.generateSigningKey(undefined, token);
-
-    res.status(200).json(signingKey);
-  } catch (error) {
-    next(error);
-  }
-});
-
-export default router;
+  return router;
+}

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -82,7 +82,7 @@ app.get('/health', (req, res) => {
 import { createImageRoutes } from './routes/images.js';
 import internalRouter from './routes/internal.js';
 import editsRouter from './routes/edits.js';
-import signingRouter from './routes/signing.js';
+import { createSigningRouter } from './routes/signing.js';
 import { createAlbumsRouter } from './routes/albums.js';
 import { createAlbumsV1Router } from './routes/albumsV1.js';
 import { createComplianceV1Router } from './routes/complianceV1.js';
@@ -100,7 +100,7 @@ app.use('/api', apiVersionMiddleware);
 app.use('/api/albums', authMiddleware, createAlbumsRouter(domainModules.albums));
 app.use('/api/v1/albums', authMiddleware, createAlbumsV1Router(domainModules.albums));
 app.use('/api/v1/compliance', authMiddleware, createComplianceV1Router(dataAdapter));
-app.use('/api/signing', authMiddleware, signingRouter);
+app.use('/api/signing', authMiddleware, createSigningRouter(dataAdapter));
 
 // Error handlers (must be last)
 app.use(notFoundHandler);

--- a/functions/src/services/audit/AuditService.ts
+++ b/functions/src/services/audit/AuditService.ts
@@ -1,0 +1,25 @@
+import { randomUUID } from 'node:crypto';
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+
+export interface AuditEventRecord {
+  id: string;
+  eventType: string;
+  actorId: string;
+  targetId?: string;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export async function recordAuditEvent(
+  dataAdapter: DataAdapter,
+  event: Omit<AuditEventRecord, 'id' | 'createdAt'> & { createdAt?: string }
+): Promise<AuditEventRecord> {
+  const record: AuditEventRecord = {
+    id: randomUUID(),
+    createdAt: event.createdAt ?? new Date().toISOString(),
+    ...event,
+  };
+
+  await dataAdapter.storeData<AuditEventRecord>('auditEvents', record.id, record);
+  return record;
+}


### PR DESCRIPTION
## Summary
- add shared audit event writer utility
- record audit events when auth/share signing keys are requested
- add  for users to view their recent audit trail

## Why
Issue #14 calls for baseline security/compliance observability. This increment delivers a user-usable audit trail surface with minimal, reversible scope.

## Testing
- 
> aurapix-functions@0.1.0 test
> vitest run --run


 RUN  v3.2.4 /Users/ryanrife/.openclaw/workspace-dev/aurapix/functions

 ✓ test/adapters/LocalDiskStorage.test.ts (6 tests) 19ms
 ✓ test/adapters/LocalJsonData.test.ts (7 tests) 23ms
 ✓ test/middleware/apiVersion.test.ts (4 tests) 42ms
{"level":40,"time":1773057619346,"pid":72603,"hostname":"Ryans-MacBook-Pro.local","err":{"type":"Error","message":"network","stack":"Error: network\n    at /Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/src/services/host/uploadPolicy.test.ts:41:54\n    at file:///Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11\n    at file:///Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26\n    at file:///Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20\n    at new Promise (<anonymous>)\n    at runWithTimeout (file:///Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)\n    at runTest (file:///Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at runSuite (file:///Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)\n    at runSuite (file:///Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)"},"webhookUrl":"https://host.example/hooks/upload-policy","msg":"Host upload policy webhook unavailable; allowing upload for compatibility"}
 ✓ src/services/host/uploadPolicy.test.ts (3 tests) 5ms
{"level":40,"time":1773057619352,"pid":72601,"hostname":"Ryans-MacBook-Pro.local","err":{"type":"Error","message":"Unknown file format","stack":""},"msg":"Failed to extract EXIF data"}
{"level":40,"time":1773057619353,"pid":72601,"hostname":"Ryans-MacBook-Pro.local","err":{"type":"RangeError","message":"Offset is outside the bounds of the DataView","stack":"RangeError: Offset is outside the bounds of the DataView\n    at DataView.prototype.getUint16 (<anonymous>)\n    at I.getUint16 (/Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/node_modules/exifr/dist/full.umd.js:1:4382)\n    at ce.setup (/Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/node_modules/exifr/dist/full.umd.js:1:12190)\n    at ce.parse (/Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/node_modules/exifr/dist/full.umd.js:1:12428)\n    at Object.fe [as parse] (/Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/node_modules/exifr/dist/full.umd.js:1:13335)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at extractExifData (/Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/src/utils/exif.ts:80:17)\n    at /Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/test/utils/exif.test.ts:33:20\n    at file:///Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/node_modules/@vitest/runner/dist/chunk-hooks.js:752:20"},"msg":"Failed to extract EXIF data"}
 ✓ test/utils/exif.test.ts (5 tests) 6ms
 ✓ test/middleware/rateLimit.test.ts (3 tests) 3ms
 ✓ test/middleware/appCheck.test.ts (3 tests) 68ms
 ✓ src/services/edits/EditProcessor.test.ts (3 tests) 36ms
 ✓ src/handlers/edits/applyEdits.conflict.test.ts (3 tests) 4ms
{"level":30,"time":1773057619420,"pid":72595,"hostname":"Ryans-MacBook-Pro.local","photoId":"test-photo-1","libraryId":"test-library-1","msg":"Starting thumbnail generation"}
{"level":30,"time":1773057619421,"pid":72600,"hostname":"Ryans-MacBook-Pro.local","photoId":"wBdZxIprVtM8uK9m9bDIw","libraryId":"lib-1","msg":"Extracting image metadata"}
{"level":30,"time":1773057619421,"pid":72595,"hostname":"Ryans-MacBook-Pro.local","photoId":"test-photo-1","libraryId":"test-library-1","path":"originals/test-library-1/test-photo-1/original.jpg","msg":"Loading original"}
{"level":30,"time":1773057619421,"pid":72600,"hostname":"Ryans-MacBook-Pro.local","msg":"Extracting EXIF data from image"}
{"level":30,"time":1773057619422,"pid":72595,"hostname":"Ryans-MacBook-Pro.local","photoId":"test-photo-1","libraryId":"test-library-1","msg":"Generating thumbnail variants"}
{"level":40,"time":1773057619422,"pid":72600,"hostname":"Ryans-MacBook-Pro.local","err":{"type":"Error","message":"Unknown file format","stack":""},"msg":"Failed to extract EXIF data"}
{"level":30,"time":1773057619422,"pid":72600,"hostname":"Ryans-MacBook-Pro.local","photoId":"wBdZxIprVtM8uK9m9bDIw","path":"originals/lib-1/wBdZxIprVtM8uK9m9bDIw/original.nef","msg":"Storing original image"}
{"level":30,"time":1773057619422,"pid":72600,"hostname":"Ryans-MacBook-Pro.local","photoId":"wBdZxIprVtM8uK9m9bDIw","msg":"Saving photo document"}
 ✓ src/handlers/images/upload.validation.test.ts (2 tests) 6ms
{"level":30,"time":1773057619424,"pid":72595,"hostname":"Ryans-MacBook-Pro.local","msg":"Generating all thumbnail variants"}
{"level":30,"time":1773057619432,"pid":72595,"hostname":"Ryans-MacBook-Pro.local","photoId":"test-photo-1","libraryId":"test-library-1","msg":"Storing derivative images"}
{"level":30,"time":1773057619433,"pid":72600,"hostname":"Ryans-MacBook-Pro.local","photoId":"wBdZxIprVtM8uK9m9bDIw","libraryId":"lib-1","msg":"Starting thumbnail generation"}
{"level":30,"time":1773057619434,"pid":72595,"hostname":"Ryans-MacBook-Pro.local","photoId":"test-photo-1","libraryId":"test-library-1","msg":"Thumbnail generation complete"}
{"level":50,"time":1773057619434,"pid":72600,"hostname":"Ryans-MacBook-Pro.local","err":{"type":"Error","message":"Photo wBdZxIprVtM8uK9m9bDIw not found","stack":"Error: Photo wBdZxIprVtM8uK9m9bDIw not found\n    at generateThumbnailsForPhoto (/Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/src/handlers/thumbnails/generate.ts:31:13)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at Immediate.<anonymous> (/Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/src/handlers/images/upload.ts:272:9)"},"photoId":"wBdZxIprVtM8uK9m9bDIw","libraryId":"lib-1","msg":"Thumbnail generation failed"}
{"level":50,"time":1773057619436,"pid":72600,"hostname":"Ryans-MacBook-Pro.local","err":{"type":"Error","message":"Photo wBdZxIprVtM8uK9m9bDIw not found","stack":"Error: Photo wBdZxIprVtM8uK9m9bDIw not found\n    at generateThumbnailsForPhoto (/Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/src/handlers/thumbnails/generate.ts:31:13)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at Immediate.<anonymous> (/Users/ryanrife/.openclaw/workspace-dev/aurapix/functions/src/handlers/images/upload.ts:272:9)"},"photoId":"wBdZxIprVtM8uK9m9bDIw","msg":"Failed to generate thumbnails in background"}
{"level":30,"time":1773057619444,"pid":72595,"hostname":"Ryans-MacBook-Pro.local","photoId":"test-photo-2","libraryId":"test-library-2","msg":"Starting thumbnail generation"}
{"level":30,"time":1773057619444,"pid":72595,"hostname":"Ryans-MacBook-Pro.local","photoId":"test-photo-2","libraryId":"test-library-2","msg":"Thumbnails already exist, skipping"}
 ✓ test/integration/upload.test.ts (2 tests) 47ms
 ✓ src/handlers/storage/usageReport.test.ts (1 test) 2ms
 ✓ src/handlers/edits/editIdempotency.test.ts (4 tests) 2ms
 ✓ test/handlers/uploadIdempotency.test.ts (5 tests) 2ms
 ✓ src/services/edits/pluginRegistry.test.ts (7 tests) 2ms
 ✓ src/adapters/domain/in-memory/InMemoryAlbumRepository.test.ts (2 tests) 2ms
 ✓ src/services/image/rawSupport.test.ts (3 tests) 1ms

 Test Files  17 passed (17)
      Tests  63 passed (63)
   Start at  05:00:19
   Duration  437ms (transform 325ms, setup 0ms, collect 994ms, tests 271ms, environment 3ms, prepare 982ms) (pass)
- full functions lint/build currently fail due pre-existing repo issues unrelated to this change

Refs #14