### PR TITLE
feat(albums): sync filters with URL state

### DIFF
--- a/src/pages/AlbumsPage.test.tsx
+++ b/src/pages/AlbumsPage.test.tsx
@@ -93,6 +93,36 @@ describe('AlbumsPage', () => {
     expect(filteredAlbumLinks).not.toContain('Alpha Trip');
   });
 
+  it('keeps album search, sort, and pagination state in the URL', async () => {
+    window.history.pushState({}, '', '/albums?q=zoo&sort=name-asc');
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: 'Albums' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Search albums')).toHaveValue('zoo');
+    expect(screen.getByLabelText('Sort albums')).toHaveValue('name-asc');
+
+    await user.clear(screen.getByLabelText('Search albums'));
+    await user.type(screen.getByLabelText('Search albums'), 'alpha');
+    expect(window.location.search).toContain('q=alpha');
+    expect(window.location.search).toContain('sort=name-asc');
+
+    await user.clear(screen.getByLabelText('Search albums'));
+    expect(window.location.search).not.toContain('q=');
+
+    for (let i = 0; i < 13; i += 1) {
+      await user.clear(screen.getByPlaceholderText('New album name'));
+      await user.type(screen.getByPlaceholderText('New album name'), `Paged Album ${i + 1}`);
+      await user.click(screen.getByRole('button', { name: 'Create album' }));
+    }
+
+    expect(await screen.findByRole('button', { name: 'Next' })).toBeEnabled();
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(window.location.search).toContain('page=2');
+  });
+
   it('renames an album from the list actions', async () => {
     window.history.pushState({}, '', '/albums');
     const user = userEvent.setup();

--- a/src/pages/AlbumsPage.tsx
+++ b/src/pages/AlbumsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import type { Album, AlbumFolder } from '../domain/albums/types';
 import type { Photo } from '../domain/library/types';
 import { useAlbums } from '../features/albums/useAlbums';
@@ -299,6 +299,8 @@ function FolderSection({
 
 // ── Page ──────────────────────────────────────────────────────────────────
 export function AlbumsPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
   const { user } = useAuth();
   const libraryId = toLibraryId(user?.id ?? 'local-user-1');
   const {
@@ -325,10 +327,25 @@ export function AlbumsPage() {
   const [creatingFolder, setCreatingFolder] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortMode, setSortMode] = useState<'newest' | 'oldest' | 'name-asc' | 'name-desc'>('newest');
-  const [page, setPage] = useState(1);
+  const initialFilters = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return {
+      q: params.get('q')?.trim() ?? '',
+      sort: (params.get('sort') as 'newest' | 'oldest' | 'name-asc' | 'name-desc' | null) ?? 'newest',
+      page: Math.max(1, Number.parseInt(params.get('page') ?? '1', 10) || 1),
+    };
+  }, [location.search]);
+
+  const [searchQuery, setSearchQuery] = useState(initialFilters.q);
+  const [sortMode, setSortMode] = useState<'newest' | 'oldest' | 'name-asc' | 'name-desc'>(initialFilters.sort);
+  const [page, setPage] = useState(initialFilters.page);
   const pageSize = 12;
+
+  useEffect(() => {
+    setSearchQuery(initialFilters.q);
+    setSortMode(initialFilters.sort);
+    setPage(initialFilters.page);
+  }, [initialFilters]);
 
   const visibleAlbums = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
@@ -351,6 +368,21 @@ export function AlbumsPage() {
   useEffect(() => {
     setPage(1);
   }, [searchQuery, sortMode]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (searchQuery.trim()) params.set('q', searchQuery.trim());
+    else params.delete('q');
+    if (sortMode !== 'newest') params.set('sort', sortMode);
+    else params.delete('sort');
+    if (currentPage > 1) params.set('page', String(currentPage));
+    else params.delete('page');
+
+    const nextSearch = params.toString();
+    if (nextSearch !== location.search.replace(/^\?/, '')) {
+      navigate({ pathname: location.pathname, search: nextSearch ? `?${nextSearch}` : '' }, { replace: true });
+    }
+  }, [currentPage, location.pathname, location.search, navigate, searchQuery, sortMode]);
 
   useEffect(() => {
     if (page > totalPages) {


### PR DESCRIPTION
## Summary\n\nPersist album search, sort, and pagination controls in the URL so the current albums view can be refreshed or shared without losing state.\n\n## Changes\n\n- Read initial album search, sort, and page values from query parameters\n- Keep the URL updated as users change search, sort, or pagination controls\n- Added coverage for restoring and updating URL-backed album view state\n\n## Testing\n\n- npm test -- --run src/pages/AlbumsPage.test.tsx\n- npm run build:frontend\n\nFixes none