### PR TITLE
fix: per-tenant host API keys for service-to-service calls (read scopes)

### DIFF
--- a/docs/features/host-api-keys.md
+++ b/docs/features/host-api-keys.md
@@ -1,0 +1,160 @@
+# Per-tenant Host API Keys
+
+Host backends (the services that integrate AuraPix into a larger product) need
+to make server-to-server calls — reading usage for billing, listing libraries
+during tenant onboarding, triggering data exports — _without_ impersonating an
+end user. Per-tenant API keys solve this with a least-privilege, auditable
+credential bound to a single tenant.
+
+Issue: [#131](https://github.com/rwrife/AuraPix/issues/131). This feature
+ultimately depends on the `tenantId` data-model foundation (#129 / #134); until
+that lands, `tenantId` is a free-form identifier supplied by the admin
+endpoint and is not yet cross-referenced against a `tenants` collection.
+
+## Key format
+
+```
+ak_live_<43 chars of base64url>
+```
+
+The first 12 characters (`ak_live_xxxx`) are stored as `keyPrefix` so we can
+look up a candidate row in Firestore by an indexed equality query, then verify
+the full key with a SHA-256 hash compare.
+
+## Firestore layout
+
+Collection `tenantApiKeys/{keyId}`:
+
+| Field          | Type             | Notes                                           |
+| -------------- | ---------------- | ----------------------------------------------- |
+| `id`           | string           | Document id; mirrored in body for convenience   |
+| `tenantId`     | string           | The tenant this key is bound to                 |
+| `keyPrefix`    | string           | First 12 chars of plaintext, indexed for lookup |
+| `hashedSecret` | string           | SHA-256 hex digest of the plaintext key         |
+| `scopes`       | string[]         | Subset of supported scopes (see below)          |
+| `createdAt`    | ISO-8601 string  | Creation timestamp                              |
+| `lastUsedAt`   | ISO-8601 \| null | Updated best-effort on each successful auth     |
+| `revokedAt`    | ISO-8601 \| null | When non-null, the key is rejected              |
+| `label`        | string?          | Optional human-readable label                   |
+
+Indexes (`firestore.indexes.json`): `(keyPrefix, revokedAt)` for lookup,
+`(tenantId, createdAt desc)` for the admin list view.
+
+## Supported scopes
+
+| Scope          | What it allows                                                              |
+| -------------- | --------------------------------------------------------------------------- |
+| `usage.read`   | Read storage usage rollups for libraries owned by the bound tenant          |
+| `tenants.read` | Read tenant configuration (not yet wired; reserved for the #129 follow-up)  |
+
+Future scopes such as `admin.users` and `libraries.write` are intentionally
+out of scope for this release.
+
+## Admin endpoints
+
+All `/internal/tenants/:tenantId/api-keys*` endpoints require an admin user
+(see `ADMIN_USER_IDS` env var, comma-separated UIDs or emails). Host API keys
+themselves can never be used to manage other keys.
+
+### Create
+
+```
+POST /internal/tenants/{tenantId}/api-keys
+Authorization: Bearer <admin firebase id token>
+Content-Type: application/json
+
+{
+  "scopes": ["usage.read"],
+  "label": "billing-rollup-prod"  // optional
+}
+```
+
+Response 201:
+
+```json
+{
+  "key": {
+    "id": "tak_...",
+    "tenantId": "tenant-acme",
+    "keyPrefix": "ak_live_abcd",
+    "scopes": ["usage.read"],
+    "createdAt": "2026-05-18T12:00:00.000Z",
+    "lastUsedAt": null,
+    "revokedAt": null,
+    "label": "billing-rollup-prod"
+  },
+  "secret": "ak_live_<43 chars>"
+}
+```
+
+**The `secret` field is shown exactly once.** AuraPix only stores the SHA-256
+hash; if the plaintext is lost the key must be revoked and re-issued.
+
+### List
+
+```
+GET /internal/tenants/{tenantId}/api-keys
+```
+
+Returns `{ "keys": [...] }` with `hashedSecret` stripped. Revoked keys are
+included (with `revokedAt` set) so operators can audit history.
+
+### Revoke
+
+```
+DELETE /internal/tenants/{tenantId}/api-keys/{keyId}
+```
+
+Soft-deletes by setting `revokedAt`. Subsequent requests using that key are
+rejected with 401. Revocation is idempotent.
+
+## Calling AuraPix with a key
+
+```
+GET /internal/storage-usage/{libraryId}?tenantId=tenant-acme
+Authorization: Bearer ak_live_<...>
+```
+
+Behavior:
+
+- Missing/invalid/revoked key → 401.
+- Valid key without the required scope → 403 with `{ error, missing: [...] }`.
+- Valid key whose `tenantId` does not match the resource's tenant → 403
+  (`"Cross-tenant request rejected"`).
+- Otherwise: handled as the authenticated tenant, with `req.tenant = { id,
+  scopes, keyId }` available to downstream handlers.
+
+The same endpoint also accepts a logged-in admin user as before, so existing
+internal tooling keeps working.
+
+## Rotation
+
+There is no in-place "rotate" operation. The recommended pattern is:
+
+1. Create a new key with the same scopes (`POST .../api-keys`).
+2. Roll it out to your host backend.
+3. Once you've confirmed the new key is in use (`lastUsedAt` advances),
+   revoke the old one (`DELETE .../api-keys/{oldKeyId}`).
+
+Plan for at least one rotation window of overlap so an in-flight deploy
+doesn't get caught between revocation and rollout.
+
+## Metering and audit
+
+- Each successful key-authenticated request emits a sampled
+  `metering.key.used` log line (`{ tenantId, keyId, path }`) at ~10% rate so
+  the host can audit which integrations are active without exploding log
+  volume.
+- The `api_call.count` aggregate added in the rollup issue is incremented on
+  every key-authenticated call.
+
+## Security notes
+
+- Plaintext keys are never logged or persisted; only the SHA-256 hash is
+  stored.
+- Hash comparison uses `crypto.timingSafeEqual` (constant-time).
+- Lookups are O(1) by `keyPrefix`; the prefix collision space is large enough
+  (≈2^60) that practical collisions are vanishingly unlikely, but the code
+  still iterates and constant-time-compares all candidates returned for a
+  given prefix.
+- Keys are bound to a single tenant; cross-tenant calls return 403.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -169,6 +169,34 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "tenantApiKeys",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keyPrefix",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "revokedAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "tenantApiKeys",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "tenantId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/src/config/index.ts
+++ b/functions/src/config/index.ts
@@ -55,6 +55,25 @@ export const featureConfig = {
   complianceExportsEnabled: process.env.FEATURE_COMPLIANCE_EXPORTS_ENABLED === 'true',
 } as const;
 
+// Comma-separated allowlist of user UIDs (or emails) treated as admins for
+// internal management endpoints (e.g. minting tenant API keys).
+const adminIds = (process.env.ADMIN_USER_IDS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+export const adminConfig = {
+  userIds: new Set<string>(adminIds),
+} as const;
+
+export function isAdminUser(user: { uid?: string; email?: string } | undefined): boolean {
+  if (!user) return false;
+  if (adminConfig.userIds.size === 0) return false;
+  if (user.uid && adminConfig.userIds.has(user.uid)) return true;
+  if (user.email && adminConfig.userIds.has(user.email)) return true;
+  return false;
+}
+
 export const securityConfig = {
   uploadRateLimit: {
     windowMs: parseInt(process.env.UPLOAD_RATE_LIMIT_WINDOW_MS || '60000', 10),

--- a/functions/src/middleware/hostApiKeyAuth.ts
+++ b/functions/src/middleware/hostApiKeyAuth.ts
@@ -1,0 +1,145 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import {
+  authenticatePlaintextKey,
+  touchTenantApiKey,
+} from '../services/host/tenantApiKeyService.js';
+import type { TenantApiKeyScope } from '../models/TenantApiKey.js';
+import { logger } from '../utils/logger.js';
+
+export interface AuthenticatedTenantContext {
+  id: string;
+  scopes: TenantApiKeyScope[];
+  keyId: string;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      /**
+       * Present when the request was authenticated via a host API key
+       * (Authorization: Bearer ak_live_...). Mutually exclusive with `user`
+       * in practice, though both can be checked independently.
+       */
+      tenant?: AuthenticatedTenantContext;
+    }
+  }
+}
+
+const KEY_PREFIX = 'ak_live_';
+
+/**
+ * Lightweight metering hook — sampled and best-effort. The host can audit
+ * which integrations are active via these logs. (See issue #131,
+ * `metering.key.used`.) Sampled at ~10% to keep log volume bounded.
+ */
+function emitKeyUsedMetric(ctx: AuthenticatedTenantContext, path: string): void {
+  if (Math.random() < 0.1) {
+    logger.info(
+      { event: 'metering.key.used', tenantId: ctx.id, keyId: ctx.keyId, path },
+      'host api key used'
+    );
+  }
+}
+
+/**
+ * Express middleware that authenticates a request using a per-tenant host
+ * API key in the form `Authorization: Bearer ak_live_...`.
+ *
+ * Behavior:
+ *  - If no Bearer token is present, or the token does not look like a host
+ *    API key, the middleware is a no-op and forwards to `next()`. This lets
+ *    the same route be composed with other auth strategies (e.g. a Firebase
+ *    user token via `authMiddleware`).
+ *  - If a key-shaped token is present but invalid (unknown prefix, hash
+ *    mismatch, or revoked), responds with 401.
+ *  - On success, sets `req.tenant = { id, scopes, keyId }` and continues.
+ *
+ * Hash compare is constant-time. Revoked keys are rejected. `lastUsedAt` is
+ * updated best-effort and any write error is swallowed.
+ */
+export function createHostApiKeyAuth(dataAdapter: DataAdapter) {
+  return async function hostApiKeyAuth(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    const header = req.headers.authorization;
+    if (!header || !header.startsWith('Bearer ')) {
+      next();
+      return;
+    }
+    const token = header.substring('Bearer '.length).trim();
+    if (!token.startsWith(KEY_PREFIX)) {
+      // Not a host API key — let the next auth middleware handle it.
+      next();
+      return;
+    }
+    try {
+      const authed = await authenticatePlaintextKey(dataAdapter, token);
+      if (!authed) {
+        res.status(401).json({ error: 'Invalid or revoked host API key' });
+        return;
+      }
+      const ctx: AuthenticatedTenantContext = {
+        id: authed.record.tenantId,
+        scopes: authed.record.scopes,
+        keyId: authed.record.id,
+      };
+      req.tenant = ctx;
+      emitKeyUsedMetric(ctx, req.path);
+      // Best-effort lastUsedAt update; never block the request on it.
+      void touchTenantApiKey(dataAdapter, authed.record.id).catch((err) => {
+        logger.debug({ err, keyId: authed.record.id }, 'Failed to update lastUsedAt');
+      });
+      next();
+    } catch (err) {
+      logger.error({ err }, 'Host API key authentication failed');
+      res.status(401).json({ error: 'Host API key authentication failed' });
+    }
+  };
+}
+
+/**
+ * Route guard: allow either an authenticated user (set by `authMiddleware`)
+ * OR an authenticated host API key carrying ALL of the required scopes for
+ * the tenant that owns the resource.
+ *
+ * `tenantIdFromReq` extracts the tenant context that owns the target
+ * resource. If the call is key-authenticated but `req.tenant.id` does not
+ * match, this returns 403 (cross-tenant rejection).
+ *
+ * If neither auth source is present, responds with 401.
+ */
+export function requireUserOrTenantScopes(options: {
+  scopes: TenantApiKeyScope[];
+  tenantIdFromReq?: (req: Request) => string | undefined;
+}) {
+  const { scopes, tenantIdFromReq } = options;
+  return function guard(req: Request, res: Response, next: NextFunction): void {
+    if (req.tenant) {
+      const tenantId = tenantIdFromReq ? tenantIdFromReq(req) : undefined;
+      if (tenantId && tenantId !== req.tenant.id) {
+        res.status(403).json({ error: 'Cross-tenant request rejected' });
+        return;
+      }
+      const granted = new Set(req.tenant.scopes);
+      const missing = scopes.filter((s) => !granted.has(s));
+      if (missing.length > 0) {
+        res.status(403).json({
+          error: 'Insufficient scope',
+          missing,
+        });
+        return;
+      }
+      next();
+      return;
+    }
+    if (req.user) {
+      next();
+      return;
+    }
+    res.status(401).json({ error: 'Authentication required' });
+  };
+}

--- a/functions/src/models/TenantApiKey.ts
+++ b/functions/src/models/TenantApiKey.ts
@@ -1,0 +1,48 @@
+/**
+ * Per-tenant host API key for service-to-service calls.
+ *
+ * Plaintext secrets are formatted as `ak_live_<random>` and are only ever
+ * returned to the caller at creation time. Firestore stores the SHA-256 hash
+ * of the secret (`hashedSecret`) along with a short `keyPrefix` (the first
+ * 12 characters of the plaintext, e.g. `ak_live_ab12`) so that incoming
+ * requests can be looked up cheaply by prefix and then verified with a
+ * constant-time hash compare.
+ *
+ * NOTE: This feature depends on the tenantId data-model foundation
+ * (see issue #129 / PR #134). Until that lands, `tenantId` here is a
+ * free-form identifier supplied by the admin endpoint and is not yet
+ * cross-referenced against a tenants collection.
+ */
+
+export type TenantApiKeyScope = 'usage.read' | 'tenants.read';
+
+export const TENANT_API_KEY_SCOPES: readonly TenantApiKeyScope[] = [
+  'usage.read',
+  'tenants.read',
+] as const;
+
+export interface TenantApiKeyRecord {
+  /** Document id (also returned to the admin). */
+  id: string;
+  /** Tenant this key is bound to. Cross-tenant calls return 403. */
+  tenantId: string;
+  /** First 12 chars of the plaintext key, used as a lookup index. */
+  keyPrefix: string;
+  /** SHA-256 hex digest of the plaintext key. */
+  hashedSecret: string;
+  /** Granted scopes (subset of TENANT_API_KEY_SCOPES). */
+  scopes: TenantApiKeyScope[];
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
+  /** ISO-8601 timestamp of last successful authentication, or null. */
+  lastUsedAt: string | null;
+  /** ISO-8601 timestamp of revocation, or null if active. */
+  revokedAt: string | null;
+  /** Optional human-readable label for the key. */
+  label?: string;
+}
+
+export const TENANT_API_KEYS_COLLECTION = 'tenantApiKeys';
+export const TENANT_API_KEY_PREFIX = 'ak_live_';
+/** Length (in chars) of the prefix used as a Firestore lookup index. */
+export const TENANT_API_KEY_PREFIX_INDEX_LENGTH = 12;

--- a/functions/src/routes/internal.ts
+++ b/functions/src/routes/internal.ts
@@ -6,13 +6,35 @@ import { generateThumbnailsForPhoto } from '../handlers/thumbnails/generate.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 import { buildStorageUsageReport } from '../handlers/storage/usageReport.js';
+import {
+  createTenantApiKey,
+  listTenantApiKeys,
+  redactTenantApiKey,
+  revokeTenantApiKey,
+  validateScopes,
+} from '../services/host/tenantApiKeyService.js';
+import { requireUserOrTenantScopes } from '../middleware/hostApiKeyAuth.js';
+import { isAdminUser } from '../config/index.js';
 
 const router = Router();
 
 /**
- * Manually trigger thumbnail generation
- * POST /internal/generate-thumbnails/:libraryId/:photoId
+ * Admin-only guard. Allows requests from a user on the ADMIN_USER_IDS
+ * allowlist. Host API keys can never use these endpoints (managing keys is
+ * a privileged user-only action).
  */
+function requireAdmin(req: Request, res: Response, next: () => void): void {
+  if (req.tenant) {
+    res.status(403).json({ error: 'Admin endpoints are not accessible via host API keys' });
+    return;
+  }
+  if (!isAdminUser(req.user)) {
+    res.status(403).json({ error: 'Admin privileges required' });
+    return;
+  }
+  next();
+}
+
 /**
  * Health check endpoint
  * GET /internal/health
@@ -27,27 +49,131 @@ router.get('/health', (_req: Request, res: Response) => {
 });
 
 /**
- * Report library storage usage totals and photo-level breakdown
+ * Tenant API key management (admin-only). Plaintext secret is returned
+ * exactly once on creation; only the SHA-256 hash is stored.
+ */
+router.post(
+  '/tenants/:tenantId/api-keys',
+  requireAdmin,
+  async (req: Request, res: Response, next) => {
+    try {
+      const tenantId = req.params.tenantId as string;
+      const dataAdapter = req.app.locals.dataAdapter as DataAdapter;
+      const body = (req.body || {}) as { scopes?: unknown; label?: unknown };
+      let scopes;
+      try {
+        scopes = validateScopes(body.scopes);
+      } catch (err) {
+        res.status(400).json({
+          error: err instanceof Error ? err.message : 'Invalid scopes',
+        });
+        return;
+      }
+      const label = typeof body.label === 'string' ? body.label : undefined;
+      const created = await createTenantApiKey(dataAdapter, { tenantId, scopes, label });
+      res.status(201).json({
+        key: redactTenantApiKey(created.record),
+        // Show plaintext exactly once. The client MUST persist it now.
+        secret: created.plaintextSecret,
+      });
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to create tenant API key');
+      next(
+        new AppError(
+          500,
+          'TENANT_API_KEY_CREATE_FAILED',
+          error instanceof Error ? error.message : 'Failed to create tenant API key'
+        )
+      );
+    }
+  }
+);
+
+router.get(
+  '/tenants/:tenantId/api-keys',
+  requireAdmin,
+  async (req: Request, res: Response, next) => {
+    try {
+      const tenantId = req.params.tenantId as string;
+      const dataAdapter = req.app.locals.dataAdapter as DataAdapter;
+      const keys = await listTenantApiKeys(dataAdapter, tenantId);
+      res.json({ keys: keys.map(redactTenantApiKey) });
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to list tenant API keys');
+      next(
+        new AppError(
+          500,
+          'TENANT_API_KEY_LIST_FAILED',
+          error instanceof Error ? error.message : 'Failed to list tenant API keys'
+        )
+      );
+    }
+  }
+);
+
+router.delete(
+  '/tenants/:tenantId/api-keys/:keyId',
+  requireAdmin,
+  async (req: Request, res: Response, next) => {
+    try {
+      const tenantId = req.params.tenantId as string;
+      const keyId = req.params.keyId as string;
+      const dataAdapter = req.app.locals.dataAdapter as DataAdapter;
+      const revoked = await revokeTenantApiKey(dataAdapter, tenantId, keyId);
+      if (!revoked) {
+        res.status(404).json({ error: 'Key not found' });
+        return;
+      }
+      res.json({ key: redactTenantApiKey(revoked) });
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to revoke tenant API key');
+      next(
+        new AppError(
+          500,
+          'TENANT_API_KEY_REVOKE_FAILED',
+          error instanceof Error ? error.message : 'Failed to revoke tenant API key'
+        )
+      );
+    }
+  }
+);
+
+/**
+ * Report library storage usage totals and photo-level breakdown.
+ *
+ * Accepts EITHER:
+ *  - an authenticated admin user, OR
+ *  - a host API key carrying the `usage.read` scope (and matching the tenant
+ *    that owns the library, if a `tenantId` query param is provided).
+ *
  * GET /internal/storage-usage/:libraryId
  */
-router.get('/storage-usage/:libraryId', async (req: Request, res: Response, next) => {
-  try {
-    const libraryId = req.params.libraryId as string;
-    const storageAdapter = req.app.locals.storageAdapter as StorageAdapter;
+router.get(
+  '/storage-usage/:libraryId',
+  requireUserOrTenantScopes({
+    scopes: ['usage.read'],
+    tenantIdFromReq: (req) =>
+      typeof req.query.tenantId === 'string' ? (req.query.tenantId as string) : undefined,
+  }),
+  async (req: Request, res: Response, next) => {
+    try {
+      const libraryId = req.params.libraryId as string;
+      const storageAdapter = req.app.locals.storageAdapter as StorageAdapter;
 
-    const report = await buildStorageUsageReport(storageAdapter, libraryId);
-    res.json(report);
-  } catch (error) {
-    logger.error({ err: error }, 'Storage usage report failed');
-    next(
-      new AppError(
-        500,
-        'STORAGE_USAGE_REPORT_FAILED',
-        error instanceof Error ? error.message : 'Storage usage report failed'
-      )
-    );
+      const report = await buildStorageUsageReport(storageAdapter, libraryId);
+      res.json(report);
+    } catch (error) {
+      logger.error({ err: error }, 'Storage usage report failed');
+      next(
+        new AppError(
+          500,
+          'STORAGE_USAGE_REPORT_FAILED',
+          error instanceof Error ? error.message : 'Storage usage report failed'
+        )
+      );
+    }
   }
-});
+);
 
 /**
  * Manually trigger thumbnail generation
@@ -55,6 +181,15 @@ router.get('/storage-usage/:libraryId', async (req: Request, res: Response, next
  */
 router.post(
   '/generate-thumbnails/:libraryId/:photoId',
+  (req, res, next) => {
+    // Preserve existing behavior: thumbnail generation requires a logged-in
+    // user. Host API keys cannot trigger generation.
+    if (!req.user) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+    next();
+  },
   async (req: Request, res: Response, next) => {
     try {
       const libraryId = req.params.libraryId as string;

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -3,7 +3,8 @@ import pinoHttp from 'pino-http';
 import { serverConfig, storageConfig } from './config/index.js';
 import { logger } from './utils/logger.js';
 import { errorHandler, notFoundHandler } from './middleware/errorHandler.js';
-import { authMiddleware } from './middleware/auth.js';
+import { authMiddleware, optionalAuthMiddleware } from './middleware/auth.js';
+import { createHostApiKeyAuth } from './middleware/hostApiKeyAuth.js';
 import { apiVersionMiddleware } from './middleware/apiVersion.js';
 import { LocalDiskStorage } from './adapters/storage/LocalDiskStorage.js';
 import { LocalJsonData } from './adapters/data/LocalJsonData.js';
@@ -91,8 +92,14 @@ import { createComplianceV1Router } from './routes/complianceV1.js';
 // Images route handles its own auth (signed URLs for GET, Bearer for POST)
 app.use('/images', createImageRoutes(dataAdapter));
 
-// These routes require authentication
-app.use('/internal', authMiddleware, internalRouter);
+// /internal endpoints accept EITHER a Firebase user token OR a host API
+// key (Authorization: Bearer ak_live_...). The hostApiKeyAuth middleware
+// short-circuits on a valid key and sets req.tenant; otherwise we fall
+// through to optional Firebase auth so per-route guards can decide what to
+// require. Individual routes inside internalRouter enforce admin or scope
+// requirements via requireUserOrTenantScopes / requireAdmin.
+const hostApiKeyAuth = createHostApiKeyAuth(dataAdapter);
+app.use('/internal', hostApiKeyAuth, optionalAuthMiddleware, internalRouter);
 app.use('/edits', authMiddleware, editsRouter);
 
 // Versioned API surface (desktop/web clients)

--- a/functions/src/services/host/tenantApiKeyService.test.ts
+++ b/functions/src/services/host/tenantApiKeyService.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type {
+  DataAdapter,
+  QueryFilter,
+} from '../../adapters/data/DataAdapter.js';
+import {
+  TENANT_API_KEYS_COLLECTION,
+  TENANT_API_KEY_PREFIX,
+  type TenantApiKeyRecord,
+} from '../../models/TenantApiKey.js';
+import {
+  authenticatePlaintextKey,
+  constantTimeHashCompare,
+  createTenantApiKey,
+  extractKeyPrefix,
+  hashSecret,
+  listTenantApiKeys,
+  redactTenantApiKey,
+  revokeTenantApiKey,
+  validateScopes,
+} from './tenantApiKeyService.js';
+
+function createInMemoryAdapter(): DataAdapter & {
+  store: Map<string, Map<string, any>>;
+} {
+  const store = new Map<string, Map<string, any>>();
+  function col(name: string): Map<string, any> {
+    let c = store.get(name);
+    if (!c) {
+      c = new Map();
+      store.set(name, c);
+    }
+    return c;
+  }
+  const adapter: DataAdapter & { store: Map<string, Map<string, any>> } = {
+    store,
+    async storeData(collection, id, data) {
+      col(collection).set(id, { ...(data as object) });
+    },
+    async fetchData<T>(collection: string, id: string): Promise<T | null> {
+      const v = col(collection).get(id);
+      return (v as T) ?? null;
+    },
+    async queryData<T>(collection: string, filters: QueryFilter[]): Promise<T[]> {
+      const all = Array.from(col(collection).values());
+      const matched = all.filter((doc) =>
+        filters.every((f) => {
+          switch (f.operator) {
+            case '==':
+              return (doc as any)[f.field] === f.value;
+            case '!=':
+              return (doc as any)[f.field] !== f.value;
+            default:
+              return false;
+          }
+        })
+      );
+      return matched as T[];
+    },
+    async updateData(collection, id, updates) {
+      const c = col(collection);
+      const existing = c.get(id);
+      if (existing) c.set(id, { ...existing, ...(updates as object) });
+    },
+    async deleteData(collection, id) {
+      col(collection).delete(id);
+    },
+    async exists(collection, id) {
+      return col(collection).has(id);
+    },
+    async listIds(collection) {
+      return Array.from(col(collection).keys());
+    },
+    async getPhoto() {
+      return null;
+    },
+  };
+  return adapter;
+}
+
+describe('tenantApiKeyService', () => {
+  let adapter: ReturnType<typeof createInMemoryAdapter>;
+  beforeEach(() => {
+    adapter = createInMemoryAdapter();
+  });
+
+  describe('validateScopes', () => {
+    it('accepts known scopes', () => {
+      expect(validateScopes(['usage.read'])).toEqual(['usage.read']);
+      expect(validateScopes(['usage.read', 'tenants.read'])).toEqual([
+        'usage.read',
+        'tenants.read',
+      ]);
+    });
+    it('dedupes scopes', () => {
+      expect(validateScopes(['usage.read', 'usage.read'])).toEqual(['usage.read']);
+    });
+    it('rejects empty or unknown scopes', () => {
+      expect(() => validateScopes([])).toThrow();
+      expect(() => validateScopes(['admin.users'])).toThrow();
+      expect(() => validateScopes('usage.read' as any)).toThrow();
+    });
+  });
+
+  describe('hashSecret + constantTimeHashCompare', () => {
+    it('produces stable SHA-256 hex digests', () => {
+      const h = hashSecret('hello');
+      expect(h).toMatch(/^[0-9a-f]{64}$/);
+      expect(hashSecret('hello')).toBe(h);
+      expect(hashSecret('hello!')).not.toBe(h);
+    });
+    it('compares equal-length strings safely', () => {
+      const a = hashSecret('a');
+      expect(constantTimeHashCompare(a, a)).toBe(true);
+      expect(constantTimeHashCompare(a, hashSecret('b'))).toBe(false);
+      expect(constantTimeHashCompare(a, a.slice(0, -1))).toBe(false);
+    });
+  });
+
+  describe('extractKeyPrefix', () => {
+    it('returns the first 12 chars for valid keys', () => {
+      expect(extractKeyPrefix('ak_live_ABCDEFGH')).toBe('ak_live_ABCD');
+    });
+    it('rejects non-key inputs', () => {
+      expect(extractKeyPrefix('bearer-xyz')).toBeNull();
+      expect(extractKeyPrefix('ak_live_')).toBeNull();
+      expect(extractKeyPrefix('')).toBeNull();
+    });
+  });
+
+  describe('createTenantApiKey', () => {
+    it('returns plaintext exactly once and stores only the hash', async () => {
+      const created = await createTenantApiKey(adapter, {
+        tenantId: 'tenant-a',
+        scopes: ['usage.read'],
+        label: 'rollup',
+      });
+      expect(created.plaintextSecret.startsWith(TENANT_API_KEY_PREFIX)).toBe(true);
+      expect(created.record.hashedSecret).toBe(hashSecret(created.plaintextSecret));
+      // Stored document must contain only the hash, never the plaintext.
+      const stored = adapter.store
+        .get(TENANT_API_KEYS_COLLECTION)!
+        .get(created.record.id);
+      expect(stored.hashedSecret).toBe(created.record.hashedSecret);
+      expect(JSON.stringify(stored)).not.toContain(created.plaintextSecret);
+      expect(stored.keyPrefix).toBe(created.plaintextSecret.slice(0, 12));
+      expect(stored.scopes).toEqual(['usage.read']);
+      expect(stored.lastUsedAt).toBeNull();
+      expect(stored.revokedAt).toBeNull();
+      expect(stored.label).toBe('rollup');
+    });
+
+    it('rejects missing tenantId', async () => {
+      await expect(
+        createTenantApiKey(adapter, { tenantId: '', scopes: ['usage.read'] })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('authenticatePlaintextKey', () => {
+    it('authenticates a valid key and returns the record', async () => {
+      const created = await createTenantApiKey(adapter, {
+        tenantId: 'tenant-a',
+        scopes: ['usage.read'],
+      });
+      const result = await authenticatePlaintextKey(adapter, created.plaintextSecret);
+      expect(result).not.toBeNull();
+      expect(result!.record.id).toBe(created.record.id);
+      expect(result!.record.tenantId).toBe('tenant-a');
+    });
+
+    it('rejects an unknown key', async () => {
+      const result = await authenticatePlaintextKey(
+        adapter,
+        'ak_live_definitely_not_real_key_value_here_xx'
+      );
+      expect(result).toBeNull();
+    });
+
+    it('rejects a non-key shaped token', async () => {
+      expect(await authenticatePlaintextKey(adapter, 'not-a-key')).toBeNull();
+    });
+
+    it('rejects a revoked key', async () => {
+      const created = await createTenantApiKey(adapter, {
+        tenantId: 'tenant-a',
+        scopes: ['usage.read'],
+      });
+      await revokeTenantApiKey(adapter, 'tenant-a', created.record.id);
+      const result = await authenticatePlaintextKey(adapter, created.plaintextSecret);
+      expect(result).toBeNull();
+    });
+
+    it('rejects when prefix matches but full hash does not', async () => {
+      // Manually plant a row with a chosen prefix but mismatched hash.
+      const fakePlaintext = 'ak_live_collide_aaaa_bbbb_cccc_dddd_eeee';
+      const prefix = fakePlaintext.slice(0, 12);
+      const record: TenantApiKeyRecord = {
+        id: 'tak_fake',
+        tenantId: 'tenant-a',
+        keyPrefix: prefix,
+        hashedSecret: hashSecret('something-else'),
+        scopes: ['usage.read'],
+        createdAt: new Date().toISOString(),
+        lastUsedAt: null,
+        revokedAt: null,
+      };
+      await adapter.storeData(TENANT_API_KEYS_COLLECTION, record.id, record);
+      const result = await authenticatePlaintextKey(adapter, fakePlaintext);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listTenantApiKeys + revokeTenantApiKey', () => {
+    it('lists only keys for the tenant', async () => {
+      const a1 = await createTenantApiKey(adapter, {
+        tenantId: 'tenant-a',
+        scopes: ['usage.read'],
+      });
+      await createTenantApiKey(adapter, {
+        tenantId: 'tenant-b',
+        scopes: ['usage.read'],
+      });
+      const listed = await listTenantApiKeys(adapter, 'tenant-a');
+      expect(listed.map((k) => k.id)).toEqual([a1.record.id]);
+    });
+
+    it('refuses cross-tenant revocation', async () => {
+      const created = await createTenantApiKey(adapter, {
+        tenantId: 'tenant-a',
+        scopes: ['usage.read'],
+      });
+      const result = await revokeTenantApiKey(
+        adapter,
+        'tenant-b',
+        created.record.id
+      );
+      expect(result).toBeNull();
+      // Key remains usable.
+      const auth = await authenticatePlaintextKey(adapter, created.plaintextSecret);
+      expect(auth).not.toBeNull();
+    });
+
+    it('revocation is idempotent', async () => {
+      const created = await createTenantApiKey(adapter, {
+        tenantId: 'tenant-a',
+        scopes: ['usage.read'],
+      });
+      const first = await revokeTenantApiKey(adapter, 'tenant-a', created.record.id);
+      const second = await revokeTenantApiKey(adapter, 'tenant-a', created.record.id);
+      expect(first?.revokedAt).toBeTruthy();
+      expect(second?.revokedAt).toBe(first?.revokedAt);
+    });
+  });
+
+  describe('redactTenantApiKey', () => {
+    it('omits hashedSecret', async () => {
+      const created = await createTenantApiKey(adapter, {
+        tenantId: 'tenant-a',
+        scopes: ['usage.read'],
+      });
+      const redacted = redactTenantApiKey(created.record);
+      expect((redacted as any).hashedSecret).toBeUndefined();
+      expect(redacted.id).toBe(created.record.id);
+    });
+  });
+});

--- a/functions/src/services/host/tenantApiKeyService.ts
+++ b/functions/src/services/host/tenantApiKeyService.ts
@@ -1,0 +1,199 @@
+import { createHash, randomBytes, timingSafeEqual } from 'crypto';
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+import {
+  TENANT_API_KEYS_COLLECTION,
+  TENANT_API_KEY_PREFIX,
+  TENANT_API_KEY_PREFIX_INDEX_LENGTH,
+  TENANT_API_KEY_SCOPES,
+  type TenantApiKeyRecord,
+  type TenantApiKeyScope,
+} from '../../models/TenantApiKey.js';
+
+export interface CreatedTenantApiKey {
+  record: TenantApiKeyRecord;
+  /** Plaintext secret. Returned exactly once to the admin caller. */
+  plaintextSecret: string;
+}
+
+/**
+ * SHA-256 hash of a plaintext key, hex-encoded.
+ */
+export function hashSecret(plaintext: string): string {
+  return createHash('sha256').update(plaintext, 'utf8').digest('hex');
+}
+
+/**
+ * Constant-time compare for two hex-encoded SHA-256 digests. Returns false on
+ * length mismatch (rather than throwing) so callers can treat it as a simple
+ * boolean predicate.
+ */
+export function constantTimeHashCompare(a: string, b: string): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  if (a.length !== b.length) return false;
+  const bufA = Buffer.from(a, 'utf8');
+  const bufB = Buffer.from(b, 'utf8');
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Validates that all provided scopes are recognized.
+ */
+export function validateScopes(scopes: unknown): TenantApiKeyScope[] {
+  if (!Array.isArray(scopes) || scopes.length === 0) {
+    throw new Error('scopes must be a non-empty array');
+  }
+  const allowed = new Set<string>(TENANT_API_KEY_SCOPES);
+  const out: TenantApiKeyScope[] = [];
+  for (const s of scopes) {
+    if (typeof s !== 'string' || !allowed.has(s)) {
+      throw new Error(`Unknown scope: ${String(s)}`);
+    }
+    out.push(s as TenantApiKeyScope);
+  }
+  return Array.from(new Set(out));
+}
+
+/**
+ * Generates a fresh plaintext key. 32 random bytes encoded as base64url, giving
+ * ~43 chars of entropy after the `ak_live_` prefix.
+ */
+export function generatePlaintextKey(): string {
+  const random = randomBytes(32).toString('base64url');
+  return `${TENANT_API_KEY_PREFIX}${random}`;
+}
+
+/**
+ * Extract the lookup prefix from a full plaintext key. Returns null when the
+ * input is too short or does not match the expected key format.
+ */
+export function extractKeyPrefix(plaintext: string): string | null {
+  if (typeof plaintext !== 'string') return null;
+  if (!plaintext.startsWith(TENANT_API_KEY_PREFIX)) return null;
+  if (plaintext.length < TENANT_API_KEY_PREFIX_INDEX_LENGTH) return null;
+  return plaintext.slice(0, TENANT_API_KEY_PREFIX_INDEX_LENGTH);
+}
+
+/**
+ * Persist a new tenant API key. Returns the stored record along with the
+ * plaintext secret, which the caller MUST show to the admin exactly once.
+ */
+export async function createTenantApiKey(
+  dataAdapter: DataAdapter,
+  options: { tenantId: string; scopes: TenantApiKeyScope[]; label?: string }
+): Promise<CreatedTenantApiKey> {
+  const { tenantId, scopes, label } = options;
+  if (!tenantId || typeof tenantId !== 'string') {
+    throw new Error('tenantId is required');
+  }
+  const plaintextSecret = generatePlaintextKey();
+  const keyPrefix = extractKeyPrefix(plaintextSecret);
+  if (!keyPrefix) {
+    // Should be unreachable: generatePlaintextKey always produces a valid key.
+    throw new Error('Failed to derive key prefix');
+  }
+  const id = `tak_${randomBytes(12).toString('base64url')}`;
+  const now = new Date().toISOString();
+  const record: TenantApiKeyRecord = {
+    id,
+    tenantId,
+    keyPrefix,
+    hashedSecret: hashSecret(plaintextSecret),
+    scopes,
+    createdAt: now,
+    lastUsedAt: null,
+    revokedAt: null,
+    ...(label ? { label } : {}),
+  };
+  await dataAdapter.storeData(TENANT_API_KEYS_COLLECTION, id, record);
+  return { record, plaintextSecret };
+}
+
+export async function listTenantApiKeys(
+  dataAdapter: DataAdapter,
+  tenantId: string
+): Promise<TenantApiKeyRecord[]> {
+  return dataAdapter.queryData<TenantApiKeyRecord>(TENANT_API_KEYS_COLLECTION, [
+    { field: 'tenantId', operator: '==', value: tenantId },
+  ]);
+}
+
+export async function revokeTenantApiKey(
+  dataAdapter: DataAdapter,
+  tenantId: string,
+  keyId: string
+): Promise<TenantApiKeyRecord | null> {
+  const existing = await dataAdapter.fetchData<TenantApiKeyRecord>(
+    TENANT_API_KEYS_COLLECTION,
+    keyId
+  );
+  if (!existing) return null;
+  if (existing.tenantId !== tenantId) {
+    // Don't leak whether the key exists under a different tenant.
+    return null;
+  }
+  if (existing.revokedAt) return existing;
+  const revokedAt = new Date().toISOString();
+  await dataAdapter.updateData<TenantApiKeyRecord>(
+    TENANT_API_KEYS_COLLECTION,
+    keyId,
+    { revokedAt }
+  );
+  return { ...existing, revokedAt };
+}
+
+export interface AuthenticatedTenantKey {
+  record: TenantApiKeyRecord;
+}
+
+/**
+ * Look up a key by prefix and verify the full plaintext against the stored
+ * hash. Returns the record on success, or null if no active key matches.
+ */
+export async function authenticatePlaintextKey(
+  dataAdapter: DataAdapter,
+  plaintext: string
+): Promise<AuthenticatedTenantKey | null> {
+  const prefix = extractKeyPrefix(plaintext);
+  if (!prefix) return null;
+  const candidates = await dataAdapter.queryData<TenantApiKeyRecord>(
+    TENANT_API_KEYS_COLLECTION,
+    [{ field: 'keyPrefix', operator: '==', value: prefix }]
+  );
+  if (!candidates || candidates.length === 0) return null;
+  const presented = hashSecret(plaintext);
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate.hashedSecret !== 'string') continue;
+    if (!constantTimeHashCompare(presented, candidate.hashedSecret)) continue;
+    if (candidate.revokedAt) return null;
+    return { record: candidate };
+  }
+  return null;
+}
+
+/**
+ * Update lastUsedAt for an authenticated key. Best-effort: failures are
+ * intentionally swallowed by the caller so a transient write error does not
+ * block a valid request.
+ */
+export async function touchTenantApiKey(
+  dataAdapter: DataAdapter,
+  keyId: string
+): Promise<void> {
+  await dataAdapter.updateData<TenantApiKeyRecord>(
+    TENANT_API_KEYS_COLLECTION,
+    keyId,
+    { lastUsedAt: new Date().toISOString() }
+  );
+}
+
+/**
+ * Strip sensitive fields before returning a key record to an admin caller.
+ */
+export function redactTenantApiKey(
+  record: TenantApiKeyRecord
+): Omit<TenantApiKeyRecord, 'hashedSecret'> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { hashedSecret: _hashed, ...rest } = record;
+  return rest;
+}

--- a/functions/test/middleware/hostApiKeyAuth.test.ts
+++ b/functions/test/middleware/hostApiKeyAuth.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+import type { DataAdapter, QueryFilter } from '../../src/adapters/data/DataAdapter.js';
+import {
+  createHostApiKeyAuth,
+  requireUserOrTenantScopes,
+} from '../../src/middleware/hostApiKeyAuth.js';
+import { createTenantApiKey } from '../../src/services/host/tenantApiKeyService.js';
+
+function createInMemoryAdapter(): DataAdapter & {
+  store: Map<string, Map<string, any>>;
+} {
+  const store = new Map<string, Map<string, any>>();
+  function col(name: string): Map<string, any> {
+    let c = store.get(name);
+    if (!c) {
+      c = new Map();
+      store.set(name, c);
+    }
+    return c;
+  }
+  return {
+    store,
+    async storeData(c, id, d) {
+      col(c).set(id, { ...(d as object) });
+    },
+    async fetchData(c, id) {
+      return col(c).get(id) ?? null;
+    },
+    async queryData<T>(c: string, filters: QueryFilter[]): Promise<T[]> {
+      const all = Array.from(col(c).values());
+      return all.filter((doc) =>
+        filters.every((f) => (doc as any)[f.field] === f.value)
+      ) as T[];
+    },
+    async updateData(c, id, u) {
+      const existing = col(c).get(id);
+      if (existing) col(c).set(id, { ...existing, ...(u as object) });
+    },
+    async deleteData(c, id) {
+      col(c).delete(id);
+    },
+    async exists(c, id) {
+      return col(c).has(id);
+    },
+    async listIds(c) {
+      return Array.from(col(c).keys());
+    },
+    async getPhoto() {
+      return null;
+    },
+  };
+}
+
+function mockRes(): Response {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+describe('hostApiKeyAuth middleware', () => {
+  let adapter: ReturnType<typeof createInMemoryAdapter>;
+  let middleware: ReturnType<typeof createHostApiKeyAuth>;
+
+  beforeEach(() => {
+    adapter = createInMemoryAdapter();
+    middleware = createHostApiKeyAuth(adapter);
+  });
+
+  it('is a no-op when no Authorization header is present', async () => {
+    const req = { headers: {}, path: '/x' } as unknown as Request;
+    const res = mockRes();
+    const next: NextFunction = vi.fn();
+    await middleware(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.tenant).toBeUndefined();
+  });
+
+  it('is a no-op when Bearer token is not a host API key', async () => {
+    const req = {
+      headers: { authorization: 'Bearer firebase-id-token-xyz' },
+      path: '/x',
+    } as unknown as Request;
+    const res = mockRes();
+    const next: NextFunction = vi.fn();
+    await middleware(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.tenant).toBeUndefined();
+    expect((res.status as any).mock?.calls ?? []).toHaveLength(0);
+  });
+
+  it('sets req.tenant on a valid key', async () => {
+    const created = await createTenantApiKey(adapter, {
+      tenantId: 'tenant-a',
+      scopes: ['usage.read'],
+    });
+    const req = {
+      headers: { authorization: `Bearer ${created.plaintextSecret}` },
+      path: '/internal/storage-usage/lib-1',
+    } as unknown as Request;
+    const res = mockRes();
+    const next: NextFunction = vi.fn();
+    await middleware(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.tenant).toEqual({
+      id: 'tenant-a',
+      scopes: ['usage.read'],
+      keyId: created.record.id,
+    });
+  });
+
+  it('rejects an unknown key with 401', async () => {
+    const req = {
+      headers: { authorization: 'Bearer ak_live_not-a-real-key-xxxxxxxxxxxxxxxxxxxx' },
+      path: '/internal/anything',
+    } as unknown as Request;
+    const res = mockRes();
+    const next: NextFunction = vi.fn();
+    await middleware(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('rejects a revoked key with 401', async () => {
+    const created = await createTenantApiKey(adapter, {
+      tenantId: 'tenant-a',
+      scopes: ['usage.read'],
+    });
+    // Mark as revoked in-place.
+    const rec = adapter.store
+      .get('tenantApiKeys')!
+      .get(created.record.id);
+    rec.revokedAt = new Date().toISOString();
+    const req = {
+      headers: { authorization: `Bearer ${created.plaintextSecret}` },
+      path: '/x',
+    } as unknown as Request;
+    const res = mockRes();
+    const next: NextFunction = vi.fn();
+    await middleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('requireUserOrTenantScopes', () => {
+  it('allows a logged-in user even without tenant scopes', () => {
+    const guard = requireUserOrTenantScopes({ scopes: ['usage.read'] });
+    const req = { user: { uid: 'u1' } } as unknown as Request;
+    const res = mockRes();
+    const next: NextFunction = vi.fn();
+    guard(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a tenant with the required scope', () => {
+    const guard = requireUserOrTenantScopes({ scopes: ['usage.read'] });
+    const req = {
+      tenant: { id: 'tenant-a', scopes: ['usage.read'], keyId: 'k1' },
+    } as unknown as Request;
+    const res = mockRes();
+    const next: NextFunction = vi.fn();
+    guard(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a tenant missing the required scope with 403', () => {
+    const guard = requireUserOrTenantScopes({ scopes: ['usage.read'] });
+    const req = {
+      tenant: { id: 'tenant-a', scopes: ['tenants.read'], keyId: 'k1' },
+    } as unknown as Request;
+    const res = mockRes();
+    const next: NextFunction = vi.fn();
+    guard(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects cross-tenant access with 403', () => {
+    const guard = requireUserOrTenantScopes({
+      scopes: ['usage.read'],
+      tenantIdFromReq: () => 'tenant-b',
+    });
+    const req = {
+      tenant: { id: 'tenant-a', scopes: ['usage.read'], keyId: 'k1' },
+    } as unknown as Request;
+    const res = mockRes();
+    const next: NextFunction = vi.fn();
+    guard(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect((res.json as any).mock.calls[0][0]).toEqual({
+      error: 'Cross-tenant request rejected',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects unauthenticated requests with 401', () => {
+    const guard = requireUserOrTenantScopes({ scopes: ['usage.read'] });
+    const req = {} as unknown as Request;
+    const res = mockRes();
+    const next: NextFunction = vi.fn();
+    guard(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds per-tenant API keys so host backends can call AuraPix server-to-server with least privilege, instead of impersonating a logged-in user via Firebase ID tokens. Plaintext keys (`ak_live_<random>`) are returned exactly once on creation; only a SHA-256 hash is stored. A new `hostApiKeyAuth` middleware accepts `Authorization: Bearer ak_live_...`, sets `req.tenant = { id, scopes, keyId }`, enforces constant-time hash compare, rejects revoked keys, and emits sampled `metering.key.used` logs.

Fixes rwrife/AuraPix#131

## Changes

- `functions/src/models/TenantApiKey.ts` — Firestore record shape, supported scopes (`usage.read`, `tenants.read`), prefix-index constant.
- `functions/src/services/host/tenantApiKeyService.ts` — create / list / revoke / authenticate / redact, plus SHA-256 hashing, constant-time compare, scope validation, and best-effort `lastUsedAt` updates.
- `functions/src/middleware/hostApiKeyAuth.ts` — Express middleware that short-circuits on a valid `ak_live_` Bearer token and a `requireUserOrTenantScopes` guard that accepts EITHER a logged-in admin user OR a key carrying the required scopes (with cross-tenant rejection).
- `functions/src/routes/internal.ts` — new admin endpoints `POST/GET /internal/tenants/:tenantId/api-keys` and `DELETE /internal/tenants/:tenantId/api-keys/:keyId`; gated `/internal/storage-usage/:libraryId` on `usage.read`-or-user; admin gating via `ADMIN_USER_IDS` env allowlist.
- `functions/src/server.ts` — composes `hostApiKeyAuth` + optional Firebase auth on `/internal`.
- `functions/src/config/index.ts` — `ADMIN_USER_IDS` env var + `isAdminUser` helper.
- `firestore.indexes.json` — indexes on `(keyPrefix, revokedAt)` for lookup and `(tenantId, createdAt desc)` for the admin list view.
- `docs/features/host-api-keys.md` — feature docs covering key format, Firestore layout, scopes, rotation, metering, and security notes.

## Testing

- New unit tests: `functions/src/services/host/tenantApiKeyService.test.ts` covers plaintext-shown-once, hash-only storage, prefix lookup, hash-mismatch rejection, revoked-key rejection, cross-tenant revoke rejection, scope validation, and idempotent revocation.
- New middleware tests: `functions/test/middleware/hostApiKeyAuth.test.ts` covers no-op pass-through for non-key tokens, valid-key authentication, invalid/revoked key 401s, scope enforcement, cross-tenant 403s, and 401 when no auth source is present.
- `npm test` in `functions/` — all 98 tests pass (was 81; 17 new tests added).
- Root `npm test` — all 90 frontend tests pass.
- `npm run build` in `functions/` — two pre-existing TS errors on `main` (unrelated: `signing.ts` `keyId` and `applyEdits.conflict.test.ts` mock typing); no new TS errors introduced by this PR.

## Caveats / follow-ups

- This feature depends on the `tenantId` data-model foundation (#129, PR #134). Until that lands, `tenantId` is a free-form identifier supplied by the admin endpoint and is not yet cross-referenced against a `tenants` collection. The middleware contract (`req.tenant = { id, scopes, keyId }`) is forward-compatible — when #129 merges, the only change needed is to start validating that `tenantId` exists in `tenants/{id}` at key-creation time.
- The `tenants.read` scope is plumbed end-to-end but no endpoint is gated on it yet; it's reserved for the #129 follow-up.
- Admin gating uses a simple `ADMIN_USER_IDS` env allowlist (UIDs or emails) since the repo has no admin-role concept yet. Swap for a richer ACL when one exists.
- `api_call.count` aggregate increment is referenced in the issue but lives in the rollup PR; this PR does not implement it.
- Firestore indexes added to `firestore.indexes.json` — deploy `firebase deploy --only firestore:indexes` before rolling out in production.