### PR TITLE
feat: confirm album creation from the albums page

### DIFF
--- a/src/pages/AlbumsPage.test.tsx
+++ b/src/pages/AlbumsPage.test.tsx
@@ -15,6 +15,9 @@ describe('AlbumsPage', () => {
     await user.type(albumInput, 'Road Trip 2026');
     await user.click(screen.getByRole('button', { name: 'Create album' }));
 
+    expect((await screen.findByRole('link', { name: 'Open it now' })).getAttribute('href')).toMatch(
+      /^\/albums\/album-/
+    );
     expect((await screen.findAllByRole('link', { name: 'Road Trip 2026' })).length).toBeGreaterThan(0);
   });
 

--- a/src/pages/AlbumsPage.tsx
+++ b/src/pages/AlbumsPage.tsx
@@ -327,6 +327,7 @@ export function AlbumsPage() {
   const [creatingFolder, setCreatingFolder] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+  const [createdAlbumId, setCreatedAlbumId] = useState<string | null>(null);
   const initialFilters = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return {
@@ -405,13 +406,18 @@ export function AlbumsPage() {
     setAlbumFolderId('');
     setCreatingCount((count) => count + 1);
 
-    const created = await createAlbum(trimmedName, selectedFolderId);
-    if (!created) {
-      setAlbumName(trimmedName);
-      setAlbumFolderId(selectedFolderId ?? '');
-    }
+    try {
+      const created = await createAlbum(trimmedName, selectedFolderId);
+      if (!created) {
+        setAlbumName(trimmedName);
+        setAlbumFolderId(selectedFolderId ?? '');
+        return;
+      }
 
-    setCreatingCount((count) => Math.max(0, count - 1));
+      setCreatedAlbumId(created.id);
+    } finally {
+      setCreatingCount((count) => Math.max(0, count - 1));
+    }
   }
 
   async function handleCreateFolder(e: React.FormEvent) {
@@ -521,6 +527,12 @@ export function AlbumsPage() {
         </form>
 
         {albumFormError && <p className="error">{albumFormError}</p>}
+
+        {createdAlbumId && (
+          <p className="state-message" role="status">
+            Album created. <Link to={`/albums/${createdAlbumId}`}>Open it now</Link>
+          </p>
+        )}
 
         <div className="album-form" role="group" aria-label="Album list controls">
           <input


### PR DESCRIPTION
Summary:
- Keep users on the Albums page after creation
- Show a success message with a direct link to the new album
- Cover the flow with a test

Validation:
- npm test -- src/pages/AlbumsPage.test.tsx