### PR TITLE
fix: metering event bus + host webhook fanout

### DIFF
--- a/docs/features/metering-events.md
+++ b/docs/features/metering-events.md
@@ -1,0 +1,123 @@
+# Metering Events & Host Webhook Fanout
+
+AuraPix emits **metering events** at the points where billable work happens,
+so a host application (the one reselling AuraPix to its customers) can drive
+metered billing without polling.
+
+This document describes the **event catalog**, the **transport** (a single
+HMAC-signed webhook), and the **payload shape**.
+
+> Tracking issue: [#130](https://github.com/rwrife/AuraPix/issues/130).
+
+## Configuration
+
+| Env var | Required | Description |
+| --- | --- | --- |
+| `HOST_METERING_WEBHOOK_URL` | no | When unset, metering is disabled (no-op sink). When set, batched events POST here. |
+| `SIGNING_MASTER_SECRET` | yes (when webhook set) | Used for the HMAC signature header. Already used elsewhere for signed URLs. |
+
+When `HOST_METERING_WEBHOOK_URL` is unset, emit calls are queued and
+discarded; there is no outbound traffic.
+
+## Event catalog (initial set)
+
+All events share the shape:
+
+```ts
+type MeteringEvent = {
+  tenantId: string;              // host-side routing key
+  type: MeteringEventType;       // see table below
+  count?: number;                // defaults to 1
+  bytes?: number;                // when meaningful
+  resourceId?: string;           // e.g. photoId / keyId
+  occurredAt?: string;           // ISO-8601; server-stamped if missing
+  meta?: Record<string, unknown>;// small, free-form
+}
+```
+
+| `type` | Emitted from | Notable fields |
+| --- | --- | --- |
+| `upload.accepted` | `handlers/images/upload.ts` after the original image is stored | `count=1`, `bytes=metadata.sizeBytes`, `resourceId=photoId`, `meta.userId`, `meta.sourceType` |
+| `image.processed` | `handlers/thumbnails/generate.ts` after derivatives are written | one event per derivative variant (7 today: small/medium/large × webp+jpeg + preview_jpeg), `resourceId=photoId`, `meta.stage='thumbnail'` |
+| `signed_url.issued` | `routes/signing.ts` user and share grants | `resourceId=signingKey.keyId`, `meta.grantType='user'\|'share'` |
+| `edit.applied` | `handlers/edits/applyEdits.ts` after a non-destructive edit version is committed | `resourceId=photoId`, `meta.version`, `meta.operationCount` |
+
+Reserved for follow-ups (not emitted yet): `plugin.ran`, `user.active`,
+`share.viewed`.
+
+## Tenant resolution
+
+AuraPix does not yet have a first-class `tenantId` on every request (tracked
+separately). Until that lands, emit sites use the helper
+`resolveTenantId({ tenantId?, libraryId? })`, which returns the first
+non-empty of:
+
+1. an explicit `tenantId`
+2. `lib:<libraryId>` (stable, scoped fallback)
+3. `lib:unknown` (last resort)
+
+This means hosts can already partition usage by library today, and the
+payload shape will not change when a true `tenantId` is wired in.
+
+## Transport: batched POST
+
+Events are buffered by an in-memory bus and flushed when the **first** of
+these triggers fires:
+
+- 50 events queued, or
+- 1 second since the oldest queued event
+
+The bus POSTs a JSON envelope to `HOST_METERING_WEBHOOK_URL`:
+
+```json
+{
+  "version": "v1",
+  "sentAt": "2025-01-01T00:00:00.000Z",
+  "events": [
+    {
+      "tenantId": "lib:abc123",
+      "type": "upload.accepted",
+      "count": 1,
+      "bytes": 4823718,
+      "resourceId": "ph_9XaR...",
+      "occurredAt": "2025-01-01T00:00:00.000Z",
+      "meta": { "userId": "u_42", "sourceType": "raster" }
+    }
+  ]
+}
+```
+
+### Signature scheme
+
+Each request carries:
+
+```
+X-AuraPix-Signature: v1=<hex(hmac_sha256(SIGNING_MASTER_SECRET, raw_body))>
+```
+
+- The version prefix (`v1=`) allows future rotation without breaking
+  consumers.
+- The MAC is computed over the **exact raw request body** (no canonicalization
+  beyond JSON.stringify on our side). Hosts MUST verify against the raw bytes.
+- Hosts SHOULD reject requests where the signature does not match or where
+  `version` is unrecognized.
+
+### Retry and drop policy
+
+- Each batch is attempted up to **3 times** with exponential backoff
+  (base 200 ms, doubling).
+- Both non-2xx responses and request errors trigger a retry.
+- On exhaustion the batch is **dropped** and an error is logged. We **never**
+  block the originating request path on webhook delivery.
+- Hosts are expected to be idempotent on `resourceId` + `type` +
+  `occurredAt` to tolerate at-least-once delivery (though current policy is
+  at-most-3 attempts).
+
+## Failure modes
+
+| Situation | Behaviour |
+| --- | --- |
+| `HOST_METERING_WEBHOOK_URL` unset | NoopMeteringSink; emits are dropped silently. |
+| Webhook 5xx/timeout | Retried with backoff; dropped after 3 attempts. |
+| `emit()` called during high load | Bus continues to buffer; if a batch is in flight, additional events accumulate for the next flush. |
+| Process exits with pending events | Best-effort `shutdown()` flush at the call site; otherwise events in memory are lost (acceptable for usage telemetry). |

--- a/functions/src/handlers/edits/applyEdits.ts
+++ b/functions/src/handlers/edits/applyEdits.ts
@@ -15,6 +15,10 @@ import {
   getNormalizedIdempotencyKey,
   storeEditIdempotencyRecord,
 } from './editIdempotency.js';
+import {
+  emitMeteringEvent,
+  resolveTenantId,
+} from '../../services/metering/index.js';
 
 function parseExpectedCurrentVersion(headerValue: string | undefined): number | null {
   if (!headerValue) return null;
@@ -191,6 +195,18 @@ export async function handleApplyEdits(
       },
       'Edits applied successfully'
     );
+
+    emitMeteringEvent({
+      tenantId: resolveTenantId({ libraryId }),
+      type: 'edit.applied',
+      count: 1,
+      resourceId: photoId,
+      meta: {
+        libraryId,
+        version: newVersion.version,
+        operationCount: operations.length,
+      },
+    });
 
     const responseBody = {
       photoId,

--- a/functions/src/handlers/images/upload.ts
+++ b/functions/src/handlers/images/upload.ts
@@ -20,6 +20,10 @@ import { createPhotoDocument } from '../../models/Photo.js';
 import type { PhotoMetadata } from '../../models/Photo.js';
 import { evaluateUploadPolicy } from '../../services/host/uploadPolicy.js';
 import { fileExtension, isRawUpload } from '../../services/image/rawSupport.js';
+import {
+  emitMeteringEvent,
+  resolveTenantId,
+} from '../../services/metering/index.js';
 
 // Configure multer for memory storage
 const upload = multer({
@@ -263,6 +267,21 @@ export async function handleUpload(
         createdAt: new Date().toISOString(),
       });
     }
+
+    // Metering: record the accepted upload (count + bytes).
+    emitMeteringEvent({
+      tenantId: resolveTenantId({ libraryId }),
+      type: 'upload.accepted',
+      count: 1,
+      bytes: metadata.sizeBytes,
+      resourceId: photoId,
+      meta: {
+        userId,
+        libraryId,
+        mimeType: metadata.mimeType,
+        sourceType: uploadIsRaw ? 'raw' : 'raster',
+      },
+    });
 
     // Return response immediately
     res.status(202).json({

--- a/functions/src/handlers/thumbnails/generate.ts
+++ b/functions/src/handlers/thumbnails/generate.ts
@@ -10,6 +10,10 @@ import {
   isRawUpload,
 } from '../../services/image/rawSupport.js';
 import { logger } from '../../utils/logger.js';
+import {
+  emitMeteringEvent,
+  resolveTenantId,
+} from '../../services/metering/index.js';
 
 /**
  * Generate thumbnails for a photo
@@ -127,6 +131,20 @@ export async function generateThumbnailsForPhoto(
       thumbnailsOutdated: false,
       updatedAt: new Date().toISOString(),
     });
+
+    // Metering: one event per generated derivative (7 variants today:
+    // small/medium/large × webp+jpeg plus preview_jpeg).
+    const derivativeCount = 7;
+    const tenantId = resolveTenantId({ libraryId });
+    for (let i = 0; i < derivativeCount; i++) {
+      emitMeteringEvent({
+        tenantId,
+        type: 'image.processed',
+        count: 1,
+        resourceId: photoId,
+        meta: { libraryId, stage: 'thumbnail' },
+      });
+    }
 
     logger.info(logContext, 'Thumbnail generation complete');
   } catch (error) {

--- a/functions/src/routes/signing.ts
+++ b/functions/src/routes/signing.ts
@@ -7,6 +7,10 @@ import { logger } from '../utils/logger.js';
 import { AppError } from '../middleware/errorHandler.js';
 import type { DataAdapter } from '../adapters/data/DataAdapter.js';
 import { recordAuditEvent } from '../services/audit/AuditService.js';
+import {
+  emitMeteringEvent,
+  resolveTenantId,
+} from '../services/metering/index.js';
 
 // Initialize signing key service
 const signingKeyService = new SigningKeyService(
@@ -40,6 +44,14 @@ export function createSigningRouter(dataAdapter: DataAdapter): Router {
           keyFingerprint: signingKey.key.slice(0, 12),
           expiresAt: signingKey.expiresAt,
         },
+      });
+
+      emitMeteringEvent({
+        tenantId: resolveTenantId({}),
+        type: 'signed_url.issued',
+        count: 1,
+        resourceId: signingKey.key.slice(0, 12),
+        meta: { grantType: 'user', userId },
       });
 
       res.status(200).json(signingKey);
@@ -78,6 +90,17 @@ export function createSigningRouter(dataAdapter: DataAdapter): Router {
           },
         });
       }
+
+      emitMeteringEvent({
+        tenantId: resolveTenantId({}),
+        type: 'signed_url.issued',
+        count: 1,
+        resourceId: signingKey.key.slice(0, 12),
+        meta: {
+          grantType: 'share',
+          shareTokenPrefix: token.substring(0, 8),
+        },
+      });
 
       res.status(200).json(signingKey);
     } catch (error) {

--- a/functions/src/services/metering/HostWebhookSink.test.ts
+++ b/functions/src/services/metering/HostWebhookSink.test.ts
@@ -1,0 +1,138 @@
+import { createHmac } from 'crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  HostWebhookSink,
+  computeWebhookSignature,
+} from './HostWebhookSink.js';
+import type { NormalizedMeteringEvent } from './MeteringBus.js';
+
+function makeEvent(
+  overrides: Partial<NormalizedMeteringEvent> = {}
+): NormalizedMeteringEvent {
+  return {
+    tenantId: 't1',
+    type: 'upload.accepted',
+    count: 1,
+    occurredAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('computeWebhookSignature', () => {
+  it('produces v1=<hex(hmac_sha256)> over the body', () => {
+    const sig = computeWebhookSignature('hello', 'secret');
+    const expected =
+      'v1=' + createHmac('sha256', 'secret').update('hello').digest('hex');
+    expect(sig).toBe(expected);
+    expect(sig.startsWith('v1=')).toBe(true);
+    expect(sig.length).toBe('v1='.length + 64);
+  });
+
+  it('changes when body changes', () => {
+    const a = computeWebhookSignature('a', 'k');
+    const b = computeWebhookSignature('b', 'k');
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when secret changes', () => {
+    const a = computeWebhookSignature('x', 'k1');
+    const b = computeWebhookSignature('x', 'k2');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('HostWebhookSink', () => {
+  it('is disabled and no-ops when webhookUrl is unset', async () => {
+    const fetchImpl = vi.fn();
+    const sink = new HostWebhookSink({
+      signingSecret: 's',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(sink.enabled).toBe(false);
+    await sink.deliver([makeEvent()]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('POSTs JSON body with HMAC X-AuraPix-Signature header', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 200 } as Response);
+    const sink = new HostWebhookSink({
+      webhookUrl: 'https://example.com/hook',
+      signingSecret: 'topsecret',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await sink.deliver([makeEvent()]);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe('https://example.com/hook');
+    expect(init.method).toBe('POST');
+    expect(init.headers['content-type']).toBe('application/json');
+    const body = init.body as string;
+    const expected = computeWebhookSignature(body, 'topsecret');
+    expect(init.headers['X-AuraPix-Signature']).toBe(expected);
+
+    const parsed = JSON.parse(body);
+    expect(parsed.version).toBe('v1');
+    expect(Array.isArray(parsed.events)).toBe(true);
+    expect(parsed.events).toHaveLength(1);
+    expect(parsed.events[0].type).toBe('upload.accepted');
+  });
+
+  it('retries up to maxAttempts on non-2xx, then drops without throwing', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 500 } as Response);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const sink = new HostWebhookSink({
+      webhookUrl: 'https://example.com/hook',
+      signingSecret: 's',
+      maxAttempts: 3,
+      backoffBaseMs: 1,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep,
+    });
+
+    await expect(sink.deliver([makeEvent()])).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    // Two sleeps: between attempts 1->2 and 2->3.
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on fetch rejection and succeeds on a later attempt', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const sink = new HostWebhookSink({
+      webhookUrl: 'https://example.com/hook',
+      signingSecret: 's',
+      maxAttempts: 3,
+      backoffBaseMs: 1,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep,
+    });
+
+    await sink.deliver([makeEvent()]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not POST an empty batch', async () => {
+    const fetchImpl = vi.fn();
+    const sink = new HostWebhookSink({
+      webhookUrl: 'https://example.com/hook',
+      signingSecret: 's',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await sink.deliver([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/services/metering/HostWebhookSink.ts
+++ b/functions/src/services/metering/HostWebhookSink.ts
@@ -1,0 +1,146 @@
+import { createHmac } from 'crypto';
+import { logger } from '../../utils/logger.js';
+import type {
+  MeteringSink,
+  NormalizedMeteringEvent,
+} from './MeteringBus.js';
+
+export interface HostWebhookSinkOptions {
+  /** Endpoint to POST batched events. If unset, sink is a no-op. */
+  webhookUrl?: string;
+  /** Secret used for HMAC-SHA256 of the request body. */
+  signingSecret: string;
+  /** Request timeout per attempt (ms). Default 5000. */
+  timeoutMs?: number;
+  /** Maximum delivery attempts (initial + retries). Default 3. */
+  maxAttempts?: number;
+  /** Base backoff delay (ms). Default 200. */
+  backoffBaseMs?: number;
+  /** Inject custom fetch for tests. */
+  fetchImpl?: typeof fetch;
+  /** Inject sleep for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const SIGNATURE_HEADER = 'X-AuraPix-Signature';
+const SIGNATURE_VERSION = 'v1';
+
+/**
+ * Compute the value of the `X-AuraPix-Signature` header for a request body.
+ *
+ * Format: `v1=<hex(hmac_sha256(secret, body))>`
+ */
+export function computeWebhookSignature(
+  body: string,
+  signingSecret: string
+): string {
+  const mac = createHmac('sha256', signingSecret).update(body).digest('hex');
+  return `${SIGNATURE_VERSION}=${mac}`;
+}
+
+/**
+ * Sink that POSTs batched metering events to a host-supplied webhook URL.
+ *
+ * - HMAC-SHA256 signature in `X-AuraPix-Signature` header.
+ * - Retries up to `maxAttempts` with exponential backoff.
+ * - Drops the batch on exhaustion and logs; never throws.
+ * - When `webhookUrl` is unset, behaves as a no-op.
+ */
+export class HostWebhookSink implements MeteringSink {
+  private readonly webhookUrl?: string;
+  private readonly signingSecret: string;
+  private readonly timeoutMs: number;
+  private readonly maxAttempts: number;
+  private readonly backoffBaseMs: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(opts: HostWebhookSinkOptions) {
+    this.webhookUrl = opts.webhookUrl;
+    this.signingSecret = opts.signingSecret;
+    this.timeoutMs = opts.timeoutMs ?? 5000;
+    this.maxAttempts = opts.maxAttempts ?? 3;
+    this.backoffBaseMs = opts.backoffBaseMs ?? 200;
+    this.fetchImpl = opts.fetchImpl ?? ((...args) => fetch(...args));
+    this.sleep =
+      opts.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  }
+
+  /** True when a webhook URL is configured. */
+  get enabled(): boolean {
+    return Boolean(this.webhookUrl);
+  }
+
+  async deliver(events: NormalizedMeteringEvent[]): Promise<void> {
+    if (!this.webhookUrl || events.length === 0) {
+      return;
+    }
+
+    const body = JSON.stringify({
+      version: SIGNATURE_VERSION,
+      sentAt: new Date().toISOString(),
+      events,
+    });
+    const signature = computeWebhookSignature(body, this.signingSecret);
+
+    let lastError: unknown = null;
+    for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+      try {
+        const response = await this.fetchImpl(this.webhookUrl, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            [SIGNATURE_HEADER]: signature,
+          },
+          body,
+          signal: controller.signal,
+        });
+        if (response.ok) {
+          return;
+        }
+        lastError = new Error(
+          `Webhook returned non-2xx status ${response.status}`
+        );
+        logger.warn(
+          {
+            attempt,
+            status: response.status,
+            webhookUrl: this.webhookUrl,
+            eventCount: events.length,
+          },
+          'Metering webhook returned non-2xx; will retry if attempts remain'
+        );
+      } catch (err) {
+        lastError = err;
+        logger.warn(
+          {
+            attempt,
+            err,
+            webhookUrl: this.webhookUrl,
+            eventCount: events.length,
+          },
+          'Metering webhook delivery failed; will retry if attempts remain'
+        );
+      } finally {
+        clearTimeout(timeout);
+      }
+
+      if (attempt < this.maxAttempts) {
+        const delay = this.backoffBaseMs * 2 ** (attempt - 1);
+        await this.sleep(delay);
+      }
+    }
+
+    logger.error(
+      {
+        err: lastError,
+        webhookUrl: this.webhookUrl,
+        eventCount: events.length,
+        droppedTypes: Array.from(new Set(events.map((e) => e.type))),
+      },
+      'Metering webhook exhausted retries; dropping batch'
+    );
+  }
+}

--- a/functions/src/services/metering/MeteringBus.test.ts
+++ b/functions/src/services/metering/MeteringBus.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MeteringBus,
+  NoopMeteringSink,
+  type MeteringSink,
+  type NormalizedMeteringEvent,
+} from './MeteringBus.js';
+
+class CapturingSink implements MeteringSink {
+  batches: NormalizedMeteringEvent[][] = [];
+  deliverImpl: (events: NormalizedMeteringEvent[]) => Promise<void> = async () => {};
+
+  async deliver(events: NormalizedMeteringEvent[]): Promise<void> {
+    this.batches.push(events);
+    await this.deliverImpl(events);
+  }
+}
+
+describe('MeteringBus', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('preserves emit ordering within a batch', async () => {
+    const sink = new CapturingSink();
+    const bus = new MeteringBus({ sink, flushIntervalMs: 1000, maxBatchSize: 50 });
+
+    bus.emit({ tenantId: 't1', type: 'upload.accepted' });
+    bus.emit({ tenantId: 't1', type: 'image.processed' });
+    bus.emit({ tenantId: 't2', type: 'signed_url.issued' });
+
+    await bus.flush();
+
+    expect(sink.batches).toHaveLength(1);
+    expect(sink.batches[0]!.map((e) => e.type)).toEqual([
+      'upload.accepted',
+      'image.processed',
+      'signed_url.issued',
+    ]);
+    expect(sink.batches[0]!.map((e) => e.tenantId)).toEqual(['t1', 't1', 't2']);
+  });
+
+  it('defaults count to 1 and stamps occurredAt', async () => {
+    const sink = new CapturingSink();
+    const bus = new MeteringBus({ sink, flushIntervalMs: 1000 });
+
+    bus.emit({ tenantId: 't1', type: 'upload.accepted' });
+    await bus.flush();
+
+    const event = sink.batches[0]![0]!;
+    expect(event.count).toBe(1);
+    expect(typeof event.occurredAt).toBe('string');
+    expect(Number.isNaN(Date.parse(event.occurredAt))).toBe(false);
+  });
+
+  it('respects an explicit count and occurredAt', async () => {
+    const sink = new CapturingSink();
+    const bus = new MeteringBus({ sink, flushIntervalMs: 1000 });
+
+    bus.emit({
+      tenantId: 't1',
+      type: 'image.processed',
+      count: 5,
+      occurredAt: '2025-01-01T00:00:00.000Z',
+    });
+    await bus.flush();
+
+    expect(sink.batches[0]![0]).toMatchObject({
+      count: 5,
+      occurredAt: '2025-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('flushes immediately when batch threshold is reached', async () => {
+    const sink = new CapturingSink();
+    const bus = new MeteringBus({ sink, maxBatchSize: 3, flushIntervalMs: 60_000 });
+
+    bus.emit({ tenantId: 't1', type: 'upload.accepted' });
+    bus.emit({ tenantId: 't1', type: 'upload.accepted' });
+    expect(sink.batches).toHaveLength(0);
+
+    bus.emit({ tenantId: 't1', type: 'upload.accepted' });
+    // microtask drain
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sink.batches).toHaveLength(1);
+    expect(sink.batches[0]).toHaveLength(3);
+    expect(bus.pendingCount()).toBe(0);
+  });
+
+  it('flushes on the interval timer', async () => {
+    const sink = new CapturingSink();
+    const bus = new MeteringBus({ sink, maxBatchSize: 50, flushIntervalMs: 1000 });
+
+    bus.emit({ tenantId: 't1', type: 'edit.applied' });
+    expect(sink.batches).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    // Allow flush microtasks to settle.
+    await Promise.resolve();
+
+    expect(sink.batches).toHaveLength(1);
+    expect(sink.batches[0]![0]!.type).toBe('edit.applied');
+  });
+
+  it('emit never throws even when sink rejects', async () => {
+    const sink = new CapturingSink();
+    sink.deliverImpl = async () => {
+      throw new Error('boom');
+    };
+    const bus = new MeteringBus({ sink, flushIntervalMs: 10 });
+
+    expect(() => bus.emit({ tenantId: 't1', type: 'upload.accepted' })).not.toThrow();
+    await expect(bus.flush()).resolves.toBeUndefined();
+  });
+
+  it('shutdown flushes pending events', async () => {
+    const sink = new CapturingSink();
+    const bus = new MeteringBus({ sink, flushIntervalMs: 60_000 });
+
+    bus.emit({ tenantId: 't1', type: 'upload.accepted' });
+    await bus.shutdown();
+
+    expect(sink.batches).toHaveLength(1);
+  });
+
+  it('NoopMeteringSink discards events silently', async () => {
+    const sink = new NoopMeteringSink();
+    await expect(
+      sink.deliver([
+        {
+          tenantId: 't1',
+          type: 'upload.accepted',
+          count: 1,
+          occurredAt: new Date().toISOString(),
+        },
+      ])
+    ).resolves.toBeUndefined();
+  });
+});

