### PR TITLE
feat: clarify unsupported upload files

### DIFF
--- a/src/components/UploadModal.test.tsx
+++ b/src/components/UploadModal.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { UploadModal } from './UploadModal';
 
 vi.mock('../features/albums/useAlbums', () => ({
@@ -26,5 +27,21 @@ describe('UploadModal', () => {
 
     expect(await screen.findByText('Unsupported file ignored: notes.txt', { exact: false })).toBeInTheDocument();
     expect(await screen.findByText('1 file selected')).toBeInTheDocument();
+  });
+
+  it('allows dismissing the unsupported file warning', async () => {
+    const user = userEvent.setup();
+    render(<UploadModal onClose={vi.fn()} onUpload={vi.fn()} />);
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: {
+        files: [new File(['notes'], 'notes.txt', { type: 'text/plain' })],
+      },
+    });
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Unsupported file ignored: notes.txt');
+    await user.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(screen.queryByRole('status')).toBeNull();
   });
 });

--- a/src/components/UploadModal.tsx
+++ b/src/components/UploadModal.tsx
@@ -88,6 +88,10 @@ export function UploadModal({ preselectedAlbumId, onClose, onUpload }: UploadMod
     }
   }
 
+  function clearUnsupportedFiles() {
+    setUnsupportedFiles([]);
+  }
+
   async function handleUpload() {
     if (files.length === 0) return;
     setUploadError(null);
@@ -115,6 +119,7 @@ export function UploadModal({ preselectedAlbumId, onClose, onUpload }: UploadMod
       await onUpload(files, albumId, (completed) => {
         setUploadedCount(completed);
       });
+      clearUnsupportedFiles();
       onClose();
     } catch (err) {
       setUploadError(err instanceof Error ? err.message : 'Upload failed. Please try again.');
@@ -189,10 +194,15 @@ export function UploadModal({ preselectedAlbumId, onClose, onUpload }: UploadMod
               Browse files
             </button>
             {unsupportedFiles.length > 0 && (
-              <p className="error" role="status" aria-live="polite">
-                Unsupported file{unsupportedFiles.length !== 1 ? 's' : ''} ignored:{' '}
-                {unsupportedFiles.join(', ')}
-              </p>
+              <div className="upload-warning" role="status" aria-live="polite">
+                <p className="error upload-warning-text">
+                  Unsupported file{unsupportedFiles.length !== 1 ? 's' : ''} ignored:{' '}
+                  {unsupportedFiles.join(', ')}
+                </p>
+                <button type="button" className="upload-warning-dismiss" onClick={clearUnsupportedFiles}>
+                  Dismiss
+                </button>
+              </div>
             )}
           </div>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1857,6 +1857,38 @@ input:focus {
   box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
 }
 
+/* ── Upload warnings ───────────────────────────────────────────────────── */
+.upload-warning {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid #7c2d12;
+  border-radius: 10px;
+  background: rgba(127, 29, 29, 0.18);
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.upload-warning-text {
+  margin: 0;
+  flex: 1;
+}
+
+.upload-warning-dismiss {
+  border: 1px solid #fb7185;
+  background: transparent;
+  color: #fecdd3;
+  border-radius: 8px;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.upload-warning-dismiss:hover {
+  background: rgba(251, 113, 133, 0.14);
+}
+
 /* ── Upload progress bar ───────────────────────────────────────────────── */
 .upload-progress {
   display: flex;


### PR DESCRIPTION
Implements issue #117 by surfacing unsupported filenames in the upload modal, keeping supported files queued, and adding a dismiss action so the warning is non-blocking.

Validation:
- npm run lint -- --max-warnings=0
- npm test