### PR TITLE
feat(albums): support album rename via API

### DIFF
--- a/contracts/openapi/albums.openapi.json
+++ b/contracts/openapi/albums.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "AuraPix Albums API",
-    "version": "1.0.0",
-    "description": "Contract artifact for albums list/create endpoints."
+    "version": "1.1.0",
+    "description": "Contract artifact for albums list/create/update endpoints."
   },
   "servers": [
     {
@@ -116,6 +116,54 @@
           }
         }
       }
+    },
+    "/api/v1/albums/{albumId}": {
+      "patch": {
+        "operationId": "renameAlbum",
+        "summary": "Rename album",
+        "parameters": [
+          {
+            "name": "albumId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAlbumRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Album updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateAlbumResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ErrorResponse"
+          },
+          "401": {
+            "$ref": "#/components/responses/ErrorResponse"
+          },
+          "404": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -160,6 +208,22 @@
         }
       },
       "CreateAlbumResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["album"],
+        "properties": {
+          "album": { "$ref": "#/components/schemas/Album" }
+        }
+      },
+      "UpdateAlbumRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1, "maxLength": 120 }
+        }
+      },
+      "UpdateAlbumResponse": {
         "type": "object",
         "additionalProperties": false,
         "required": ["album"],

--- a/functions/src/adapters/domain/in-memory/InMemoryAlbumRepository.test.ts
+++ b/functions/src/adapters/domain/in-memory/InMemoryAlbumRepository.test.ts
@@ -18,11 +18,30 @@ describe('InMemoryAlbumRepository', () => {
     expect(user2Albums[0]?.title).toBe('Work');
   });
 
+  it('renames an album for the owner', async () => {
+    const service = new AlbumsService(new InMemoryAlbumRepository());
+    const created = await service.create({ ownerId: 'u1', title: 'Roadtrip' });
+
+    const renamed = await service.rename('u1', created.id, 'Summer Roadtrip');
+
+    expect(renamed.title).toBe('Summer Roadtrip');
+    expect(renamed.updatedAt >= created.updatedAt).toBe(true);
+
+    const listed = await service.list('u1');
+    expect(listed[0]?.title).toBe('Summer Roadtrip');
+  });
+
   it('rejects album creation when title is blank', async () => {
     const service = new AlbumsService(new InMemoryAlbumRepository());
 
     await expect(
       service.create({ ownerId: 'u1', title: '   ' })
     ).rejects.toThrow('album-title-required');
+  });
+
+  it('rejects rename when album is missing', async () => {
+    const service = new AlbumsService(new InMemoryAlbumRepository());
+
+    await expect(service.rename('u1', 'missing', 'New name')).rejects.toThrow('album-not-found');
   });
 });

--- a/functions/src/adapters/domain/in-memory/InMemoryAlbumRepository.ts
+++ b/functions/src/adapters/domain/in-memory/InMemoryAlbumRepository.ts
@@ -17,4 +17,25 @@ export class InMemoryAlbumRepository implements AlbumRepository {
     this.albums.set(input.ownerId, [...existing, record]);
     return record;
   }
+
+  async updateTitle(ownerId: string, albumId: string, title: string): Promise<Album | null> {
+    const existing = this.albums.get(ownerId) ?? [];
+    const index = existing.findIndex((album) => album.id === albumId);
+    if (index === -1) {
+      return null;
+    }
+
+    const album = existing[index]!;
+    const updated: Album = {
+      ...album,
+      title,
+      updatedAt: new Date().toISOString(),
+    };
+
+    const next = [...existing];
+    next[index] = updated;
+    this.albums.set(ownerId, next);
+
+    return updated;
+  }
 }

--- a/functions/src/domain/albums/AlbumRepository.ts
+++ b/functions/src/domain/albums/AlbumRepository.ts
@@ -3,4 +3,5 @@ import type { Album, CreateAlbumInput } from './types.js';
 export interface AlbumRepository {
   listByOwner(ownerId: string): Promise<Album[]>;
   create(input: CreateAlbumInput): Promise<Album>;
+  updateTitle(ownerId: string, albumId: string, title: string): Promise<Album | null>;
 }

--- a/functions/src/domain/albums/AlbumsService.ts
+++ b/functions/src/domain/albums/AlbumsService.ts
@@ -21,6 +21,20 @@ export class AlbumsService {
     });
   }
 
+  async rename(ownerId: string, albumId: string, title: string): Promise<Album> {
+    const nextTitle = title.trim();
+    if (!nextTitle) {
+      throw new Error('album-title-required');
+    }
+
+    const updated = await this.albums.updateTitle(ownerId, albumId, nextTitle);
+    if (!updated) {
+      throw new Error('album-not-found');
+    }
+
+    return updated;
+  }
+
   static createAlbumRecord(input: CreateAlbumInput): Album {
     const now = new Date().toISOString();
     return {

--- a/functions/src/routes/albumsV1.ts
+++ b/functions/src/routes/albumsV1.ts
@@ -172,5 +172,58 @@ export function createAlbumsV1Router(albums: AlbumsService): Router {
     }
   });
 
+  router.patch('/:albumId', async (req, res, next) => {
+    try {
+      if (!req.user) {
+        sendError(res, 401, 'AUTH_REQUIRED', 'Authentication required');
+        return;
+      }
+
+      const albumId = typeof req.params.albumId === 'string' ? req.params.albumId.trim() : '';
+      if (!albumId) {
+        sendError(res, 400, 'INVALID_PATH', 'albumId is required');
+        return;
+      }
+
+      const name =
+        typeof req.body?.name === 'string'
+          ? req.body.name
+          : typeof req.body?.title === 'string'
+            ? req.body.title
+            : '';
+
+      if (!name.trim()) {
+        sendError(res, 400, 'INVALID_BODY', 'name is required');
+        return;
+      }
+
+      const updated = await albums.rename(req.user.uid, albumId, name);
+
+      res.json({
+        album: {
+          id: updated.id,
+          name: updated.title,
+          description: updated.description ?? null,
+          folderId: null,
+          photoIds: [],
+          createdAt: updated.createdAt,
+          updatedAt: updated.updatedAt,
+        },
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'album-title-required') {
+        sendError(res, 400, 'INVALID_BODY', 'name is required');
+        return;
+      }
+
+      if (error instanceof Error && error.message === 'album-not-found') {
+        sendError(res, 404, 'ALBUM_NOT_FOUND', 'Album not found');
+        return;
+      }
+
+      next(error);
+    }
+  });
+
   return router;
 }

--- a/src/api/contracts/albums.ts
+++ b/src/api/contracts/albums.ts
@@ -17,6 +17,15 @@ export interface GetAlbumResponse {
   album: Album;
 }
 
+export interface UpdateAlbumRequest {
+  albumId: string;
+  name: string;
+}
+
+export interface UpdateAlbumResponse {
+  album: Album;
+}
+
 export interface DeleteAlbumRequest {
   albumId: string;
 }


### PR DESCRIPTION
## Summary
- add  to rename an existing album
- validate authenticated owner access and non-empty album name
- return updated album payload in the existing API response shape
- update backend + frontend OpenAPI contracts for the rename operation
- add tests for happy path, validation failure, and missing album handling

## Testing
- npm --prefix functions test
- npm run contract:check

Closes #109