--- a/functions/src/services/metering/MeteringBus.ts
+++ b/functions/src/services/metering/MeteringBus.ts
@@ -1,0 +1,172 @@
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Catalogue of billable event types emitted by AuraPix.
+ *
+ * Hosts that resell AuraPix can use these to drive metered billing.
+ * Keep this list narrow; new entries should be added intentionally
+ * and documented in `docs/features/metering-events.md`.
+ */
+export type MeteringEventType =
+  | 'upload.accepted'
+  | 'image.processed'
+  | 'signed_url.issued'
+  | 'edit.applied';
+// Future (placeholder; not emitted in this PR):
+//   | 'plugin.ran'
+//   | 'user.active'
+//   | 'share.viewed'
+
+export interface MeteringEvent {
+  /**
+   * Tenant identifier. Required so hosts can route per-customer.
+   * If a true tenantId is not yet wired through (see tenant issue),
+   * callers fall back to the libraryId, prefixed with `lib:`.
+   */
+  tenantId: string;
+  type: MeteringEventType;
+  /** Number of units (default 1). */
+  count?: number;
+  /** Byte size, where meaningful (uploads, derivatives). */
+  bytes?: number;
+  /** Optional resource id (photoId, derivativeKey, keyId, ...). */
+  resourceId?: string;
+  /** ISO-8601 timestamp; defaults to now if omitted. */
+  occurredAt?: string;
+  /** Free-form metadata for routing or analytics. Keep small. */
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * Normalized form of a MeteringEvent ready for transport.
+ */
+export interface NormalizedMeteringEvent extends MeteringEvent {
+  count: number;
+  occurredAt: string;
+}
+
+export interface MeteringSink {
+  /**
+   * Receive a batch of events. MUST NOT throw to the caller.
+   * Should perform its own retry/backoff and drop on exhaustion.
+   */
+  deliver(events: NormalizedMeteringEvent[]): Promise<void>;
+}
+
+export interface MeteringBusOptions {
+  /** Max events buffered before forcing a flush. Default 50. */
+  maxBatchSize?: number;
+  /** Max time (ms) between flushes when queue is non-empty. Default 1000. */
+  flushIntervalMs?: number;
+  /** Sink that receives flushed events. */
+  sink: MeteringSink;
+}
+
+/**
+ * In-memory typed event bus that batches metering events to a sink.
+ *
+ * Emit is fire-and-forget and never throws. The bus self-flushes on
+ * batch size or interval, whichever comes first.
+ */
+export class MeteringBus {
+  private readonly maxBatchSize: number;
+  private readonly flushIntervalMs: number;
+  private readonly sink: MeteringSink;
+  private queue: NormalizedMeteringEvent[] = [];
+  private timer: NodeJS.Timeout | null = null;
+  private inflight: Promise<void> | null = null;
+
+  constructor(opts: MeteringBusOptions) {
+    this.maxBatchSize = opts.maxBatchSize ?? 50;
+    this.flushIntervalMs = opts.flushIntervalMs ?? 1000;
+    this.sink = opts.sink;
+  }
+
+  /**
+   * Enqueue a metering event. Fire-and-forget; never throws.
+   */
+  emit(event: MeteringEvent): void {
+    try {
+      const normalized: NormalizedMeteringEvent = {
+        ...event,
+        count: event.count ?? 1,
+        occurredAt: event.occurredAt ?? new Date().toISOString(),
+      };
+      this.queue.push(normalized);
+
+      if (this.queue.length >= this.maxBatchSize) {
+        // Flush immediately on batch threshold.
+        void this.flush();
+        return;
+      }
+
+      if (!this.timer) {
+        this.timer = setTimeout(() => {
+          this.timer = null;
+          void this.flush();
+        }, this.flushIntervalMs);
+        // Allow Node to exit even if the bus has a pending timer.
+        if (typeof this.timer.unref === 'function') {
+          this.timer.unref();
+        }
+      }
+    } catch (err) {
+      logger.warn({ err }, 'MeteringBus.emit failed');
+    }
+  }
+
+  /**
+   * Flush all queued events to the sink. Safe to await; never throws.
+   * Concurrent flushes are coalesced.
+   */
+  async flush(): Promise<void> {
+    if (this.inflight) {
+      return this.inflight;
+    }
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.queue.length === 0) {
+      return;
+    }
+    const batch = this.queue;
+    this.queue = [];
+    this.inflight = (async () => {
+      try {
+        await this.sink.deliver(batch);
+      } catch (err) {
+        // Sink contract is no-throw; this is defensive.
+        logger.warn({ err, batchSize: batch.length }, 'MeteringBus sink threw');
+      } finally {
+        this.inflight = null;
+      }
+    })();
+    return this.inflight;
+  }
+
+  /**
+   * Stop the periodic timer and flush remaining events.
+   */
+  async shutdown(): Promise<void> {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    await this.flush();
+  }
+
+  /** Test/observability helper. */
+  pendingCount(): number {
+    return this.queue.length;
+  }
+}
+
+/**
+ * A sink that drops every event. Used when metering is disabled.
+ */
+export class NoopMeteringSink implements MeteringSink {
+  async deliver(_events: NormalizedMeteringEvent[]): Promise<void> {
+    // intentionally empty
+  }
+}

