### PR TITLE
feat(upload): show unsupported file warnings in upload modal

### DIFF
--- a/src/components/UploadModal.test.tsx
+++ b/src/components/UploadModal.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { UploadModal } from './UploadModal';
+
+vi.mock('../features/albums/useAlbums', () => ({
+  useAlbums: () => ({
+    albums: [],
+    createAlbum: vi.fn(),
+  }),
+}));
+
+describe('UploadModal', () => {
+  it('shows ignored unsupported files while keeping supported files selected', async () => {
+    render(<UploadModal onClose={vi.fn()} onUpload={vi.fn()} />);
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+
+    const supported = new File(['img'], 'photo.jpg', { type: 'image/jpeg' });
+    const unsupported = new File(['notes'], 'notes.txt', { type: 'text/plain' });
+
+    fireEvent.change(fileInput, {
+      target: {
+        files: [supported, unsupported],
+      },
+    });
+
+    expect(await screen.findByText('Unsupported file ignored: notes.txt', { exact: false })).toBeInTheDocument();
+    expect(await screen.findByText('1 file selected')).toBeInTheDocument();
+  });
+});

--- a/src/components/UploadModal.tsx
+++ b/src/components/UploadModal.tsx
@@ -30,6 +30,7 @@ export function UploadModal({ preselectedAlbumId, onClose, onUpload }: UploadMod
   const [newAlbumName, setNewAlbumName] = useState('');
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [unsupportedFiles, setUnsupportedFiles] = useState<string[]>([]);
   const [uploadedCount, setUploadedCount] = useState(0);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -37,8 +38,19 @@ export function UploadModal({ preselectedAlbumId, onClose, onUpload }: UploadMod
 
   function mergeFiles(incoming: FileList | File[] | null) {
     if (!incoming) return;
-    const supportedFiles = Array.from(incoming).filter((f) => isSupportedUploadFile(f));
+
+    const incomingFiles = Array.from(incoming);
+    const supportedFiles = incomingFiles.filter((f) => isSupportedUploadFile(f));
+    const rejectedFileNames = incomingFiles
+      .filter((f) => !isSupportedUploadFile(f))
+      .map((f) => f.name);
+
+    if (rejectedFileNames.length > 0) {
+      setUnsupportedFiles((prev) => Array.from(new Set([...prev, ...rejectedFileNames])));
+    }
+
     if (supportedFiles.length === 0) return;
+
     setFiles((prev) => {
       const existingKeys = new Set(prev.map((f) => `${f.name}-${f.size}`));
       return [
@@ -176,6 +188,12 @@ export function UploadModal({ preselectedAlbumId, onClose, onUpload }: UploadMod
             >
               Browse files
             </button>
+            {unsupportedFiles.length > 0 && (
+              <p className="error" role="status" aria-live="polite">
+                Unsupported file{unsupportedFiles.length !== 1 ? 's' : ''} ignored:{' '}
+                {unsupportedFiles.join(', ')}
+              </p>
+            )}
           </div>
 
           {/* Selected files list */}


### PR DESCRIPTION
## Summary\n- show a non-blocking warning when unsupported files are dropped/selected in upload modal\n- keep supported files queued normally\n- add unit test coverage for mixed supported/unsupported selection\n\n## Testing\n- npm test -- --run src/components/UploadModal.test.tsx src/features/uploads/supportedUploadFiles.test.ts\n- npm run lint\n\nFixes #117