### PR TITLE
feat(compliance): add audit event summary endpoint

### DIFF
--- a/contracts/openapi/compliance.openapi.json
+++ b/contracts/openapi/compliance.openapi.json
@@ -74,6 +74,66 @@
           }
         }
       }
+    },
+    "/api/v1/compliance/audit-events": {
+      "get": {
+        "summary": "List recent audit events for the authenticated user",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recent audit events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditEventsEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/compliance/audit-events/summary": {
+      "get": {
+        "summary": "Get audit event volume summary grouped by event type",
+        "parameters": [
+          {
+            "name": "windowDays",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 90,
+              "default": 7
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Audit event summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditEventSummary"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -100,6 +160,54 @@
         "properties": {
           "exportRequest": {
             "$ref": "#/components/schemas/ExportRequest"
+          }
+        }
+      },
+      "AuditEvent": {
+        "type": "object",
+        "required": ["id", "eventType", "actorId", "createdAt"],
+        "properties": {
+          "id": { "type": "string" },
+          "eventType": { "type": "string" },
+          "actorId": { "type": "string" },
+          "targetId": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "AuditEventsEnvelope": {
+        "type": "object",
+        "required": ["auditEvents", "total"],
+        "properties": {
+          "auditEvents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuditEvent"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "AuditEventSummary": {
+        "type": "object",
+        "required": ["windowDays", "windowStart", "total", "uniqueEventTypes", "byEventType"],
+        "properties": {
+          "windowDays": { "type": "integer", "minimum": 1, "maximum": 90 },
+          "windowStart": { "type": "string", "format": "date-time" },
+          "total": { "type": "integer", "minimum": 0 },
+          "uniqueEventTypes": { "type": "integer", "minimum": 0 },
+          "byEventType": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
           }
         }
       }

--- a/functions/src/routes/complianceV1.ts
+++ b/functions/src/routes/complianceV1.ts
@@ -65,6 +65,26 @@ function parseLimit(value: unknown, fallback: number): number {
   return fallback;
 }
 
+function parseWindowDays(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.min(90, Math.max(1, Math.floor(value)));
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      return Math.min(90, Math.max(1, parsed));
+    }
+  }
+  return fallback;
+}
+
+export function summarizeAuditEventsByType(auditEvents: AuditEventRecord[]): Record<string, number> {
+  return auditEvents.reduce<Record<string, number>>((acc, event) => {
+    acc[event.eventType] = (acc[event.eventType] ?? 0) + 1;
+    return acc;
+  }, {});
+}
+
 export function createComplianceV1Router(dataAdapter: DataAdapter): Router {
   const router = Router();
 
@@ -173,6 +193,41 @@ export function createComplianceV1Router(dataAdapter: DataAdapter): Router {
       res.json({
         auditEvents: sortedEvents,
         total: sortedEvents.length,
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/audit-events/summary', async (req, res, next) => {
+    try {
+      if (!featureConfig.complianceExportsEnabled) {
+        sendError(res, 404, 'FEATURE_DISABLED', 'Compliance exports API is disabled');
+        return;
+      }
+
+      if (!req.user) {
+        sendError(res, 401, 'AUTH_REQUIRED', 'Authentication required');
+        return;
+      }
+
+      const windowDays = parseWindowDays(req.query.windowDays, 7);
+      const windowStart = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString();
+
+      const auditEvents = await dataAdapter.queryData<AuditEventRecord>('auditEvents', [
+        { field: 'actorId', operator: '==', value: req.user.uid },
+        { field: 'createdAt', operator: '>=', value: windowStart },
+      ]);
+
+      const byEventType = summarizeAuditEventsByType(auditEvents);
+      const uniqueEventTypes = Object.keys(byEventType).length;
+
+      res.json({
+        windowDays,
+        windowStart,
+        total: auditEvents.length,
+        uniqueEventTypes,
+        byEventType,
       });
     } catch (error) {
       next(error);

--- a/functions/test/routes/complianceV1.test.ts
+++ b/functions/test/routes/complianceV1.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeAuditEventsByType } from '../../src/routes/complianceV1.js';
+import type { AuditEventRecord } from '../../src/services/audit/AuditService.js';
+
+describe('summarizeAuditEventsByType', () => {
+  it('returns grouped totals by event type', () => {
+    const events: AuditEventRecord[] = [
+      {
+        id: '1',
+        eventType: 'compliance.export.requested',
+        actorId: 'user-1',
+        targetId: 'exp-1',
+        createdAt: '2026-03-08T01:00:00.000Z',
+      },
+      {
+        id: '2',
+        eventType: 'signing.key.requested',
+        actorId: 'user-1',
+        targetId: 'key-1',
+        createdAt: '2026-03-08T02:00:00.000Z',
+      },
+      {
+        id: '3',
+        eventType: 'signing.key.requested',
+        actorId: 'user-1',
+        targetId: 'key-2',
+        createdAt: '2026-03-08T03:00:00.000Z',
+      },
+    ];
+
+    expect(summarizeAuditEventsByType(events)).toEqual({
+      'compliance.export.requested': 1,
+      'signing.key.requested': 2,
+    });
+  });
+
+  it('returns an empty summary for no events', () => {
+    expect(summarizeAuditEventsByType([])).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- add `GET /api/v1/compliance/audit-events/summary` for per-event-type volume rollups
- support configurable `windowDays` query param (1-90, default 7)
- factor summary aggregation into a tested helper
- extend compliance OpenAPI contract with audit event list + summary schemas

## Why
Issue #14 calls out observability/compliance baseline. This increment adds a user-usable API surface to quickly inspect recent audit activity trends by type.

## Validation
- npm --prefix functions test

Closes #14