--- a/functions/src/services/metering/index.ts
+++ b/functions/src/services/metering/index.ts
@@ -1,0 +1,73 @@
+import { signingConfig } from '../../config/index.js';
+import { HostWebhookSink } from './HostWebhookSink.js';
+import {
+  MeteringBus,
+  NoopMeteringSink,
+  type MeteringEvent,
+  type MeteringSink,
+} from './MeteringBus.js';
+
+/**
+ * Resolve a tenant identifier for a metering event.
+ *
+ * AuraPix does not yet have a first-class tenantId on every request
+ * (see the tenant-id issue tracked separately). Until that lands,
+ * fall back to a stable, library-derived identifier so host-side
+ * partitioning still works.
+ */
+export function resolveTenantId(opts: {
+  tenantId?: string | null;
+  libraryId?: string | null;
+}): string {
+  const explicit = opts.tenantId?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  const lib = opts.libraryId?.trim();
+  if (lib) {
+    return `lib:${lib}`;
+  }
+  return 'lib:unknown';
+}
+
+let busInstance: MeteringBus | null = null;
+
+function buildSink(): MeteringSink {
+  const webhookUrl = process.env.HOST_METERING_WEBHOOK_URL?.trim();
+  if (!webhookUrl) {
+    return new NoopMeteringSink();
+  }
+  return new HostWebhookSink({
+    webhookUrl,
+    signingSecret: signingConfig.masterSecret,
+  });
+}
+
+/**
+ * Get (or lazily create) the process-wide metering bus.
+ */
+export function getMeteringBus(): MeteringBus {
+  if (!busInstance) {
+    busInstance = new MeteringBus({ sink: buildSink() });
+  }
+  return busInstance;
+}
+
+/**
+ * Override the bus (useful for tests and for wiring a custom sink at
+ * server bootstrap). Replaces any previous instance.
+ */
+export function setMeteringBus(bus: MeteringBus | null): void {
+  busInstance = bus;
+}
+
+/**
+ * Convenience: emit a single event onto the shared bus. Never throws.
+ */
+export function emitMeteringEvent(event: MeteringEvent): void {
+  try {
+    getMeteringBus().emit(event);
+  } catch {
+    // Bus.emit is already no-throw; this is belt-and-suspenders.
+  }
+}


