### PR TITLE
feat(upload): report unsupported files in the upload modal

### DIFF
--- a/src/components/UploadModal.test.tsx
+++ b/src/components/UploadModal.test.tsx
@@ -25,7 +25,7 @@ describe('UploadModal', () => {
       },
     });
 
-    expect(await screen.findByText('Unsupported file ignored: notes.txt', { exact: false })).toBeInTheDocument();
+    expect(await screen.findByText('1 unsupported file ignored: notes.txt', { exact: false })).toBeInTheDocument();
     expect(await screen.findByText('1 file selected')).toBeInTheDocument();
   });
 
@@ -40,8 +40,26 @@ describe('UploadModal', () => {
       },
     });
 
-    expect(await screen.findByRole('status')).toHaveTextContent('Unsupported file ignored: notes.txt');
+    expect(await screen.findByRole('status')).toHaveTextContent('1 unsupported file ignored: notes.txt');
     await user.click(screen.getByRole('button', { name: /dismiss/i }));
     expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('summarizes large unsupported selections without losing the file names', async () => {
+    render(<UploadModal onClose={vi.fn()} onUpload={vi.fn()} />);
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['one'], 'one.txt', { type: 'text/plain' }),
+          new File(['two'], 'two.md', { type: 'text/markdown' }),
+          new File(['three'], 'three.pdf', { type: 'application/pdf' }),
+          new File(['four'], 'four.csv', { type: 'text/csv' }),
+        ],
+      },
+    });
+
+    expect(await screen.findByRole('status')).toHaveTextContent('4 unsupported files ignored: one.txt, two.md, three.pdf and 1 more');
   });
 });

--- a/src/components/UploadModal.tsx
+++ b/src/components/UploadModal.tsx
@@ -92,6 +92,14 @@ export function UploadModal({ preselectedAlbumId, onClose, onUpload }: UploadMod
     setUnsupportedFiles([]);
   }
 
+  function formatUnsupportedSummary(fileNames: string[]) {
+    const uniqueNames = Array.from(new Set(fileNames));
+    const visibleNames = uniqueNames.slice(0, 3);
+    const remainingCount = uniqueNames.length - visibleNames.length;
+    const suffix = remainingCount > 0 ? ` and ${remainingCount} more` : '';
+    return `${uniqueNames.length} unsupported file${uniqueNames.length !== 1 ? 's' : ''} ignored: ${visibleNames.join(', ')}${suffix}`;
+  }
+
   async function handleUpload() {
     if (files.length === 0) return;
     setUploadError(null);
@@ -195,10 +203,7 @@ export function UploadModal({ preselectedAlbumId, onClose, onUpload }: UploadMod
             </button>
             {unsupportedFiles.length > 0 && (
               <div className="upload-warning" role="status" aria-live="polite">
-                <p className="error upload-warning-text">
-                  Unsupported file{unsupportedFiles.length !== 1 ? 's' : ''} ignored:{' '}
-                  {unsupportedFiles.join(', ')}
-                </p>
+                <p className="error upload-warning-text">{formatUnsupportedSummary(unsupportedFiles)}</p>
                 <button type="button" className="upload-warning-dismiss" onClick={clearUnsupportedFiles}>
                   Dismiss
                 </button>


### PR DESCRIPTION
Closes #117\n\nAdds a non-blocking warning in the upload modal when users select or drop unsupported files. Supported files remain queued normally, and the warning can be dismissed. Covered by UI tests.