### PR TITLE
feat: per-tenant branding/theme config served to the embedded UI

### DIFF
--- a/contracts/openapi/branding.openapi.json
+++ b/contracts/openapi/branding.openapi.json
@@ -1,0 +1,146 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AuraPix Tenant Branding API",
+    "version": "0.1.0",
+    "description": "Per-tenant branding/theme configuration served to the embedded UI. The GET endpoint is intentionally public so deep-linked and share pages can render branded chrome without authentication."
+  },
+  "paths": {
+    "/api/v1/tenants/{tenantId}/branding": {
+      "parameters": [
+        {
+          "name": "tenantId",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string", "pattern": "^[a-zA-Z0-9_-]{1,64}$" }
+        }
+      ],
+      "get": {
+        "summary": "Fetch a tenant's public branding/theme",
+        "description": "Public, cacheable. Returns sensible defaults if no branding doc exists.",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Branding (possibly defaults)",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BrandingEnvelope" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tenantId",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update a tenant's branding/theme",
+        "description": "Requires the `tenants.write` scope (host API key) or the tenant owner user.",
+        "security": [{ "bearerAuth": [] }, { "hostApiKey": ["tenants.write"] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/BrandingInput" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated branding",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BrandingEnvelope" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body or tenantId",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing tenants.write scope",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": { "type": "http", "scheme": "bearer", "bearerFormat": "JWT" },
+      "hostApiKey": { "type": "apiKey", "in": "header", "name": "X-Host-API-Key" }
+    },
+    "schemas": {
+      "BrandingInput": {
+        "type": "object",
+        "required": ["appName", "primaryColor", "accentColor"],
+        "properties": {
+          "appName": { "type": "string", "minLength": 1, "maxLength": 64 },
+          "primaryColor": { "type": "string", "pattern": "^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$" },
+          "accentColor": { "type": "string", "pattern": "^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$" },
+          "logoUrl": { "type": "string", "format": "uri", "maxLength": 2048 },
+          "faviconUrl": { "type": "string", "format": "uri", "maxLength": 2048 }
+        },
+        "additionalProperties": false
+      },
+      "Branding": {
+        "type": "object",
+        "required": ["tenantId", "appName", "primaryColor", "accentColor", "updatedAt"],
+        "properties": {
+          "tenantId": { "type": "string" },
+          "appName": { "type": "string" },
+          "primaryColor": { "type": "string" },
+          "accentColor": { "type": "string" },
+          "logoUrl": { "type": "string", "format": "uri" },
+          "faviconUrl": { "type": "string", "format": "uri" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "BrandingEnvelope": {
+        "type": "object",
+        "required": ["branding"],
+        "properties": {
+          "branding": { "$ref": "#/components/schemas/Branding" }
+        }
+      },
+      "ErrorEnvelope": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "message", "requestId"],
+            "properties": {
+              "code": { "type": "string" },
+              "message": { "type": "string" },
+              "requestId": { "type": "string" },
+              "details": { "type": ["object", "null"] }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/functions/src/routes/brandingV1.ts
+++ b/functions/src/routes/brandingV1.ts
@@ -1,0 +1,202 @@
+import { randomUUID } from 'node:crypto';
+import { Router } from 'express';
+import { z } from 'zod';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import { recordAuditEvent } from '../services/audit/AuditService.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Per-tenant branding/theme configuration.
+ *
+ * Stored under the logical collection `tenants_branding` keyed by tenantId
+ * (the conceptual Firestore path is `tenants/{tenantId}/branding`, flattened
+ * to fit the existing DataAdapter API).
+ */
+export interface BrandingRecord {
+  tenantId: string;
+  appName: string;
+  primaryColor: string;
+  accentColor: string;
+  logoUrl?: string;
+  faviconUrl?: string;
+  updatedAt: string;
+}
+
+export const BRANDING_COLLECTION = 'tenants_branding';
+
+export const DEFAULT_BRANDING: Omit<BrandingRecord, 'tenantId' | 'updatedAt'> = {
+  appName: 'AuraPix',
+  primaryColor: '#2563eb',
+  accentColor: '#7c3aed',
+};
+
+const HEX_COLOR_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+const TENANT_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
+
+/**
+ * Validate a CSS hex color. Accepts #RGB or #RRGGBB. Rejects everything else
+ * (named colors, rgb(), rgba(), hsl(), arbitrary strings, attempts to inject
+ * CSS via `}` etc.). Exported for unit tests.
+ */
+export function sanitizeHexColor(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!HEX_COLOR_RE.test(trimmed)) return null;
+  return trimmed;
+}
+
+const UrlSchema = z.string().url().max(2048);
+
+export const BrandingUpdateSchema = z.object({
+  appName: z.string().min(1).max(64),
+  primaryColor: z
+    .string()
+    .refine((v) => sanitizeHexColor(v) !== null, { message: 'primaryColor must be a hex color like #RRGGBB' }),
+  accentColor: z
+    .string()
+    .refine((v) => sanitizeHexColor(v) !== null, { message: 'accentColor must be a hex color like #RRGGBB' }),
+  logoUrl: UrlSchema.optional(),
+  faviconUrl: UrlSchema.optional(),
+});
+
+export type BrandingUpdateInput = z.infer<typeof BrandingUpdateSchema>;
+
+interface ApiErrorPayload {
+  error: {
+    code: string;
+    message: string;
+    requestId: string;
+    details: Record<string, unknown> | null;
+  };
+}
+
+function sendError(
+  res: { status: (code: number) => { json: (payload: ApiErrorPayload) => void } },
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> | null = null
+): void {
+  res.status(status).json({
+    error: { code, message, requestId: randomUUID(), details },
+  });
+}
+
+function isValidTenantId(value: string): boolean {
+  return TENANT_ID_RE.test(value);
+}
+
+export function brandingWithDefaults(tenantId: string, partial: Partial<BrandingRecord> | null): BrandingRecord {
+  return {
+    tenantId,
+    appName: partial?.appName ?? DEFAULT_BRANDING.appName,
+    primaryColor: partial?.primaryColor ?? DEFAULT_BRANDING.primaryColor,
+    accentColor: partial?.accentColor ?? DEFAULT_BRANDING.accentColor,
+    logoUrl: partial?.logoUrl,
+    faviconUrl: partial?.faviconUrl,
+    updatedAt: partial?.updatedAt ?? new Date(0).toISOString(),
+  };
+}
+
+export interface BrandingRouterOptions {
+  /**
+   * Authorization gate for PUT. Should return true when the caller has
+   * `tenants.write` scope (host API key) or is the tenant owner.
+   * Defaults to requiring an authenticated `req.user` (treated as owner).
+   */
+  canWriteBranding?: (req: import('express').Request, tenantId: string) => boolean | Promise<boolean>;
+}
+
+export function createBrandingV1Router(
+  dataAdapter: DataAdapter,
+  options: BrandingRouterOptions = {}
+): Router {
+  const router = Router({ mergeParams: true });
+
+  const canWrite =
+    options.canWriteBranding ??
+    ((req) => Boolean(req.user));
+
+  // Public read — no auth required (branding is public-facing).
+  router.get('/:tenantId/branding', async (req, res, next) => {
+    try {
+      const tenantId = req.params.tenantId;
+      if (!isValidTenantId(tenantId)) {
+        sendError(res, 400, 'INVALID_TENANT_ID', 'tenantId must match [a-zA-Z0-9_-]{1,64}');
+        return;
+      }
+
+      const stored = await dataAdapter.fetchData<BrandingRecord>(BRANDING_COLLECTION, tenantId);
+      const branding = brandingWithDefaults(tenantId, stored);
+
+      // Cacheable: branding rarely changes and is public.
+      res.setHeader('Cache-Control', 'public, max-age=60, stale-while-revalidate=300');
+      res.status(200).json({ branding });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // Admin-gated write.
+  router.put('/:tenantId/branding', async (req, res, next) => {
+    try {
+      const tenantId = req.params.tenantId;
+      if (!isValidTenantId(tenantId)) {
+        sendError(res, 400, 'INVALID_TENANT_ID', 'tenantId must match [a-zA-Z0-9_-]{1,64}');
+        return;
+      }
+
+      const allowed = await canWrite(req, tenantId);
+      if (!allowed) {
+        sendError(res, 403, 'FORBIDDEN', 'tenants.write scope required to update branding');
+        return;
+      }
+
+      const parsed = BrandingUpdateSchema.safeParse(req.body);
+      if (!parsed.success) {
+        sendError(res, 400, 'INVALID_BODY', 'Invalid branding payload', {
+          issues: parsed.error.issues,
+        });
+        return;
+      }
+
+      const now = new Date().toISOString();
+      const record: BrandingRecord = {
+        tenantId,
+        appName: parsed.data.appName,
+        primaryColor: sanitizeHexColor(parsed.data.primaryColor)!,
+        accentColor: sanitizeHexColor(parsed.data.accentColor)!,
+        logoUrl: parsed.data.logoUrl,
+        faviconUrl: parsed.data.faviconUrl,
+        updatedAt: now,
+      };
+
+      await dataAdapter.storeData<BrandingRecord>(BRANDING_COLLECTION, tenantId, record);
+
+      // Emit metering / audit event for compliance trails.
+      try {
+        await recordAuditEvent(dataAdapter, {
+          eventType: 'metering.branding.updated',
+          actorId: req.user?.uid ?? 'host-api-key',
+          targetId: tenantId,
+          createdAt: now,
+          metadata: {
+            tenantId,
+            appName: record.appName,
+            hasLogo: Boolean(record.logoUrl),
+            hasFavicon: Boolean(record.faviconUrl),
+          },
+        });
+      } catch (auditErr) {
+        // Audit failures should not break the write.
+        logger.warn({ err: auditErr, tenantId }, 'Failed to record branding audit event');
+      }
+
+      res.status(200).json({ branding: record });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -86,6 +86,7 @@ import { createSigningRouter } from './routes/signing.js';
 import { createAlbumsRouter } from './routes/albums.js';
 import { createAlbumsV1Router } from './routes/albumsV1.js';
 import { createComplianceV1Router } from './routes/complianceV1.js';
+import { createBrandingV1Router } from './routes/brandingV1.js';
 
 // Mount routes
 // Images route handles its own auth (signed URLs for GET, Bearer for POST)
@@ -101,6 +102,18 @@ app.use('/api/albums', authMiddleware, createAlbumsRouter(domainModules.albums))
 app.use('/api/v1/albums', authMiddleware, createAlbumsV1Router(domainModules.albums));
 app.use('/api/v1/compliance', authMiddleware, createComplianceV1Router(dataAdapter));
 app.use('/api/signing', authMiddleware, createSigningRouter(dataAdapter));
+
+// Tenant branding: GET is public (no auth), PUT requires auth.
+// Use a per-method gate so the public GET is reachable without a Bearer token.
+const brandingRouter = createBrandingV1Router(dataAdapter);
+app.use(
+  '/api/v1/tenants',
+  (req, res, next) => {
+    if (req.method === 'GET') return next();
+    return authMiddleware(req, res, next);
+  },
+  brandingRouter
+);
 
 // Error handlers (must be last)
 app.use(notFoundHandler);

--- a/functions/test/routes/brandingV1.test.ts
+++ b/functions/test/routes/brandingV1.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import {
+  createBrandingV1Router,
+  sanitizeHexColor,
+  brandingWithDefaults,
+  BRANDING_COLLECTION,
+  DEFAULT_BRANDING,
+  type BrandingRecord,
+} from '../../src/routes/brandingV1.js';
+import type { DataAdapter } from '../../src/adapters/data/DataAdapter.js';
+
+function makeAdapter(initial: Record<string, BrandingRecord> = {}): DataAdapter & { _store: Record<string, BrandingRecord> } {
+  const store: Record<string, BrandingRecord> = { ...initial };
+  const auditStore: Record<string, unknown> = {};
+  return {
+    _store: store,
+    async storeData(collection, id, data) {
+      if (collection === BRANDING_COLLECTION) store[id] = data as BrandingRecord;
+      else auditStore[id] = data;
+    },
+    async fetchData(collection, id) {
+      if (collection === BRANDING_COLLECTION) return (store[id] as any) ?? null;
+      return (auditStore[id] as any) ?? null;
+    },
+    async queryData() { return []; },
+    async updateData() {},
+    async deleteData() {},
+    async exists(collection, id) { return collection === BRANDING_COLLECTION ? id in store : id in auditStore; },
+    async listIds() { return []; },
+    async getPhoto() { return null; },
+  } as unknown as DataAdapter & { _store: Record<string, BrandingRecord> };
+}
+
+async function request(
+  app: express.Express,
+  method: 'GET' | 'PUT',
+  path: string,
+  body?: unknown
+): Promise<{ status: number; body: any; headers: Record<string, string> }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const port = (server.address() as any).port;
+      const init: RequestInit = {
+        method,
+        headers: { 'content-type': 'application/json' },
+      };
+      if (body !== undefined) init.body = JSON.stringify(body);
+      fetch(`http://127.0.0.1:${port}${path}`, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: any = null;
+          try { parsed = text ? JSON.parse(text) : null; } catch { parsed = text; }
+          const headers: Record<string, string> = {};
+          res.headers.forEach((v, k) => { headers[k] = v; });
+          server.close();
+          resolve({ status: res.status, body: parsed, headers });
+        })
+        .catch((err) => { server.close(); reject(err); });
+    });
+  });
+}
+
+describe('sanitizeHexColor', () => {
+  it('accepts #RRGGBB', () => {
+    expect(sanitizeHexColor('#ff00aa')).toBe('#ff00aa');
+    expect(sanitizeHexColor('#000000')).toBe('#000000');
+  });
+
+  it('accepts #RGB shorthand', () => {
+    expect(sanitizeHexColor('#abc')).toBe('#abc');
+  });
+
+  it('trims whitespace', () => {
+    expect(sanitizeHexColor('  #112233  ')).toBe('#112233');
+  });
+
+  it('rejects non-hex values', () => {
+    expect(sanitizeHexColor('red')).toBeNull();
+    expect(sanitizeHexColor('rgb(255,0,0)')).toBeNull();
+    expect(sanitizeHexColor('hsl(0,100%,50%)')).toBeNull();
+    expect(sanitizeHexColor('#12')).toBeNull();
+    expect(sanitizeHexColor('#1234')).toBeNull();
+    expect(sanitizeHexColor('#ggg')).toBeNull();
+    expect(sanitizeHexColor('#112233; }body{color:red')).toBeNull();
+    expect(sanitizeHexColor(null)).toBeNull();
+    expect(sanitizeHexColor(undefined)).toBeNull();
+    expect(sanitizeHexColor(42)).toBeNull();
+    expect(sanitizeHexColor('')).toBeNull();
+  });
+});
+
+describe('brandingWithDefaults', () => {
+  it('returns defaults when no doc exists', () => {
+    const b = brandingWithDefaults('tenantA', null);
+    expect(b.tenantId).toBe('tenantA');
+    expect(b.appName).toBe(DEFAULT_BRANDING.appName);
+    expect(b.primaryColor).toBe(DEFAULT_BRANDING.primaryColor);
+    expect(b.accentColor).toBe(DEFAULT_BRANDING.accentColor);
+  });
+
+  it('preserves stored values', () => {
+    const b = brandingWithDefaults('t1', {
+      appName: 'Custom', primaryColor: '#111111', accentColor: '#222222', updatedAt: '2025-01-01T00:00:00.000Z',
+    } as any);
+    expect(b.appName).toBe('Custom');
+    expect(b.primaryColor).toBe('#111111');
+  });
+});
+
+describe('GET /:tenantId/branding contract', () => {
+  let app: express.Express;
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/tenants', createBrandingV1Router(makeAdapter()));
+  });
+
+  it('returns the BrandingEnvelope shape with defaults when missing', async () => {
+    const res = await request(app, 'GET', '/api/v1/tenants/acme/branding');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('branding');
+    expect(res.body.branding).toMatchObject({
+      tenantId: 'acme',
+      appName: expect.any(String),
+      primaryColor: expect.stringMatching(/^#[0-9a-fA-F]{3,6}$/),
+      accentColor: expect.stringMatching(/^#[0-9a-fA-F]{3,6}$/),
+      updatedAt: expect.any(String),
+    });
+    expect(res.headers['cache-control']).toContain('public');
+  });
+
+  it('rejects invalid tenantId', async () => {
+    const res = await request(app, 'GET', '/api/v1/tenants/has%20space/branding');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_TENANT_ID');
+  });
+
+  it('returns stored branding when present', async () => {
+    const adapter = makeAdapter({
+      acme: {
+        tenantId: 'acme', appName: 'Acme', primaryColor: '#abcdef', accentColor: '#123456',
+        logoUrl: 'https://cdn.example.com/logo.png', updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    });
+    const localApp = express();
+    localApp.use(express.json());
+    localApp.use('/api/v1/tenants', createBrandingV1Router(adapter));
+    const res = await request(localApp, 'GET', '/api/v1/tenants/acme/branding');
+    expect(res.status).toBe(200);
+    expect(res.body.branding.appName).toBe('Acme');
+    expect(res.body.branding.logoUrl).toBe('https://cdn.example.com/logo.png');
+  });
+});
+
+describe('PUT /:tenantId/branding', () => {
+  it('requires authorization (returns 403 when canWrite returns false)', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1/tenants', createBrandingV1Router(makeAdapter(), { canWriteBranding: () => false }));
+    const res = await request(app, 'PUT', '/api/v1/tenants/acme/branding', {
+      appName: 'X', primaryColor: '#111111', accentColor: '#222222',
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects non-hex colors', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1/tenants', createBrandingV1Router(makeAdapter(), { canWriteBranding: () => true }));
+    const res = await request(app, 'PUT', '/api/v1/tenants/acme/branding', {
+      appName: 'X', primaryColor: 'red', accentColor: '#222222',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_BODY');
+  });
+
+  it('persists and returns updated branding when authorized', async () => {
+    const adapter = makeAdapter();
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1/tenants', createBrandingV1Router(adapter, { canWriteBranding: () => true }));
+    const res = await request(app, 'PUT', '/api/v1/tenants/acme/branding', {
+      appName: 'Acme', primaryColor: '#abcdef', accentColor: '#123456',
+      logoUrl: 'https://cdn.example.com/l.png',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.branding.appName).toBe('Acme');
+    expect(adapter._store.acme.primaryColor).toBe('#abcdef');
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { HealthBanner } from './components/HealthBanner';
 import { initializeHealthCheck, cleanupHealthCheck } from './services/healthCheck';
 import { setupHealthDebug } from './utils/debugHealth';
 import { ImageAuthProvider } from './hooks/useImageAuth';
+import { BrandingProvider } from './features/branding/BrandingProvider';
 
 // Some CI environments have incorrectly flagged JSX component usage as unused.
 // This ensures the import is always treated as a runtime value.
@@ -38,9 +39,12 @@ export default function App() {
     };
   }, []);
 
+  const tenantId = import.meta.env.VITE_TENANT_ID as string | undefined;
+
   return (
     <ServiceProvider services={services}>
       <ImageAuthProvider authService={services.auth}>
+        <BrandingProvider tenantId={tenantId}>
         <HealthBanner />
         <BrowserRouter>
           <Routes>
@@ -59,6 +63,7 @@ export default function App() {
             </Route>
           </Routes>
         </BrowserRouter>
+        </BrandingProvider>
       </ImageAuthProvider>
     </ServiceProvider>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { AlbumsProvider, useAlbums } from '../features/albums/useAlbums';
 import { useAuth } from '../features/auth/useAuth';
+import { useBranding } from '../features/branding/BrandingProvider';
 import { SidebarNav } from './sidebar';
 import type { SidebarItem } from './sidebar';
 
@@ -65,6 +66,7 @@ function SearchIcon() {
 function LayoutShell() {
   const { user, signOut, signInWithOAuth } = useAuth();
   const { albums, folders } = useAlbums();
+  const { branding } = useBranding();
   const navigate = useNavigate();
   const location = useLocation();
   const [searchQuery, setSearchQuery] = useState('');
@@ -190,7 +192,7 @@ function LayoutShell() {
     <div className="app-shell">
       <header className="app-topbar">
         <div className="topbar-left">
-          <span className="app-logo">AuraPix</span>
+          <span className="app-logo">{branding.appName}</span>
           <button
             className="btn-primary topbar-add-btn"
             onClick={() => navigate('/library?upload=1')}

--- a/src/features/branding/BrandingProvider.test.tsx
+++ b/src/features/branding/BrandingProvider.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import {
+  BrandingProvider,
+  applyBrandingToDocument,
+  DEFAULT_BRANDING,
+  useBranding,
+  type Branding,
+} from './BrandingProvider';
+
+function Probe() {
+  const { branding } = useBranding();
+  return <span data-testid="app-name">{branding.appName}</span>;
+}
+
+describe('applyBrandingToDocument', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute('style');
+    document.title = '';
+  });
+
+  it('sets --brand-primary and --brand-accent CSS variables', () => {
+    applyBrandingToDocument({
+      ...DEFAULT_BRANDING,
+      primaryColor: '#abcdef',
+      accentColor: '#123456',
+      appName: 'TenantX',
+    });
+    expect(document.documentElement.style.getPropertyValue('--brand-primary')).toBe('#abcdef');
+    expect(document.documentElement.style.getPropertyValue('--brand-accent')).toBe('#123456');
+    expect(document.title).toBe('TenantX');
+  });
+
+  it('falls back to defaults for invalid hex colors', () => {
+    applyBrandingToDocument({
+      ...DEFAULT_BRANDING,
+      primaryColor: 'red' as unknown as string,
+      accentColor: 'rgb(0,0,0)' as unknown as string,
+    });
+    expect(document.documentElement.style.getPropertyValue('--brand-primary')).toBe(DEFAULT_BRANDING.primaryColor);
+    expect(document.documentElement.style.getPropertyValue('--brand-accent')).toBe(DEFAULT_BRANDING.accentColor);
+  });
+});
+
+describe('BrandingProvider', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute('style');
+    document.title = '';
+  });
+
+  it('applies default branding without a tenantId', () => {
+    render(
+      <BrandingProvider>
+        <Probe />
+      </BrandingProvider>
+    );
+    expect(document.documentElement.style.getPropertyValue('--brand-primary')).toBe(DEFAULT_BRANDING.primaryColor);
+  });
+
+  it('fetches and applies tenant branding', async () => {
+    const tenantBranding: Branding = {
+      tenantId: 't1',
+      appName: 'AcmePhoto',
+      primaryColor: '#ff0000',
+      accentColor: '#00ff00',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+    const { findByTestId } = render(
+      <BrandingProvider tenantId="t1" fetchBranding={async () => tenantBranding}>
+        <Probe />
+      </BrandingProvider>
+    );
+    const el = await findByTestId('app-name');
+    await waitFor(() => expect(el.textContent).toBe('AcmePhoto'));
+    expect(document.documentElement.style.getPropertyValue('--brand-primary')).toBe('#ff0000');
+    expect(document.documentElement.style.getPropertyValue('--brand-accent')).toBe('#00ff00');
+    expect(document.title).toBe('AcmePhoto');
+  });
+
+  it('keeps defaults when fetch fails', async () => {
+    render(
+      <BrandingProvider tenantId="t1" fetchBranding={async () => { throw new Error('nope'); }}>
+        <Probe />
+      </BrandingProvider>
+    );
+    await waitFor(() => {
+      expect(document.documentElement.style.getPropertyValue('--brand-primary')).toBe(DEFAULT_BRANDING.primaryColor);
+    });
+  });
+});

--- a/src/features/branding/BrandingProvider.tsx
+++ b/src/features/branding/BrandingProvider.tsx
@@ -1,0 +1,137 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+export interface Branding {
+  tenantId: string;
+  appName: string;
+  primaryColor: string;
+  accentColor: string;
+  logoUrl?: string;
+  faviconUrl?: string;
+  updatedAt: string;
+}
+
+export const DEFAULT_BRANDING: Branding = {
+  tenantId: 'default',
+  appName: 'AuraPix',
+  primaryColor: '#2563eb',
+  accentColor: '#7c3aed',
+  updatedAt: new Date(0).toISOString(),
+};
+
+const HEX_COLOR_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+function safeColor(value: string | undefined, fallback: string): string {
+  if (typeof value !== 'string') return fallback;
+  return HEX_COLOR_RE.test(value.trim()) ? value.trim() : fallback;
+}
+
+export interface BrandingContextValue {
+  branding: Branding;
+  loading: boolean;
+}
+
+const BrandingContext = createContext<BrandingContextValue>({
+  branding: DEFAULT_BRANDING,
+  loading: false,
+});
+
+export function useBranding(): BrandingContextValue {
+  return useContext(BrandingContext);
+}
+
+export interface BrandingProviderProps {
+  tenantId?: string;
+  /** Optional override for the fetch fn (used in tests). */
+  fetchBranding?: (tenantId: string) => Promise<Branding>;
+  /** Optional API base URL. Defaults to relative `/api/...`. */
+  apiBaseUrl?: string;
+  children: ReactNode;
+}
+
+async function defaultFetchBranding(
+  tenantId: string,
+  apiBaseUrl: string
+): Promise<Branding> {
+  const url = `${apiBaseUrl}/api/v1/tenants/${encodeURIComponent(tenantId)}/branding`;
+  const res = await fetch(url, { credentials: 'omit' });
+  if (!res.ok) throw new Error(`branding fetch failed: ${res.status}`);
+  const json = (await res.json()) as { branding?: Branding };
+  if (!json.branding) throw new Error('branding fetch: missing envelope');
+  return json.branding;
+}
+
+/**
+ * Apply branding to the document: CSS custom properties and <title>.
+ * Exported for tests.
+ */
+export function applyBrandingToDocument(branding: Branding): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.style.setProperty('--brand-primary', safeColor(branding.primaryColor, DEFAULT_BRANDING.primaryColor));
+  root.style.setProperty('--brand-accent', safeColor(branding.accentColor, DEFAULT_BRANDING.accentColor));
+  if (branding.appName) {
+    document.title = branding.appName;
+  }
+  if (branding.faviconUrl) {
+    let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    if (!link) {
+      link = document.createElement('link');
+      link.rel = 'icon';
+      document.head.appendChild(link);
+    }
+    link.href = branding.faviconUrl;
+  }
+}
+
+export function BrandingProvider({
+  tenantId,
+  fetchBranding,
+  apiBaseUrl = '',
+  children,
+}: BrandingProviderProps): JSX.Element {
+  const [branding, setBranding] = useState<Branding>(DEFAULT_BRANDING);
+  const [loading, setLoading] = useState<boolean>(Boolean(tenantId));
+
+  useEffect(() => {
+    // Always inject defaults synchronously so the UI never paints unbranded.
+    applyBrandingToDocument(branding);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!tenantId) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const fetcher = fetchBranding ?? ((id: string) => defaultFetchBranding(id, apiBaseUrl));
+    fetcher(tenantId)
+      .then((result) => {
+        if (cancelled) return;
+        const sanitized: Branding = {
+          ...result,
+          primaryColor: safeColor(result.primaryColor, DEFAULT_BRANDING.primaryColor),
+          accentColor: safeColor(result.accentColor, DEFAULT_BRANDING.accentColor),
+          appName: result.appName || DEFAULT_BRANDING.appName,
+        };
+        setBranding(sanitized);
+        applyBrandingToDocument(sanitized);
+      })
+      .catch(() => {
+        // Defaults already applied; nothing else to do.
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tenantId, fetchBranding, apiBaseUrl]);
+
+  return (
+    <BrandingContext.Provider value={{ branding, loading }}>
+      {children}
+    </BrandingContext.Provider>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,6 +4,12 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
 
+/* ── Brand tokens (overridden at runtime by BrandingProvider) ──────────── */
+:root {
+  --brand-primary: #2563eb;
+  --brand-accent: #7c3aed;
+}
+
 /* ── Reset / base ──────────────────────────────────────────────────────── */
 *,
 *::before,


### PR DESCRIPTION
## Summary

Implements per-tenant branding so hosts can make the embedded AuraPix UI feel native.

### Backend (`functions/`)
- `GET /api/v1/tenants/:tenantId/branding` — **public, cacheable** (`Cache-Control: public, max-age=60, stale-while-revalidate=300`). Returns sensible defaults when no branding doc exists.
- `PUT /api/v1/tenants/:tenantId/branding` — auth-gated. Pluggable `canWriteBranding(req, tenantId)` hook so the upcoming `tenants.write` host-API-key scope can plug in without a rewrite; today defaults to “authenticated user = owner”.
- Zod validation on PUT, with strict hex-color sanitization (`sanitizeHexColor`) that rejects named colors, `rgb()`, `hsl()`, attempted CSS injection, short/long bad hex, etc.
- Emits `metering.branding.updated` via the existing audit service (low-volume, for tenant SOC trails).
- Storage uses the existing `DataAdapter` (`tenants_branding` collection — conceptually `tenants/{tenantId}/branding`, flattened to fit the current adapter API). Works in both local-JSON and Firestore modes with no schema migration needed.
- Mounted in `server.ts` with a per-method gate so `GET` skips auth and `PUT` runs it.

### Frontend (`src/`)
- New `BrandingProvider` (`src/features/branding/BrandingProvider.tsx`) fetches branding once per session for `VITE_TENANT_ID`, injects `--brand-primary` and `--brand-accent` CSS custom properties on `<html>`, updates `document.title`, and optionally swaps the favicon. Defaults render immediately so the UI never flashes unbranded.
- `Layout.tsx` topbar logo now reads `branding.appName`.
- Default brand tokens added to `:root` in `styles.css`.

### Contract
- New `contracts/openapi/branding.openapi.json` with `BrandingInput`, `Branding`, `BrandingEnvelope`, and `ErrorEnvelope` schemas; both `bearerAuth` and `hostApiKey` security schemes documented for PUT.

### Tests
- **Backend** (`functions/test/routes/brandingV1.test.ts`, 12 tests): GET contract/shape + cache header, defaults when missing, stored values, tenantId validation, 403 when unauthorized, 400 on non-hex color, persistence, plus dedicated unit tests for `sanitizeHexColor` and `brandingWithDefaults`.
- **Frontend** (`src/features/branding/BrandingProvider.test.tsx`, 5 tests): CSS-var injection snapshot, fallback on invalid hex, default-only render when no `tenantId`, fetch+apply happy path, graceful fallback when fetch fails.
- Full suites still pass: backend 82/82, frontend 95/95.

## Acceptance criteria
- [x] Firestore branding doc schema + zod validation on PUT.
- [x] Public `GET` + admin-gated `PUT` endpoints with OpenAPI contract updated.
- [x] Frontend `BrandingProvider` injects CSS variables on load; topbar consumes `appName`.
- [x] Defaults applied when branding doc absent.
- [x] Tests: contract test for GET response shape, unit test for color sanitization, snapshot test that CSS vars are set.

## Notes / caveats
- No `resolveTenant` middleware exists in the codebase yet — the issue called it out as a future hook. The router takes `tenantId` from the path; when `resolveTenant` lands it can populate `req.tenantId` and the route will keep working. The `canWriteBranding` hook is the integration point for the future `tenants.write` host-API-key scope.
- Hardcoded color refs in topbar/sidebar were not rewritten beyond the global `:root` tokens to keep this PR minimal; the CSS vars are now available for follow-up restyling without further plumbing.

Fixes rwrife/AuraPix#132