### PR TITLE
HUD-111: add Firebase emulator gate coverage for upload-session flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Validate Firestore indexes (upload-session paths)
+        run: npm run firestore:indexes:validate
+
+      - name: Targeted Firebase upload-session adapter tests
+        run: npm run test:uploads:firebase-adapter
+
+      - name: Firestore emulator upload-session integration tests
+        run: npm run test:uploads:firebase-emulator
+
       - name: Lint
         run: npm run lint
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,35 @@ npm run test:coverage
 npm run contract:check
 ```
 
+### Upload-session CI parity checks
+
+Run these before opening a PR that touches upload-session/query/index paths:
+
+```bash
+# from AuraPix repo root
+npm ci
+npm run firestore:indexes:validate
+npm run test:uploads:firebase-adapter
+npm run test:uploads:firebase-emulator
+```
+
+`npm run test:uploads:firebase-emulator` now includes a deterministic preflight that fails fast with actionable output when Java, emulator tooling, or required files are missing.
+
+### Firebase Emulator Prerequisites
+
+The upload emulator test command is designed to be one-command runnable from a fresh checkout after dependency install:
+
+```bash
+npm ci
+npm run test:uploads:firebase-emulator
+```
+
+Preflight requirements:
+- Java runtime available on `PATH` (`java -version` succeeds).
+- Root dependencies installed (`node_modules` exists).
+- `functions/firebase.json` and the emulator test file exist.
+- `npx -y firebase-tools@14.3.1 --version` is executable.
+
 ## Architecture
 
 AuraPix follows a clean architecture approach with:

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -247,6 +247,22 @@ cd functions
 npm run test:integration
 ```
 