### PR DESCRIPTION
## Summary

Adds a metering event bus and an HMAC-signed host webhook fanout so reseller/host applications can drive metered billing without polling. Emit calls are wired into the four billable code paths called out in #130: uploads, thumbnail generation, signed-URL issuance, and non-destructive edit commits. When the webhook URL is unset, the system is a no-op — no behaviour change for existing deployments.

## Changes

- **`functions/src/services/metering/MeteringBus.ts`** — typed `MeteringEvent` + `MeteringBus` with in-memory queue, batched flush (50 events or 1s), defensive no-throw emit, and a `NoopMeteringSink`.
- **`functions/src/services/metering/HostWebhookSink.ts`** — POSTs the batch as JSON to `HOST_METERING_WEBHOOK_URL`, signs the raw body with HMAC-SHA256 in `X-AuraPix-Signature: v1=<hex>` using `SIGNING_MASTER_SECRET`. Retries up to 3× with exponential backoff (200 ms base), drops on exhaustion, never blocks the caller.
- **`functions/src/services/metering/index.ts`** — process-wide bus singleton + `resolveTenantId({ tenantId?, libraryId? })` fallback helper (falls back to `lib:<libraryId>` until the tenant-id issue lands).
- **Emit sites:**
  - `handlers/images/upload.ts` → `upload.accepted` (count + bytes)
  - `handlers/thumbnails/generate.ts` → `image.processed` (one per derivative)
  - `routes/signing.ts` → `signed_url.issued` for both user and share grants
  - `handlers/edits/applyEdits.ts` → `edit.applied` after the new edit version is committed
