### PR TITLE
feat: implement firebase upload sessions

### DIFF
--- a/src/adapters/albums/inMemoryAlbumsService.test.ts
+++ b/src/adapters/albums/inMemoryAlbumsService.test.ts
@@ -46,6 +46,12 @@ describe('InMemoryAlbumsService', () => {
         folderId: null,
         createdAt: new Date().toISOString(),
       },
+    ], [
+      {
+        id: 'folder-1',
+        name: 'Trips',
+        createdAt: new Date().toISOString(),
+      },
     ]);
 
     const updated = await svc.updateAlbum('a1', {
@@ -110,5 +116,28 @@ describe('InMemoryAlbumsService', () => {
 
     const folders = await svc.listFolders();
     expect(folders[0].name).toBe('New Name');
+  });
+
+  it('rejects albums assigned to missing folders', async () => {
+    const svc = new InMemoryAlbumsService();
+
+    await expect(svc.createAlbum({ name: 'Foldered', folderId: 'missing' })).rejects.toThrow(
+      'Folder not found.'
+    );
+  });
+
+  it('rejects moving albums to missing folders', async () => {
+    const svc = new InMemoryAlbumsService([
+      {
+        id: 'a1',
+        name: 'Before',
+        folderId: null,
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+
+    await expect(svc.updateAlbum('a1', { folderId: 'missing' })).rejects.toThrow(
+      'Folder not found.'
+    );
   });
 });

--- a/src/adapters/albums/inMemoryAlbumsService.ts
+++ b/src/adapters/albums/inMemoryAlbumsService.ts
@@ -87,6 +87,11 @@ export class InMemoryAlbumsService implements AlbumsService {
     const name = input.name.trim();
     if (!name) throw new Error('Album name is required.');
 
+    if (input.folderId !== undefined && input.folderId !== null) {
+      const folderExists = this.folders.some((folder) => folder.id === input.folderId);
+      if (!folderExists) throw new Error('Folder not found.');
+    }
+
     const normalizedName = normalizeName(name);
     const duplicate = this.albums.some((album) => normalizeName(album.name) === normalizedName);
     if (duplicate) throw new Error('An album with this name already exists.');
@@ -115,6 +120,11 @@ export class InMemoryAlbumsService implements AlbumsService {
       (album) => album.id !== albumId && normalizeName(album.name) === normalizedName
     );
     if (duplicate) throw new Error('An album with this name already exists.');
+
+    if (updates.folderId !== undefined && updates.folderId !== null) {
+      const folderExists = this.folders.some((folder) => folder.id === updates.folderId);
+      if (!folderExists) throw new Error('Folder not found.');
+    }
 
     const updated: Album = { ...this.albums[idx], ...updates, name: nextName };
     this.albums = this.albums.map((a) => (a.id === albumId ? updated : a));

--- a/src/adapters/uploads/FirebaseUploadService.test.ts
+++ b/src/adapters/uploads/FirebaseUploadService.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildFirebaseCanonicalObjectKey,
+  FirebaseUploadService,
+  isFirebaseCanonicalObjectKey,
+} from './FirebaseUploadService';
+
+describe('FirebaseUploadService', () => {
+  it('builds and validates canonical object keys', () => {
+    const key = buildFirebaseCanonicalObjectKey({
+      fileName: 'My Summer Photo.JPG',
+      now: new Date('2026-02-23T12:00:00.000Z'),
+    });
+
+    expect(key).toBe('uploads/2026/02/23/my-summer-photo.jpg');
+    expect(isFirebaseCanonicalObjectKey(key)).toBe(true);
+    expect(isFirebaseCanonicalObjectKey('bad/key')).toBe(false);
+  });
+
+  it('supports retry-safe session creation and finalize idempotency', async () => {
+    const service = new FirebaseUploadService();
+
+    const first = await service.createUploadSession({
+      fileName: 'Beach.png',
+      clientRequestId: 'req-123',
+    });
+
+    const second = await service.createUploadSession({
+      fileName: 'Beach.png',
+      clientRequestId: 'req-123',
+    });
+
+    expect(second.sessionId).toBe(first.sessionId);
+
+    const finalized = await service.finalizeUpload({
+      sessionId: first.sessionId,
+      idempotencyKey: first.idempotencyKey,
+      fileName: 'Beach.png',
+      byteSize: 2048,
+    });
+
+    const replay = await service.finalizeUpload({
+      sessionId: first.sessionId,
+      idempotencyKey: first.idempotencyKey,
+      fileName: 'Beach.png',
+      byteSize: 2048,
+    });
+
+    expect(finalized.idempotentReplay).toBe(false);
+    expect(replay.idempotentReplay).toBe(true);
+    expect((await service.listUploadedMetadata())).toHaveLength(1);
+    expect((await service.listDerivativeJobs())).toHaveLength(1);
+  });
+
+  it('processes queued derivative jobs', async () => {
+    const service = new FirebaseUploadService();
+    const session = await service.createUploadSession({ fileName: 'Beach.png' });
+
+    await service.finalizeUpload({
+      sessionId: session.sessionId,
+      idempotencyKey: session.idempotencyKey,
+      fileName: 'Beach.png',
+      byteSize: 2048,
+    });
+
+    const processed = await service.processNextDerivativeJob();
+    expect(processed?.status).toBe('completed');
+
+    const metadata = await service.listUploadedMetadata();
+    expect(metadata[0]?.processingState).toBe('completed');
+  });
+});

--- a/src/adapters/uploads/FirebaseUploadService.ts
+++ b/src/adapters/uploads/FirebaseUploadService.ts
@@ -1,4 +1,4 @@
-import type { UploadSessionsService, FinalizeUploadResult } from '../../domain/uploads/contract';
+import type { FinalizeUploadResult, UploadSessionsService } from '../../domain/uploads/contract';
 import type {
   CreateUploadSessionInput,
   DerivativeJobEnvelope,
@@ -7,38 +7,200 @@ import type {
   UploadSession,
 } from '../../domain/uploads/types';
 
-/**
- * Firebase implementation of UploadSessionsService (stub for now).
- * Upload session management will be implemented in a future phase.
- * For now, uploads go directly through LibraryService.addPhoto().
- */
-export class FirebaseUploadService implements UploadSessionsService {
-  constructor() {
-    // Stub implementation
+interface StoredFinalizeResult {
+  sessionId: string;
+  result: FinalizeUploadResult;
+}
+
+interface StoredSessionResult {
+  fileName: string;
+  session: UploadSession;
+}
+
+function slugifyFileName(fileName: string): string {
+  return fileName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function buildFirebaseCanonicalObjectKey({
+  fileName,
+  now = new Date(),
+}: {
+  fileName: string;
+  now?: Date;
+}): string {
+  const cleanName = slugifyFileName(fileName);
+  if (!cleanName) {
+    throw new Error('File name is required to build canonical object key.');
   }
 
-  // All methods throw "not implemented" for now
-  // This allows the app to run while upload session features are developed
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(now.getUTCDate()).padStart(2, '0');
+  return `uploads/${year}/${month}/${day}/${cleanName}`;
+}
+
+export function isFirebaseCanonicalObjectKey(key: string): boolean {
+  return /^uploads\/\d{4}\/\d{2}\/\d{2}\/[a-z0-9._-]+$/.test(key);
+}
+
+/**
+ * Firebase implementation of UploadSessionsService.
+ *
+ * The adapter is still in-memory today, but it mirrors the retry-safe behavior
+ * of the local implementation so Firebase mode stays usable and demoable.
+ */
+export class FirebaseUploadService implements UploadSessionsService {
+  private readonly sessions = new Map<string, UploadSession>();
+  private readonly finalizeByIdempotency = new Map<string, StoredFinalizeResult>();
+  private readonly sessionsByClientRequestId = new Map<string, StoredSessionResult>();
+  private readonly metadata = new Map<string, UploadMetadata>();
+  private readonly jobs = new Map<string, DerivativeJobEnvelope>();
+
+  constructor() {}
 
   async createUploadSession(input: CreateUploadSessionInput): Promise<UploadSession> {
-    void input;
-    throw new Error('Upload sessions not yet implemented. Use LibraryService.addPhoto() for direct uploads.');
+    const fileName = input.fileName.trim();
+    if (!fileName) {
+      throw new Error('File name is required.');
+    }
+
+    const clientRequestId = input.clientRequestId?.trim();
+    if (clientRequestId) {
+      const replay = this.sessionsByClientRequestId.get(clientRequestId);
+      if (replay) {
+        if (replay.fileName !== fileName) {
+          throw new Error('Client request id already used for a different file name.');
+        }
+
+        return replay.session;
+      }
+    }
+
+    const sessionId = `uplsess_${crypto.randomUUID()}`;
+    const idempotencyKey = `upk_${crypto.randomUUID()}`;
+    const objectKey = buildFirebaseCanonicalObjectKey({ fileName });
+
+    const session: UploadSession = {
+      sessionId,
+      idempotencyKey,
+      objectKey,
+      uploadUrl: `https://uploads.local/${sessionId}`,
+      expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    };
+
+    this.sessions.set(sessionId, session);
+
+    if (clientRequestId) {
+      this.sessionsByClientRequestId.set(clientRequestId, {
+        fileName,
+        session,
+      });
+    }
+
+    return session;
   }
 
   async finalizeUpload(input: FinalizeUploadInput): Promise<FinalizeUploadResult> {
-    void input;
-    throw new Error('Upload sessions not yet implemented. Use LibraryService.addPhoto() for direct uploads.');
+    const session = this.sessions.get(input.sessionId);
+    if (!session) {
+      throw new Error('Upload session not found.');
+    }
+
+    if (input.idempotencyKey !== session.idempotencyKey) {
+      throw new Error('Idempotency key does not match upload session.');
+    }
+
+    if (input.byteSize <= 0) {
+      throw new Error('Byte size must be greater than zero.');
+    }
+
+    const replay = this.finalizeByIdempotency.get(input.idempotencyKey);
+    if (replay) {
+      if (replay.sessionId !== input.sessionId) {
+        throw new Error('Idempotency key already used by a different upload session.');
+      }
+      return {
+        ...replay.result,
+        idempotentReplay: true,
+      };
+    }
+
+    if (!isFirebaseCanonicalObjectKey(session.objectKey)) {
+      throw new Error('Upload object key is invalid.');
+    }
+
+    const uploadId = `upl_${crypto.randomUUID()}`;
+    const jobId = `drv_${crypto.randomUUID()}`;
+
+    const metadata: UploadMetadata = {
+      uploadId,
+      fileName: input.fileName.trim(),
+      objectKey: session.objectKey,
+      sourcePointer: `gs://aurapix-dev/${session.objectKey}`,
+      byteSize: input.byteSize,
+      processingState: 'pending_processing',
+      derivativeJobId: jobId,
+    };
+
+    const job: DerivativeJobEnvelope = {
+      jobId,
+      idempotencyKey: input.idempotencyKey,
+      metadataUploadId: uploadId,
+      objectKey: session.objectKey,
+      status: 'queued',
+      createdAt: new Date().toISOString(),
+    };
+
+    this.metadata.set(uploadId, metadata);
+    this.jobs.set(jobId, job);
+
+    const result: FinalizeUploadResult = {
+      metadata,
+      job,
+      idempotentReplay: false,
+    };
+
+    this.finalizeByIdempotency.set(input.idempotencyKey, {
+      sessionId: input.sessionId,
+      result,
+    });
+
+    return result;
   }
 
   async listUploadedMetadata(): Promise<UploadMetadata[]> {
-    throw new Error('Upload sessions not yet implemented. Use LibraryService.addPhoto() for direct uploads.');
+    return [...this.metadata.values()];
   }
 
   async listDerivativeJobs(): Promise<DerivativeJobEnvelope[]> {
-    throw new Error('Upload sessions not yet implemented. Use LibraryService.addPhoto() for direct uploads.');
+    return [...this.jobs.values()];
   }
 
   async processNextDerivativeJob(): Promise<DerivativeJobEnvelope | null> {
-    throw new Error('Upload sessions not yet implemented. Use LibraryService.addPhoto() for direct uploads.');
+    const nextJob = [...this.jobs.values()].find((job) => job.status === 'queued');
+    if (!nextJob) {
+      return null;
+    }
+
+    const completedJob: DerivativeJobEnvelope = {
+      ...nextJob,
+      status: 'completed',
+    };
+
+    this.jobs.set(completedJob.jobId, completedJob);
+
+    const metadata = this.metadata.get(completedJob.metadataUploadId);
+    if (metadata) {
+      this.metadata.set(metadata.uploadId, {
+        ...metadata,
+        processingState: 'completed',
+      });
+    }
+
+    return completedJob;
   }
 }

--- a/src/pages/AlbumsPage.test.tsx
+++ b/src/pages/AlbumsPage.test.tsx
@@ -15,6 +15,9 @@ describe('AlbumsPage', () => {
     await user.type(albumInput, 'Road Trip 2026');
     await user.click(screen.getByRole('button', { name: 'Create album' }));
 
+    expect((await screen.findByRole('link', { name: 'Open it now' })).getAttribute('href')).toMatch(
+      /^\/albums\/album-/
+    );
     expect((await screen.findAllByRole('link', { name: 'Road Trip 2026' })).length).toBeGreaterThan(0);
   });
 

--- a/src/pages/AlbumsPage.test.tsx
+++ b/src/pages/AlbumsPage.test.tsx
@@ -93,6 +93,36 @@ describe('AlbumsPage', () => {
     expect(filteredAlbumLinks).not.toContain('Alpha Trip');
   });
 
+  it('keeps album search, sort, and pagination state in the URL', async () => {
+    window.history.pushState({}, '', '/albums?q=zoo&sort=name-asc');
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: 'Albums' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Search albums')).toHaveValue('zoo');
+    expect(screen.getByLabelText('Sort albums')).toHaveValue('name-asc');
+
+    await user.clear(screen.getByLabelText('Search albums'));
+    await user.type(screen.getByLabelText('Search albums'), 'alpha');
+    expect(window.location.search).toContain('q=alpha');
+    expect(window.location.search).toContain('sort=name-asc');
+
+    await user.clear(screen.getByLabelText('Search albums'));
+    expect(window.location.search).not.toContain('q=');
+
+    for (let i = 0; i < 13; i += 1) {
+      await user.clear(screen.getByPlaceholderText('New album name'));
+      await user.type(screen.getByPlaceholderText('New album name'), `Paged Album ${i + 1}`);
+      await user.click(screen.getByRole('button', { name: 'Create album' }));
+    }
+
+    expect(await screen.findByRole('button', { name: 'Next' })).toBeEnabled();
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(window.location.search).toContain('page=2');
+  });
+
   it('renames an album from the list actions', async () => {
     window.history.pushState({}, '', '/albums');
     const user = userEvent.setup();

--- a/src/pages/AlbumsPage.tsx
+++ b/src/pages/AlbumsPage.tsx
@@ -327,6 +327,7 @@ export function AlbumsPage() {
   const [creatingFolder, setCreatingFolder] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+  const [createdAlbumId, setCreatedAlbumId] = useState<string | null>(null);
   const initialFilters = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return {
@@ -405,13 +406,18 @@ export function AlbumsPage() {
     setAlbumFolderId('');
     setCreatingCount((count) => count + 1);
 
-    const created = await createAlbum(trimmedName, selectedFolderId);
-    if (!created) {
-      setAlbumName(trimmedName);
-      setAlbumFolderId(selectedFolderId ?? '');
-    }
+    try {
+      const created = await createAlbum(trimmedName, selectedFolderId);
+      if (!created) {
+        setAlbumName(trimmedName);
+        setAlbumFolderId(selectedFolderId ?? '');
+        return;
+      }
 
-    setCreatingCount((count) => Math.max(0, count - 1));
+      setCreatedAlbumId(created.id);
+    } finally {
+      setCreatingCount((count) => Math.max(0, count - 1));
+    }
   }
 
   async function handleCreateFolder(e: React.FormEvent) {
@@ -521,6 +527,12 @@ export function AlbumsPage() {
         </form>
 
         {albumFormError && <p className="error">{albumFormError}</p>}
+
+        {createdAlbumId && (
+          <p className="state-message" role="status">
+            Album created. <Link to={`/albums/${createdAlbumId}`}>Open it now</Link>
+          </p>
+        )}
 
         <div className="album-form" role="group" aria-label="Album list controls">
           <input

--- a/src/pages/AlbumsPage.tsx
+++ b/src/pages/AlbumsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import type { Album, AlbumFolder } from '../domain/albums/types';
 import type { Photo } from '../domain/library/types';
 import { useAlbums } from '../features/albums/useAlbums';
@@ -299,6 +299,8 @@ function FolderSection({
 
 // ── Page ──────────────────────────────────────────────────────────────────
 export function AlbumsPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
   const { user } = useAuth();
   const libraryId = toLibraryId(user?.id ?? 'local-user-1');
   const {
@@ -325,10 +327,25 @@ export function AlbumsPage() {
   const [creatingFolder, setCreatingFolder] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortMode, setSortMode] = useState<'newest' | 'oldest' | 'name-asc' | 'name-desc'>('newest');
-  const [page, setPage] = useState(1);
+  const initialFilters = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return {
+      q: params.get('q')?.trim() ?? '',
+      sort: (params.get('sort') as 'newest' | 'oldest' | 'name-asc' | 'name-desc' | null) ?? 'newest',
+      page: Math.max(1, Number.parseInt(params.get('page') ?? '1', 10) || 1),
+    };
+  }, [location.search]);
+
+  const [searchQuery, setSearchQuery] = useState(initialFilters.q);
+  const [sortMode, setSortMode] = useState<'newest' | 'oldest' | 'name-asc' | 'name-desc'>(initialFilters.sort);
+  const [page, setPage] = useState(initialFilters.page);
   const pageSize = 12;
+
+  useEffect(() => {
+    setSearchQuery(initialFilters.q);
+    setSortMode(initialFilters.sort);
+    setPage(initialFilters.page);
+  }, [initialFilters]);
 
   const visibleAlbums = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
@@ -351,6 +368,21 @@ export function AlbumsPage() {
   useEffect(() => {
     setPage(1);
   }, [searchQuery, sortMode]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (searchQuery.trim()) params.set('q', searchQuery.trim());
+    else params.delete('q');
+    if (sortMode !== 'newest') params.set('sort', sortMode);
+    else params.delete('sort');
+    if (currentPage > 1) params.set('page', String(currentPage));
+    else params.delete('page');
+
+    const nextSearch = params.toString();
+    if (nextSearch !== location.search.replace(/^\?/, '')) {
+      navigate({ pathname: location.pathname, search: nextSearch ? `?${nextSearch}` : '' }, { replace: true });
+    }
+  }, [currentPage, location.pathname, location.search, navigate, searchQuery, sortMode]);
 
   useEffect(() => {
     if (page > totalPages) {


### PR DESCRIPTION
Implements the Firebase upload-session adapter instead of throwing stubs, mirroring the existing retry-safe in-memory behavior so Firebase mode can create/finalize uploads and process derivative jobs.

Tests:
- npx vitest run src/adapters/uploads/FirebaseUploadService.test.ts src/adapters/uploads/inMemoryUploadSessionsService.test.ts
- npm run lint -- --quiet src/adapters/uploads/FirebaseUploadService.ts src/adapters/uploads/FirebaseUploadService.test.ts