+### Firebase Upload Emulator Validation
+
+Run this from the AuraPix repo root to execute the upload integration suite against Firestore emulator:
+
+```bash
+npm run test:uploads:firebase-emulator
+```
+
+The command performs an automatic preflight before emulator startup. If prerequisites are missing, it exits with explicit remediation steps.
+
+Preflight checks:
+- Java runtime available on `PATH`.
+- Root dependencies already installed.
+- Required project files (`functions/firebase.json`, emulator test file) exist.
+- `firebase-tools@14.3.1` can be invoked via `npx`.
+
 ## Next Steps
 
 - Review [Architecture Documentation](../IMPLEMENTATION_PLAN.md)

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -83,6 +83,92 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "uploadSessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "ownerUserId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "clientRequestId",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "uploadMetadata",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "ownerUserId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "idempotencyKey",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "uploadMetadata",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "ownerUserId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "ownerLibraryId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "derivativeJobs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "ownerUserId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "ownerLibraryId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "derivativeJobs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "ownerUserId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "ownerLibraryId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/firebase.json
+++ b/functions/firebase.json
@@ -11,7 +11,7 @@
       "port": 5001
     },
     "firestore": {
-      "port": 8080
+      "port": 8085
     },
     "storage": {
       "port": 9199

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "contract:validate": "node scripts/validate-contract.mjs",
     "contract:breaking": "node scripts/check-contract-breaking.mjs",
     "contract:check": "npm run contract:validate && npm run contract:breaking",
+    "firestore:indexes:validate": "node scripts/validate-firestore-indexes.mjs",
+    "test:uploads:firebase-adapter": "vitest src/adapters/uploads/FirebaseUploadService.test.ts",
+    "preflight:uploads:firebase-emulator": "node scripts/check-firebase-emulator-prereqs.mjs",
+    "test:uploads:firebase-emulator": "npm run preflight:uploads:firebase-emulator && npx -y firebase-tools@14.3.1 emulators:exec --project demo-aurapix --config functions/firebase.json \"vitest run src/adapters/uploads/FirebaseUploadService.emulator.test.ts\"",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:backend": "npm --prefix functions run build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest --exclude src/**/*.emulator.test.ts",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "contract:validate": "node scripts/validate-contract.mjs",

--- a/scripts/check-firebase-emulator-prereqs.mjs
+++ b/scripts/check-firebase-emulator-prereqs.mjs
@@ -1,0 +1,116 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+
+const FIREBASE_TOOLS_VERSION = '14.3.1';
+const FIREBASE_CONFIG_PATH = 'functions/firebase.json';
+const EMULATOR_TEST_PATH = 'src/adapters/uploads/FirebaseUploadService.emulator.test.ts';
+
+function runCommand(command, args) {
+  return spawnSync(command, args, {
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+}
+
+function formatStderr(text) {
+  return text?.trim() ? `\n${text.trim()}` : '';
+}
+
+function fail(lines) {
+  console.error('Firebase emulator preflight failed.\n');
+  for (const line of lines) {
+    console.error(`- ${line}`);
+  }
+  process.exit(1);
+}
+
+function checkJava() {
+  const result = runCommand('java', ['-version']);
+  if (result.error || result.status !== 0) {
+    const detail =
+      result.error?.code === 'ENOENT'
+        ? 'Install Java (JRE/JDK) and ensure `java` is on your PATH.'
+        : `java -version exited with status ${result.status}.${formatStderr(result.stderr)}`;
+    fail([
+      'Java runtime is required by Firestore emulator but was not available.',
+      detail,
+      'After installing Java, rerun: npm run test:uploads:firebase-emulator',
+    ]);
+  }
+}
+
+function checkNodeModules() {
+  if (!fs.existsSync('node_modules')) {
+    fail([
+      'Root dependencies are missing (`node_modules` not found).',
+      'Run `npm install` (or `npm ci`) from the AuraPix repo root, then rerun this command.',
+    ]);
+  }
+}
+
+function checkProjectFiles() {
+  const missing = [FIREBASE_CONFIG_PATH, EMULATOR_TEST_PATH].filter((path) => !fs.existsSync(path));
+  if (missing.length > 0) {
+    fail([
+      `Required project files are missing: ${missing.join(', ')}`,
+      'Run this command from the AuraPix repo root and ensure your branch includes emulator test assets.',
+    ]);
+  }
+}
+
+function loadFirebaseEmulatorPorts() {
+  const raw = fs.readFileSync(FIREBASE_CONFIG_PATH, 'utf8');
+  const parsed = JSON.parse(raw);
+  const emulators = parsed.emulators ?? {};
+
+  return Object.entries(emulators)
+    .filter(([, value]) => typeof value === 'object' && value !== null && Number.isInteger(value.port))
+    .map(([name, value]) => ({ name, port: value.port }));
+}
+
+function assertPortAvailable(port) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+async function checkConfiguredEmulatorPortsAvailable() {
+  const configuredPorts = loadFirebaseEmulatorPorts();
+  for (const emulator of configuredPorts) {
+    const available = await assertPortAvailable(emulator.port);
+    if (!available) {
+      fail([
+        `Configured emulator port is already in use: ${emulator.name} -> ${emulator.port}`,
+        `Free the port or change ${FIREBASE_CONFIG_PATH} -> emulators.${emulator.name}.port, then rerun this command.`,
+      ]);
+    }
+  }
+}
+
+function checkFirebaseTools() {
+  const result = runCommand('npx', ['-y', `firebase-tools@${FIREBASE_TOOLS_VERSION}`, '--version']);
+  if (result.error || result.status !== 0) {
+    fail([
+      `Unable to execute firebase-tools@${FIREBASE_TOOLS_VERSION} via npx.`,
+      result.error?.message ?? `Command exited with status ${result.status}.${formatStderr(result.stderr)}`,
+      'Check network access/npm registry settings, then rerun this command.',
+    ]);
+  }
+}
+
+async function main() {
+  checkNodeModules();
+  checkProjectFiles();
+  checkJava();
+  checkFirebaseTools();
+  await checkConfiguredEmulatorPortsAvailable();
+  console.log('Firebase emulator preflight passed (Java + firebase-tools + project files).');
+}
+
+await main();

--- a/scripts/validate-firestore-indexes.mjs
+++ b/scripts/validate-firestore-indexes.mjs
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+
+const INDEX_PATH = 'firestore.indexes.json';
+
+const REQUIRED_INDEXES = [
+  {
+    collectionGroup: 'uploadSessions',
+    fields: [
+      { fieldPath: 'ownerUserId', order: 'ASCENDING' },
+      { fieldPath: 'clientRequestId', order: 'ASCENDING' },
+    ],
+  },
+  {
+    collectionGroup: 'uploadMetadata',
+    fields: [
+      { fieldPath: 'ownerUserId', order: 'ASCENDING' },
+      { fieldPath: 'idempotencyKey', order: 'ASCENDING' },
+    ],
+  },
+  {
+    collectionGroup: 'uploadMetadata',
+    fields: [
+      { fieldPath: 'ownerUserId', order: 'ASCENDING' },
+      { fieldPath: 'ownerLibraryId', order: 'ASCENDING' },
+      { fieldPath: 'createdAt', order: 'DESCENDING' },
+    ],
+  },
+  {
+    collectionGroup: 'derivativeJobs',
+    fields: [
+      { fieldPath: 'ownerUserId', order: 'ASCENDING' },
+      { fieldPath: 'ownerLibraryId', order: 'ASCENDING' },
+      { fieldPath: 'createdAt', order: 'ASCENDING' },
+    ],
+  },
+  {
+    collectionGroup: 'derivativeJobs',
+    fields: [
+      { fieldPath: 'ownerUserId', order: 'ASCENDING' },
+      { fieldPath: 'ownerLibraryId', order: 'ASCENDING' },
+      { fieldPath: 'status', order: 'ASCENDING' },
+      { fieldPath: 'createdAt', order: 'ASCENDING' },
+    ],
+  },
+];
+
+function loadIndexFile() {
+  const raw = fs.readFileSync(INDEX_PATH, 'utf8');
+  const parsed = JSON.parse(raw);
+
+  if (!Array.isArray(parsed.indexes)) {
+    throw new Error(`${INDEX_PATH} must contain an "indexes" array.`);
+  }
+
+  return parsed.indexes;
+}
+
+function normalizeIndex(index) {
+  const fields = Array.isArray(index.fields) ? index.fields : [];
+  const fieldKey = fields
+    .map((field) => {
+      const mode = field.order ?? field.arrayConfig ?? 'UNKNOWN';
+      return `${field.fieldPath}:${mode}`;
+    })
+    .join(',');
+  return `${index.collectionGroup}|${fieldKey}`;
+}
+
+function describeIndex(index) {
+  return `${index.collectionGroup} [${index.fields
+    .map((field) => `${field.fieldPath}:${field.order ?? field.arrayConfig ?? 'UNKNOWN'}`)
+    .join(', ')}]`;
+}
+
+function main() {
+  const indexes = loadIndexFile();
+  const available = new Set(indexes.map(normalizeIndex));
+
+  const missing = REQUIRED_INDEXES.filter((required) => !available.has(normalizeIndex(required)));
+
+  if (missing.length > 0) {
+    console.error('Firestore index validation failed. Missing required indexes:');
+    for (const index of missing) {
+      console.error(`- ${describeIndex(index)}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Firestore index validation passed (${REQUIRED_INDEXES.length} required indexes present).`);
+}
+
+main();

--- a/src/adapters/uploads/FirebaseUploadService.emulator.test.ts
+++ b/src/adapters/uploads/FirebaseUploadService.emulator.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { deleteApp, initializeApp, type FirebaseApp } from 'firebase/app';
+import { connectFirestoreEmulator, getFirestore, terminate, type Firestore } from 'firebase/firestore';
+import { FirebaseUploadService } from './FirebaseUploadService';
+
+interface ServiceHarness {
+  app: FirebaseApp;
+  db: Firestore;
+  service: FirebaseUploadService;
+}
+
+const createdHarnesses: ServiceHarness[] = [];
+
+function getEmulatorHostPort(): { host: string; port: number } {
+  const rawHost = process.env.FIRESTORE_EMULATOR_HOST;
+  if (!rawHost) {
+    throw new Error('FIRESTORE_EMULATOR_HOST must be set. Run this suite with firebase emulators:exec.');
+  }
+
+  const [host, portText] = rawHost.split(':');
+  const port = Number(portText);
+  if (!host || Number.isNaN(port) || port <= 0) {
+    throw new Error(`Invalid FIRESTORE_EMULATOR_HOST value: ${rawHost}`);
+  }
+
+  return { host, port };
+}
+
+function createServiceHarness(userId: string, libraryId?: string): ServiceHarness {
+  const { host, port } = getEmulatorHostPort();
+  const app = initializeApp(
+    {
+      apiKey: 'demo-key',
+      appId: `aurapix-emulator-${crypto.randomUUID()}`,
+      projectId: process.env.GCLOUD_PROJECT ?? 'demo-aurapix',
+    },
+    `aurapix-emulator-${crypto.randomUUID()}`,
+  );
+  const db = getFirestore(app);
+  connectFirestoreEmulator(db, host, port);
+
+  const service = new FirebaseUploadService(db, {
+    userId,
+    libraryId,
+    now: () => 1_700_000_000_000,
+  });
+
+  const harness = { app, db, service };
+  createdHarnesses.push(harness);
+  return harness;
+}
+
+afterEach(async () => {
+  while (createdHarnesses.length > 0) {
+    const harness = createdHarnesses.pop();
+    if (!harness) {
+      continue;
+    }
+
+    await terminate(harness.db);
+    await deleteApp(harness.app);
+  }
+});
+
+describe('FirebaseUploadService (Firestore emulator)', () => {
+  it('creates upload sessions and replays by client request id', async () => {
+    const { service } = createServiceHarness(`user-${crypto.randomUUID()}`);
+
+    const first = await service.createUploadSession({
+      fileName: 'Photo.JPG',
+      clientRequestId: 'req-1',
+    });
+    const replay = await service.createUploadSession({
+      fileName: 'Photo.JPG',
+      clientRequestId: 'req-1',
+    });
+
+    expect(replay).toEqual(first);
+    expect(first.sessionId).toMatch(/^uplsess_/);
+    expect(first.idempotencyKey).toMatch(/^upk_/);
+    expect(first.objectKey).toMatch(/^uploads\/\d{4}\/\d{2}\/\d{2}\/photo\.jpg$/);
+    expect(first.uploadUrl).toContain(first.sessionId);
+  });
+
+  it('finalizes uploads with idempotent replay and queue processing', async () => {
+    const { service } = createServiceHarness(`user-${crypto.randomUUID()}`);
+    const session = await service.createUploadSession({ fileName: 'photo.jpg' });
+
+    const firstFinalize = await service.finalizeUpload({
+      sessionId: session.sessionId,
+      idempotencyKey: session.idempotencyKey,
+      fileName: 'photo.jpg',
+      byteSize: 2048,
+    });
+    expect(firstFinalize.idempotentReplay).toBe(false);
+    expect(firstFinalize.metadata.processingState).toBe('pending_processing');
+    expect(firstFinalize.job.status).toBe('queued');
+
+    const replayFinalize = await service.finalizeUpload({
+      sessionId: session.sessionId,
+      idempotencyKey: session.idempotencyKey,
+      fileName: 'photo.jpg',
+      byteSize: 2048,
+    });
+    expect(replayFinalize.idempotentReplay).toBe(true);
+    expect(replayFinalize.metadata.uploadId).toBe(firstFinalize.metadata.uploadId);
+    expect(replayFinalize.job.jobId).toBe(firstFinalize.job.jobId);
+
+    const metadataBeforeProcessing = await service.listUploadedMetadata();
+    const jobsBeforeProcessing = await service.listDerivativeJobs();
+    expect(metadataBeforeProcessing).toHaveLength(1);
+    expect(jobsBeforeProcessing).toHaveLength(1);
+    expect(jobsBeforeProcessing[0].status).toBe('queued');
+
+    const processedJob = await service.processNextDerivativeJob();
+    expect(processedJob).not.toBeNull();
+    expect(processedJob?.status).toBe('completed');
+
+    const metadataAfterProcessing = await service.listUploadedMetadata();
+    const jobsAfterProcessing = await service.listDerivativeJobs();
+    expect(metadataAfterProcessing[0].processingState).toBe('completed');
+    expect(jobsAfterProcessing[0].status).toBe('completed');
+  });
+
+  it('enforces owner user and owner library scoping', async () => {
+    const ownerUserId = `user-${crypto.randomUUID()}`;
+    const { service: ownerLibraryA } = createServiceHarness(ownerUserId, 'library-a');
+    const { service: ownerLibraryB } = createServiceHarness(ownerUserId, 'library-b');
+    const { service: otherUser } = createServiceHarness(`user-${crypto.randomUUID()}`, 'library-a');
+
+    const session = await ownerLibraryA.createUploadSession({ fileName: 'scoped.jpg' });
+    await ownerLibraryA.finalizeUpload({
+      sessionId: session.sessionId,
+      idempotencyKey: session.idempotencyKey,
+      fileName: 'scoped.jpg',
+      byteSize: 1024,
+    });
+
+    expect(await ownerLibraryA.listUploadedMetadata()).toHaveLength(1);
+    expect(await ownerLibraryA.listDerivativeJobs()).toHaveLength(1);
+
+    expect(await ownerLibraryB.listUploadedMetadata()).toHaveLength(0);
+    expect(await ownerLibraryB.listDerivativeJobs()).toHaveLength(0);
+    expect(await otherUser.listUploadedMetadata()).toHaveLength(0);
+    expect(await otherUser.listDerivativeJobs()).toHaveLength(0);
+
+    await expect(
+      ownerLibraryB.finalizeUpload({
+        sessionId: session.sessionId,
+        idempotencyKey: session.idempotencyKey,
+        fileName: 'scoped.jpg',
+        byteSize: 1024,
+      }),
+    ).rejects.toThrow('Upload session not found.');
+  });
+});

--- a/src/adapters/uploads/FirebaseUploadService.test.ts
+++ b/src/adapters/uploads/FirebaseUploadService.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type FirestoreDoc = Record<string, unknown>;
+
+interface CollectionRefMock {
+  path: string;
+}
+
+interface DocRefMock {
+  collectionPath: string;
+  id: string;
+}
+
+interface WhereConstraint {
+  kind: 'where';
+  fieldPath: string;
+  value: unknown;
+}
+
+interface OrderByConstraint {
+  kind: 'orderBy';
+  fieldPath: string;
+  direction: 'asc' | 'desc';
+}
+
+interface LimitConstraint {
+  kind: 'limit';
+  value: number;
+}
+
+type QueryConstraintMock = WhereConstraint | OrderByConstraint | LimitConstraint;
+
+interface QueryRefMock {
+  collectionPath: string;
+  constraints: QueryConstraintMock[];
+}
+
+const dbState = new Map<string, Map<string, FirestoreDoc>>();
+let nextAutoId = 0;
+
+function ensureCollection(path: string): Map<string, FirestoreDoc> {
+  const existing = dbState.get(path);
+  if (existing) {
+    return existing;
+  }
+  const created = new Map<string, FirestoreDoc>();
+  dbState.set(path, created);
+  return created;
+}
+
+function cloneDoc(docData: FirestoreDoc): FirestoreDoc {
+  return { ...docData };
+}
+
+function applyConstraints(docs: Array<{ id: string; data: FirestoreDoc }>, constraints: QueryConstraintMock[]) {
+  let result = docs;
+
+  for (const constraint of constraints) {
+    if (constraint.kind === 'where') {
+      result = result.filter((docEntry) => docEntry.data[constraint.fieldPath] === constraint.value);
+    }
+  }
+
+  for (const constraint of constraints) {
+    if (constraint.kind === 'orderBy') {
+      result = [...result].sort((left, right) => {
+        const leftValue = left.data[constraint.fieldPath];
+        const rightValue = right.data[constraint.fieldPath];
+
+        if (leftValue === rightValue) {
+          return 0;
+        }
+        if (leftValue === undefined) {
+          return 1;
+        }
+        if (rightValue === undefined) {
+          return -1;
+        }
+
+        const comparison = String(leftValue).localeCompare(String(rightValue));
+        return constraint.direction === 'asc' ? comparison : comparison * -1;
+      });
+    }
+  }
+
+  const limitConstraint = constraints.find((constraint) => constraint.kind === 'limit') as
+    | LimitConstraint
+    | undefined;
+  if (limitConstraint) {
+    result = result.slice(0, limitConstraint.value);
+  }
+
+  return result;
+}
+
+vi.mock('firebase/firestore', () => {
+  return {
+    collection: (_db: unknown, path: string): CollectionRefMock => ({ path }),
+    doc: (first: unknown, second: string, third?: string): DocRefMock => {
+      if (typeof third === 'string') {
+        return {
+          collectionPath: second,
+          id: third,
+        };
+      }
+
+      return {
+        collectionPath: (first as CollectionRefMock).path,
+        id: second,
+      };
+    },
+    where: (fieldPath: string, op: string, value: unknown): WhereConstraint => {
+      if (op !== '==') {
+        throw new Error(`Unsupported where operator in test mock: ${op}`);
+      }
+      return {
+        kind: 'where',
+        fieldPath,
+        value,
+      };
+    },
+    orderBy: (fieldPath: string, direction: 'asc' | 'desc' = 'asc'): OrderByConstraint => ({
+      kind: 'orderBy',
+      fieldPath,
+      direction,
+    }),
+    limit: (value: number): LimitConstraint => ({
+      kind: 'limit',
+      value,
+    }),
+    query: (collectionRef: CollectionRefMock, ...constraints: QueryConstraintMock[]): QueryRefMock => ({
+      collectionPath: collectionRef.path,
+      constraints,
+    }),
+    setDoc: async (docRef: DocRefMock, data: FirestoreDoc): Promise<void> => {
+      const collectionStore = ensureCollection(docRef.collectionPath);
+      collectionStore.set(docRef.id, cloneDoc(data));
+    },
+    addDoc: async (collectionRef: CollectionRefMock, data: FirestoreDoc): Promise<{ id: string }> => {
+      const collectionStore = ensureCollection(collectionRef.path);
+      const id = `auto_${nextAutoId++}`;
+      collectionStore.set(id, cloneDoc(data));
+      return { id };
+    },
+    updateDoc: async (docRef: DocRefMock, updates: FirestoreDoc): Promise<void> => {
+      const collectionStore = ensureCollection(docRef.collectionPath);
+      const existing = collectionStore.get(docRef.id);
+      if (!existing) {
+        throw new Error(`Doc not found: ${docRef.collectionPath}/${docRef.id}`);
+      }
+      collectionStore.set(docRef.id, { ...existing, ...updates });
+    },
+    getDoc: async (docRef: DocRefMock) => {
+      const collectionStore = ensureCollection(docRef.collectionPath);
+      const data = collectionStore.get(docRef.id);
+      return {
+        id: docRef.id,
+        exists: () => Boolean(data),
+        data: () => cloneDoc(data ?? {}),
+      };
+    },
+    getDocs: async (target: QueryRefMock | CollectionRefMock) => {
+      const isQuery = 'constraints' in target;
+      const collectionPath = target.collectionPath ?? target.path;
+      const constraints = isQuery ? target.constraints : [];
+      const collectionStore = ensureCollection(collectionPath);
+      const rawDocs = [...collectionStore.entries()].map(([id, data]) => ({
+        id,
+        data,
+      }));
+      const docs = applyConstraints(rawDocs, constraints).map((entry) => ({
+        id: entry.id,
+        data: () => cloneDoc(entry.data),
+      }));
+      return {
+        empty: docs.length === 0,
+        docs,
+      };
+    },
+  };
+});
+
+import { FirebaseUploadService } from './FirebaseUploadService';
+
+describe('FirebaseUploadService', () => {
+  beforeEach(() => {
+    dbState.clear();
+    nextAutoId = 0;
+  });
+
+  it('creates upload sessions and replays by client request id', async () => {
+    const service = new FirebaseUploadService({} as never, { userId: 'user-1', now: () => 1_700_000_000_000 });
+
+    const first = await service.createUploadSession({
+      fileName: 'Photo.JPG',
+      clientRequestId: 'req-1',
+    });
+
+    const replay = await service.createUploadSession({
+      fileName: 'Photo.JPG',
+      clientRequestId: 'req-1',
+    });
+
+    expect(replay).toEqual(first);
+    expect(first.sessionId).toMatch(/^uplsess_/);
+    expect(first.idempotencyKey).toMatch(/^upk_/);
+    expect(first.objectKey).toMatch(/^uploads\/\d{4}\/\d{2}\/\d{2}\/photo\.jpg$/);
+    expect(first.uploadUrl).toContain(first.sessionId);
+  });
+
+  it('finalizes uploads with idempotent replay and queue processing', async () => {
+    const service = new FirebaseUploadService({} as never, { userId: 'user-1', now: () => 1_700_000_000_000 });
+    const session = await service.createUploadSession({ fileName: 'photo.jpg' });
+
+    const firstFinalize = await service.finalizeUpload({
+      sessionId: session.sessionId,
+      idempotencyKey: session.idempotencyKey,
+      fileName: 'photo.jpg',
+      byteSize: 2048,
+    });
+
+    expect(firstFinalize.idempotentReplay).toBe(false);
+    expect(firstFinalize.metadata.processingState).toBe('pending_processing');
+    expect(firstFinalize.job.status).toBe('queued');
+
+    const replayFinalize = await service.finalizeUpload({
+      sessionId: session.sessionId,
+      idempotencyKey: session.idempotencyKey,
+      fileName: 'photo.jpg',
+      byteSize: 2048,
+    });
+
+    expect(replayFinalize.idempotentReplay).toBe(true);
+    expect(replayFinalize.metadata.uploadId).toBe(firstFinalize.metadata.uploadId);
+    expect(replayFinalize.job.jobId).toBe(firstFinalize.job.jobId);
+
+    const metadataBeforeProcessing = await service.listUploadedMetadata();
+    const jobsBeforeProcessing = await service.listDerivativeJobs();
+    expect(metadataBeforeProcessing).toHaveLength(1);
+    expect(jobsBeforeProcessing).toHaveLength(1);
+    expect(jobsBeforeProcessing[0].status).toBe('queued');
+
+    const processedJob = await service.processNextDerivativeJob();
+    expect(processedJob).not.toBeNull();
+    expect(processedJob?.status).toBe('completed');
+
+    const metadataAfterProcessing = await service.listUploadedMetadata();
+    const jobsAfterProcessing = await service.listDerivativeJobs();
+    expect(metadataAfterProcessing[0].processingState).toBe('completed');
+    expect(jobsAfterProcessing[0].status).toBe('completed');
+  });
+
+  it('scopes metadata and jobs by user', async () => {
+    const alice = new FirebaseUploadService({} as never, { userId: 'alice', now: () => 1_700_000_000_000 });
+    const bob = new FirebaseUploadService({} as never, { userId: 'bob', now: () => 1_700_000_000_000 });
+
+    const aliceSession = await alice.createUploadSession({ fileName: 'alice.jpg' });
+    await alice.finalizeUpload({
+      sessionId: aliceSession.sessionId,
+      idempotencyKey: aliceSession.idempotencyKey,
+      fileName: 'alice.jpg',
+      byteSize: 1024,
+    });
+
+    expect(await alice.listUploadedMetadata()).toHaveLength(1);
+    expect(await alice.listDerivativeJobs()).toHaveLength(1);
+    expect(await bob.listUploadedMetadata()).toHaveLength(0);
+    expect(await bob.listDerivativeJobs()).toHaveLength(0);
+  });
+});

--- a/src/adapters/uploads/FirebaseUploadService.test.ts
+++ b/src/adapters/uploads/FirebaseUploadService.test.ts
@@ -161,7 +161,7 @@ vi.mock('firebase/firestore', () => {
     },
     getDocs: async (target: QueryRefMock | CollectionRefMock) => {
       const isQuery = 'constraints' in target;
-      const collectionPath = target.collectionPath ?? target.path;
+      const collectionPath = isQuery ? target.collectionPath : target.path;
       const constraints = isQuery ? target.constraints : [];
       const collectionStore = ensureCollection(collectionPath);
       const rawDocs = [...collectionStore.entries()].map(([id, data]) => ({

--- a/src/adapters/uploads/FirebaseUploadService.ts
+++ b/src/adapters/uploads/FirebaseUploadService.ts
@@ -1,3 +1,16 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  limit as firestoreLimit,
+  orderBy,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+  type Firestore,
+} from 'firebase/firestore';
 import type { UploadSessionsService, FinalizeUploadResult } from '../../domain/uploads/contract';
 import type {
   CreateUploadSessionInput,
@@ -6,39 +19,296 @@ import type {
   UploadMetadata,
   UploadSession,
 } from '../../domain/uploads/types';
+import { COLLECTIONS } from '../../config/collections';
+import {
+  buildCanonicalObjectKey,
+  isValidCanonicalObjectKey,
+} from './inMemoryUploadSessionsService';
 
-/**
- * Firebase implementation of UploadSessionsService (stub for now).
- * Upload session management will be implemented in a future phase.
- * For now, uploads go directly through LibraryService.addPhoto().
- */
+interface FirebaseUploadServiceOptions {
+  userId: string;
+  libraryId?: string;
+  now?: () => number;
+}
+
+interface StoredUploadSession {
+  ownerUserId: string;
+  ownerLibraryId: string;
+  fileName: string;
+  idempotencyKey: string;
+  objectKey: string;
+  uploadUrl: string;
+  expiresAt: string;
+  clientRequestId: string | null;
+  createdAt: string;
+}
+
+interface StoredUploadMetadata {
+  ownerUserId: string;
+  ownerLibraryId: string;
+  sessionId: string;
+  idempotencyKey: string;
+  fileName: string;
+  objectKey: string;
+  sourcePointer: string;
+  byteSize: number;
+  processingState: UploadMetadata['processingState'];
+  derivativeJobId: string;
+  createdAt: string;
+}
+
+interface StoredDerivativeJob {
+  ownerUserId: string;
+  ownerLibraryId: string;
+  idempotencyKey: string;
+  metadataUploadId: string;
+  objectKey: string;
+  status: DerivativeJobEnvelope['status'];
+  createdAt: string;
+}
+
 export class FirebaseUploadService implements UploadSessionsService {
-  constructor() {
-    // Stub implementation
+  private readonly ownerUserId: string;
+  private readonly ownerLibraryId: string;
+  private readonly now: () => number;
+
+  constructor(
+    private readonly db: Firestore,
+    options: FirebaseUploadServiceOptions,
+  ) {
+    this.ownerUserId = options.userId;
+    this.ownerLibraryId = options.libraryId ?? `library-${options.userId}`;
+    this.now = options.now ?? Date.now;
   }
 
-  // All methods throw "not implemented" for now
-  // This allows the app to run while upload session features are developed
-
   async createUploadSession(input: CreateUploadSessionInput): Promise<UploadSession> {
-    void input;
-    throw new Error('Upload sessions not yet implemented. Use LibraryService.addPhoto() for direct uploads.');
+    const fileName = input.fileName.trim();
+    if (!fileName) {
+      throw new Error('File name is required.');
+    }
+
+    const clientRequestId = input.clientRequestId?.trim();
+    if (clientRequestId) {
+      const replayQuery = query(
+        collection(this.db, COLLECTIONS.UPLOAD_SESSIONS),
+        where('ownerUserId', '==', this.ownerUserId),
+        where('clientRequestId', '==', clientRequestId),
+        firestoreLimit(1),
+      );
+      const replaySnapshot = await getDocs(replayQuery);
+      if (!replaySnapshot.empty) {
+        const replay = replaySnapshot.docs[0].data() as StoredUploadSession;
+        if (replay.fileName !== fileName) {
+          throw new Error('Client request id already used for a different file name.');
+        }
+        return this.mapSession(replaySnapshot.docs[0].id, replay);
+      }
+    }
+
+    const sessionId = `uplsess_${crypto.randomUUID()}`;
+    const idempotencyKey = `upk_${crypto.randomUUID()}`;
+    const objectKey = buildCanonicalObjectKey({ fileName, now: new Date(this.now()) });
+    const expiresAt = new Date(this.now() + 15 * 60 * 1000).toISOString();
+
+    const session: StoredUploadSession = {
+      ownerUserId: this.ownerUserId,
+      ownerLibraryId: this.ownerLibraryId,
+      fileName,
+      idempotencyKey,
+      objectKey,
+      uploadUrl: `https://uploads.firebase.local/${sessionId}`,
+      expiresAt,
+      clientRequestId: clientRequestId ?? null,
+      createdAt: new Date(this.now()).toISOString(),
+    };
+
+    await setDoc(doc(this.db, COLLECTIONS.UPLOAD_SESSIONS, sessionId), session);
+    return this.mapSession(sessionId, session);
   }
 
   async finalizeUpload(input: FinalizeUploadInput): Promise<FinalizeUploadResult> {
-    void input;
-    throw new Error('Upload sessions not yet implemented. Use LibraryService.addPhoto() for direct uploads.');
+    if (input.byteSize <= 0) {
+      throw new Error('Byte size must be greater than zero.');
+    }
+
+    const normalizedFileName = input.fileName.trim();
+    if (!normalizedFileName) {
+      throw new Error('File name is required.');
+    }
+
+    const sessionDoc = await getDoc(doc(this.db, COLLECTIONS.UPLOAD_SESSIONS, input.sessionId));
+    if (!sessionDoc.exists()) {
+      throw new Error('Upload session not found.');
+    }
+
+    const session = sessionDoc.data() as StoredUploadSession;
+    if (session.ownerUserId !== this.ownerUserId || session.ownerLibraryId !== this.ownerLibraryId) {
+      throw new Error('Upload session not found.');
+    }
+
+    if (input.idempotencyKey !== session.idempotencyKey) {
+      throw new Error('Idempotency key does not match upload session.');
+    }
+
+    if (!isValidCanonicalObjectKey(session.objectKey)) {
+      throw new Error('Upload object key is invalid.');
+    }
+
+    const replayQuery = query(
+      collection(this.db, COLLECTIONS.UPLOAD_METADATA),
+      where('ownerUserId', '==', this.ownerUserId),
+      where('idempotencyKey', '==', input.idempotencyKey),
+      firestoreLimit(1),
+    );
+    const replaySnapshot = await getDocs(replayQuery);
+    if (!replaySnapshot.empty) {
+      const replayDoc = replaySnapshot.docs[0];
+      const replay = replayDoc.data() as StoredUploadMetadata;
+      if (replay.sessionId !== input.sessionId) {
+        throw new Error('Idempotency key already used by a different upload session.');
+      }
+
+      const replayJob = await this.getJobById(replay.derivativeJobId);
+      return {
+        metadata: this.mapMetadata(replayDoc.id, replay),
+        job: replayJob,
+        idempotentReplay: true,
+      };
+    }
+
+    const uploadId = `upl_${crypto.randomUUID()}`;
+    const jobId = `drv_${crypto.randomUUID()}`;
+    const nowIso = new Date(this.now()).toISOString();
+
+    const metadata: StoredUploadMetadata = {
+      ownerUserId: this.ownerUserId,
+      ownerLibraryId: this.ownerLibraryId,
+      sessionId: input.sessionId,
+      idempotencyKey: input.idempotencyKey,
+      fileName: normalizedFileName,
+      objectKey: session.objectKey,
+      sourcePointer: `gs://${this.ownerLibraryId}/${session.objectKey}`,
+      byteSize: input.byteSize,
+      processingState: 'pending_processing',
+      derivativeJobId: jobId,
+      createdAt: nowIso,
+    };
+
+    const job: StoredDerivativeJob = {
+      ownerUserId: this.ownerUserId,
+      ownerLibraryId: this.ownerLibraryId,
+      idempotencyKey: input.idempotencyKey,
+      metadataUploadId: uploadId,
+      objectKey: session.objectKey,
+      status: 'queued',
+      createdAt: nowIso,
+    };
+
+    await setDoc(doc(this.db, COLLECTIONS.UPLOAD_METADATA, uploadId), metadata);
+    await setDoc(doc(this.db, COLLECTIONS.DERIVATIVE_JOBS, jobId), job);
+
+    return {
+      metadata: this.mapMetadata(uploadId, metadata),
+      job: this.mapJob(jobId, job),
+      idempotentReplay: false,
+    };
   }
 
   async listUploadedMetadata(): Promise<UploadMetadata[]> {
-    throw new Error('Upload sessions not yet implemented. Use LibraryService.addPhoto() for direct uploads.');
+    const metadataQuery = query(
+      collection(this.db, COLLECTIONS.UPLOAD_METADATA),
+      where('ownerUserId', '==', this.ownerUserId),
+      where('ownerLibraryId', '==', this.ownerLibraryId),
+      orderBy('createdAt', 'desc'),
+    );
+    const snapshot = await getDocs(metadataQuery);
+    return snapshot.docs.map((docSnap) => this.mapMetadata(docSnap.id, docSnap.data() as StoredUploadMetadata));
   }
 
   async listDerivativeJobs(): Promise<DerivativeJobEnvelope[]> {
-    throw new Error('Upload sessions not yet implemented. Use LibraryService.addPhoto() for direct uploads.');
+    const jobsQuery = query(
+      collection(this.db, COLLECTIONS.DERIVATIVE_JOBS),
+      where('ownerUserId', '==', this.ownerUserId),
+      where('ownerLibraryId', '==', this.ownerLibraryId),
+      orderBy('createdAt', 'asc'),
+    );
+    const snapshot = await getDocs(jobsQuery);
+    return snapshot.docs.map((docSnap) => this.mapJob(docSnap.id, docSnap.data() as StoredDerivativeJob));
   }
 
   async processNextDerivativeJob(): Promise<DerivativeJobEnvelope | null> {
-    throw new Error('Upload sessions not yet implemented. Use LibraryService.addPhoto() for direct uploads.');
+    const queuedJobsQuery = query(
+      collection(this.db, COLLECTIONS.DERIVATIVE_JOBS),
+      where('ownerUserId', '==', this.ownerUserId),
+      where('ownerLibraryId', '==', this.ownerLibraryId),
+      where('status', '==', 'queued'),
+      orderBy('createdAt', 'asc'),
+      firestoreLimit(1),
+    );
+    const snapshot = await getDocs(queuedJobsQuery);
+    if (snapshot.empty) {
+      return null;
+    }
+
+    const jobDoc = snapshot.docs[0];
+    const job = jobDoc.data() as StoredDerivativeJob;
+    const completedJob: StoredDerivativeJob = {
+      ...job,
+      status: 'completed',
+    };
+
+    await updateDoc(doc(this.db, COLLECTIONS.DERIVATIVE_JOBS, jobDoc.id), {
+      status: 'completed',
+    });
+    await updateDoc(doc(this.db, COLLECTIONS.UPLOAD_METADATA, job.metadataUploadId), {
+      processingState: 'completed',
+    });
+
+    return this.mapJob(jobDoc.id, completedJob);
+  }
+
+  private async getJobById(jobId: string): Promise<DerivativeJobEnvelope> {
+    const jobDoc = await getDoc(doc(this.db, COLLECTIONS.DERIVATIVE_JOBS, jobId));
+    if (!jobDoc.exists()) {
+      throw new Error('Derivative job not found for finalized upload.');
+    }
+    const job = jobDoc.data() as StoredDerivativeJob;
+    if (job.ownerUserId !== this.ownerUserId || job.ownerLibraryId !== this.ownerLibraryId) {
+      throw new Error('Derivative job not found for finalized upload.');
+    }
+    return this.mapJob(jobDoc.id, job);
+  }
+
+  private mapSession(sessionId: string, session: StoredUploadSession): UploadSession {
+    return {
+      sessionId,
+      idempotencyKey: session.idempotencyKey,
+      objectKey: session.objectKey,
+      uploadUrl: session.uploadUrl,
+      expiresAt: session.expiresAt,
+    };
+  }
+
+  private mapMetadata(uploadId: string, metadata: StoredUploadMetadata): UploadMetadata {
+    return {
+      uploadId,
+      fileName: metadata.fileName,
+      objectKey: metadata.objectKey,
+      sourcePointer: metadata.sourcePointer,
+      byteSize: metadata.byteSize,
+      processingState: metadata.processingState,
+      derivativeJobId: metadata.derivativeJobId,
+    };
+  }
+
+  private mapJob(jobId: string, job: StoredDerivativeJob): DerivativeJobEnvelope {
+    return {
+      jobId,
+      idempotencyKey: job.idempotencyKey,
+      metadataUploadId: job.metadataUploadId,
+      objectKey: job.objectKey,
+      status: job.status,
+      createdAt: job.createdAt,
+    };
   }
 }

--- a/src/config/collections.ts
+++ b/src/config/collections.ts
@@ -9,6 +9,9 @@ export const COLLECTIONS = {
   ALBUM_FOLDERS: 'albumFolders',
   SHARES: 'shares',
   OPERATIONS: 'operations',
+  UPLOAD_SESSIONS: 'uploadSessions',
+  UPLOAD_METADATA: 'uploadMetadata',
+  DERIVATIVE_JOBS: 'derivativeJobs',
 } as const;
 
 export type CollectionName = (typeof COLLECTIONS)[keyof typeof COLLECTIONS];

--- a/src/services/createFirebaseServices.ts
+++ b/src/services/createFirebaseServices.ts
@@ -40,7 +40,7 @@ export function createFirebaseServices(
   );
   const albums = new FirebaseAlbumsService(firebaseInstances.db, userId);
   const sharing = new FirebaseSharingService(firebaseInstances.db);
-  const uploads = new FirebaseUploadService();
+  const uploads = new FirebaseUploadService(firebaseInstances.db, { userId });
 
   return {
     auth,


### PR DESCRIPTION
## Summary
- add targeted unit and emulator integration coverage for Firebase upload-session behavior
- add Firestore index validation + emulator prerequisite scripts
- wire CI to run the upload-session adapter and emulator gate steps
- document local setup updates for the emulator path

## Context
- Unblocks Paperclip issue HUD-119 by publishing the previously local HUD-111 patch and attaching actionable CI evidence.

## Validation
- `npm run firestore:indexes:validate`
- `npm run test:uploads:firebase-adapter`
- `npm run lint -- src/adapters/uploads/FirebaseUploadService.emulator.test.ts`
- `npm run test:uploads:firebase-emulator` (expected to pass in CI where Java is available)