- **`docs/features/metering-events.md`** — event catalog, payload shape, signature scheme, retry/drop policy.
- **Tests:** `MeteringBus.test.ts` (8) and `HostWebhookSink.test.ts` (8) covering emit ordering, default `count`/`occurredAt`, batch-size and interval flush triggers, no-throw emit, HMAC signature shape/changes, retry on 5xx, retry on network error → success, empty-batch + disabled no-op.

## Testing

- `npx vitest run` in `functions/` — all 86 tests pass (16 new).
- `npx tsc --noEmit` — only pre-existing errors remain (`applyEdits.conflict.test.ts` and one pre-existing `signingKey.keyId` reference unrelated to this PR). All new code typechecks cleanly.

## Caveats / follow-ups

- **Tenant id is library-derived for now.** AuraPix doesn't yet thread a first-class `tenantId` through requests, so emit sites use `resolveTenantId({ libraryId })` which yields `lib:<libraryId>`. When the tenant-id issue lands, swap callers to pass an explicit `tenantId` and the payload shape is unchanged.
- Reserved-but-not-emitted types from the issue (`plugin.ran`, `user.active`, `share.viewed`) are documented as follow-ups.
- Process exits while events are buffered will drop those events (acceptable for usage telemetry; `MeteringBus.shutdown()` is available for graceful shutdown wiring if desired later).

Fixes rwrife/AuraPix#130