### PR TITLE
fix: Host webhook delivery log + manual replay endpoint

### DIFF
--- a/docs/features/metering-events.md
+++ b/docs/features/metering-events.md
@@ -121,3 +121,105 @@ X-AuraPix-Signature: v1=<hex(hmac_sha256(SIGNING_MASTER_SECRET, raw_body))>
 | Webhook 5xx/timeout | Retried with backoff; dropped after 3 attempts. |
 | `emit()` called during high load | Bus continues to buffer; if a batch is in flight, additional events accumulate for the next flush. |
 | Process exits with pending events | Best-effort `shutdown()` flush at the call site; otherwise events in memory are lost (acceptable for usage telemetry). |
+
+## Delivery observability (issue #144)
+
+Metering POSTs are fire-and-forget by default, which makes it hard for hosts
+to know *what* failed during an outage of their billing service. To close that
+gap, every POST attempt records a **delivery record** scoped under the tenant:
+
+```
+tenants/{tenantId}/webhookDeliveries/{batchId}
+```
+
+Record shape:
+
+```ts
+type WebhookDeliveryRecord = {
+  batchId: string;            // also the Firestore doc id
+  tenantId: string;
+  sentAt: string;             // ISO-8601 of first attempt
+  statusCode: number | null;  // last observed HTTP status, null on network err
+  ok: boolean;                // statusCode is 2xx
+  attemptCount: number;       // number of attempts so far
+  eventCount: number;         // events in the batch
+  contentHash: string;        // sha256(raw body); NO body is persisted
+  status: 'pending' | 'ok' | 'failed';
+  errorMessage?: string;      // truncated to 500 chars
+  updatedAt: string;          // ISO-8601 of last attempt
+  expiresAt: string;          // Firestore TTL anchor (sentAt + 30d)
+};
+```
+
+**No event bodies are stored** (privacy + cost). The `contentHash` field is
+enough to correlate a record with a known payload; if the host needs the
+raw events for a failed batch they can also derive them from the daily
+rollup window.
+
+Every POST attempt — success or failure — updates the same record (one row
+per batch, not per attempt). Records are auto-purged by a Firestore TTL
+policy on `expiresAt` after **30 days**.
+
+Each outbound POST also carries an `X-AuraPix-Idempotency-Key: <batchId>`
+header so the host can dedupe across automatic retries *and* manual
+replays.
+
+### Endpoints
+
+Both endpoints require a host API key (`Authorization: Bearer ak_live_...`)
+with the `webhooks.write` scope, scoped to the tenant in the URL.
+Cross-tenant calls return 403.
+
+#### `GET /api/v1/tenants/:tenantId/webhooks/deliveries`
+
+Returns paginated delivery records, newest first.
+
+| Query param | Type | Description |
+| --- | --- | --- |
+| `status` | `pending`\|`ok`\|`failed` | Filter by current status. |
+| `since` | ISO-8601 | Inclusive lower bound on `sentAt`. |
+| `limit` | int | Page size (default 50, max 200). |
+| `cursor` | string | `nextCursor` from a previous response. |
+
+Response:
+
+```json
+{
+  "tenantId": "acme",
+  "items": [ { "...": "WebhookDeliveryRecord" } ],
+  "nextCursor": "b_9a2f..."
+}
+```
+
+#### `POST /api/v1/tenants/:tenantId/webhooks/deliveries/:batchId:replay`
+
+Re-sends a previously-attempted batch. The replayed POST reuses the same
+`batchId` (and therefore the same `X-AuraPix-Idempotency-Key`), so a
+well-behaved host endpoint will not double-count.
+
+Response on success:
+
+```json
+{
+  "tenantId": "acme",
+  "batchId": "b_9a2f...",
+  "replayed": true,
+  "delivery": { "...": "WebhookDeliveryRecord (updated)" }
+}
+```
+
+Important behaviors:
+
+- The existing delivery record is updated in place — there is **no duplicate
+  row** per replay.
+- Concurrent replay calls for the same `batchId` are coalesced: the second
+  call returns immediately without issuing a second POST (in-flight
+  idempotency window).
+- The raw batch body is reconstructed from a small in-process cache (default
+  capacity 256 batches). Once the cache evicts a batch, replay returns
+  `410 BATCH_BODY_EXPIRED`. Hosts that need a guaranteed long replay
+  window can instead derive a fresh batch from the daily rollup.
+- A separate `webhook.delivery_failed` metric event may be emitted after
+  the in-process retries exhaust (planned follow-up; not required for the
+  initial implementation).
+

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -211,7 +211,38 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "webhookDeliveries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "sentAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "webhookDeliveries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "sentAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "webhookDeliveries",
+      "fieldPath": "expiresAt",
+      "ttl": true,
+      "indexes": []
+    }
+  ]
 }

--- a/functions/src/models/TenantApiKey.ts
+++ b/functions/src/models/TenantApiKey.ts
@@ -14,11 +14,15 @@
  * cross-referenced against a tenants collection.
  */
 
-export type TenantApiKeyScope = 'usage.read' | 'tenants.read';
+export type TenantApiKeyScope =
+  | 'usage.read'
+  | 'tenants.read'
+  | 'webhooks.write';
 
 export const TENANT_API_KEY_SCOPES: readonly TenantApiKeyScope[] = [
   'usage.read',
   'tenants.read',
+  'webhooks.write',
 ] as const;
 
 export interface TenantApiKeyRecord {

--- a/functions/src/routes/webhookDeliveriesV1.ts
+++ b/functions/src/routes/webhookDeliveriesV1.ts
@@ -1,0 +1,192 @@
+/**
+ * Host webhook delivery observability (issue #144).
+ *
+ * Exposes two host-key-authenticated endpoints under
+ * `/api/v1/tenants/:tenantId/webhooks`:
+ *
+ *   GET    /deliveries?status=failed&since=...&limit=...&cursor=...
+ *   POST   /deliveries/:batchId:replay
+ *
+ * Auth: requires a host API key with the `webhooks.write` scope for the
+ * target tenant (replay is a write). The list endpoint is read-only but
+ * uses the same scope to keep the configuration surface narrow — anyone\n * able to see failed deliveries can also retry them.\n *\n * Records are short-lived (Firestore TTL = 30 days). Bodies are NOT\n * stored; replay reconstructs the payload from an in-process cache held\n * by the sink (best-effort within the in-flight window). Replays outside\n * that window return 410 GONE.
+ */
+import { randomUUID } from 'node:crypto';
+import { Router } from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import { requireUserOrTenantScopes } from '../middleware/hostApiKeyAuth.js';
+import type { HostWebhookSink } from '../services/metering/HostWebhookSink.js';
+import type {
+  WebhookDeliveryStatus,
+  WebhookDeliveryStore,
+} from '../services/metering/WebhookDeliveryStore.js';
+
+export interface WebhookDeliveriesRouterDeps {
+  store: WebhookDeliveryStore;
+  /** Sink used to replay batches. Optional: when absent, replay returns 503. */
+  sink?: HostWebhookSink;
+}
+
+const ALLOWED_STATUSES = new Set<WebhookDeliveryStatus>([
+  'pending',
+  'ok',
+  'failed',
+]);
+
+function sendError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> | null = null
+): void {
+  res.status(status).json({
+    error: {
+      code,
+      message,
+      requestId: randomUUID(),
+      details,
+    },
+  });
+}
+
+function parseLimit(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.floor(n);
+}
+
+export function createWebhookDeliveriesRouter(
+  deps: WebhookDeliveriesRouterDeps
+): Router {
+  const router = Router({ mergeParams: true });
+
+  const tenantFromParams = (req: Request): string | undefined =>
+    req.params.tenantId ? String(req.params.tenantId) : undefined;
+
+  const guard = requireUserOrTenantScopes({
+    scopes: ['webhooks.write'],
+    tenantIdFromReq: tenantFromParams,
+  });
+
+  // GET /:tenantId/webhooks/deliveries
+  router.get(
+    '/:tenantId/webhooks/deliveries',
+    guard,
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId ?? '');
+        if (!tenantId) {
+          sendError(res, 400, 'VALIDATION_ERROR', 'tenantId is required');
+          return;
+        }
+
+        const statusParam = req.query.status
+          ? String(req.query.status)
+          : undefined;
+        if (statusParam && !ALLOWED_STATUSES.has(statusParam as WebhookDeliveryStatus)) {
+          sendError(
+            res,
+            400,
+            'VALIDATION_ERROR',
+            'status must be one of pending|ok|failed',
+            { status: statusParam }
+          );
+          return;
+        }
+
+        const since = req.query.since ? String(req.query.since) : undefined;
+        if (since && Number.isNaN(new Date(since).getTime())) {
+          sendError(
+            res,
+            400,
+            'VALIDATION_ERROR',
+            'since must be an ISO-8601 timestamp',
+            { since }
+          );
+          return;
+        }
+
+        const cursor = req.query.cursor ? String(req.query.cursor) : undefined;
+        const limit = parseLimit(req.query.limit);
+
+        const result = await deps.store.list(tenantId, {
+          status: statusParam as WebhookDeliveryStatus | undefined,
+          since,
+          cursor,
+          limit,
+        });
+
+        res.json({
+          tenantId,
+          items: result.items,
+          nextCursor: result.nextCursor ?? null,
+        });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  // POST /:tenantId/webhooks/deliveries/:batchId:replay
+  //
+  // Express treats `:` inside a path segment as part of the param token, so
+  // we use a literal `:replay` suffix matched via a regex-style param.
+  router.post(
+    '/:tenantId/webhooks/deliveries/:batchId\\:replay',
+    guard,
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId ?? '');
+        const batchId = String(req.params.batchId ?? '');
+        if (!tenantId || !batchId) {
+          sendError(res, 400, 'VALIDATION_ERROR', 'tenantId and batchId are required');
+          return;
+        }
+
+        const existing = await deps.store.get(tenantId, batchId);
+        if (!existing) {
+          sendError(res, 404, 'NOT_FOUND', 'Delivery record not found');
+          return;
+        }
+
+        if (!deps.sink) {
+          sendError(
+            res,
+            503,
+            'REPLAY_UNAVAILABLE',
+            'Webhook sink is not configured for replay'
+          );
+          return;
+        }
+
+        const cached = deps.sink.getCachedBatch(batchId);
+        if (!cached) {
+          // Bodies are not persisted (privacy/cost); outside the in-flight
+          // cache window we cannot reconstruct the batch.
+          sendError(
+            res,
+            410,
+            'BATCH_BODY_EXPIRED',
+            'Original batch payload is no longer in the replay cache'
+          );
+          return;
+        }
+
+        // Fire-and-await — the sink's own concurrency guard makes a second\n        // overlapping replay a no-op (idempotency by batchId).
+        const updated = await deps.sink.replayBatch(cached, batchId);
+        res.json({
+          tenantId,
+          batchId,
+          replayed: true,
+          delivery: updated ?? existing,
+        });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  return router;
+}

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -89,7 +89,12 @@ import { createAlbumsV1Router } from './routes/albumsV1.js';
 import { createComplianceV1Router } from './routes/complianceV1.js';
 import { createBrandingV1Router } from './routes/brandingV1.js';
 import { createTenantUsageRouter } from './routes/tenantUsage.js';
+import { createWebhookDeliveriesRouter } from './routes/webhookDeliveriesV1.js';
 import { InMemoryUsageMeteringBus } from './services/metering/UsageMeteringBus.js';
+import {
+  getHostWebhookSink,
+  getWebhookDeliveryStore,
+} from './services/metering/index.js';
 import {
   InMemoryDailyDocStore,
   UsageRollupConsumer,
@@ -135,6 +140,22 @@ app.use(
   })
 );
 app.use('/api/signing', authMiddleware, createSigningRouter(dataAdapter));
+
+// Host webhook delivery observability + manual replay (issue #144).
+// Host-key-authenticated: accepts `Authorization: Bearer ak_live_...` with
+// the `webhooks.write` scope. Falls through optional Firebase auth so the
+// per-route guard (`requireUserOrTenantScopes`) can issue the right 401/403.
+const webhookDeliveryStore = getWebhookDeliveryStore();
+app.locals.webhookDeliveryStore = webhookDeliveryStore;
+app.use(
+  '/api/v1/tenants',
+  hostApiKeyAuth,
+  optionalAuthMiddleware,
+  createWebhookDeliveriesRouter({
+    store: webhookDeliveryStore,
+    sink: getHostWebhookSink() ?? undefined,
+  })
+);
 
 // Tenant branding: GET is public (no auth), PUT requires auth.
 // Use a per-method gate so the public GET is reachable without a Bearer token.

--- a/functions/src/services/metering/HostWebhookSink.test.ts
+++ b/functions/src/services/metering/HostWebhookSink.test.ts
@@ -4,6 +4,7 @@ import {
   HostWebhookSink,
   computeWebhookSignature,
 } from './HostWebhookSink.js';
+import { InMemoryWebhookDeliveryStore } from './WebhookDeliveryStore.js';
 import type { NormalizedMeteringEvent } from './MeteringBus.js';
 
 function makeEvent(
@@ -80,6 +81,9 @@ describe('HostWebhookSink', () => {
 
     const parsed = JSON.parse(body);
     expect(parsed.version).toBe('v1');
+    expect(typeof parsed.batchId).toBe('string');
+    expect(parsed.batchId.length).toBeGreaterThan(0);
+    expect(init.headers['X-AuraPix-Idempotency-Key']).toBe(parsed.batchId);
     expect(Array.isArray(parsed.events)).toBe(true);
     expect(parsed.events).toHaveLength(1);
     expect(parsed.events[0].type).toBe('upload.accepted');
@@ -134,5 +138,139 @@ describe('HostWebhookSink', () => {
     });
     await sink.deliver([]);
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('HostWebhookSink + WebhookDeliveryStore (issue #144)', () => {
+  function makeEvent(
+    overrides: Partial<NormalizedMeteringEvent> = {}
+  ): NormalizedMeteringEvent {
+    return {
+      tenantId: 't1',
+      type: 'upload.accepted',
+      count: 1,
+      occurredAt: '2025-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  it('writes an ok delivery record on success', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 200 } as Response);
+    const store = new InMemoryWebhookDeliveryStore();
+    const sink = new HostWebhookSink({
+      webhookUrl: 'https://example.com/hook',
+      signingSecret: 's',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      deliveryStore: store,
+      batchIdFactory: () => 'batch-1',
+    });
+
+    await sink.deliver([makeEvent()]);
+
+    const rec = await store.get('t1', 'batch-1');
+    expect(rec).not.toBeNull();
+    expect(rec!.status).toBe('ok');
+    expect(rec!.ok).toBe(true);
+    expect(rec!.statusCode).toBe(200);
+    expect(rec!.attemptCount).toBe(1);
+    expect(rec!.eventCount).toBe(1);
+    expect(rec!.contentHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(rec!.expiresAt > rec!.sentAt).toBe(true);
+  });
+
+  it('writes a failed delivery record after exhausting retries', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 502 } as Response);
+    const store = new InMemoryWebhookDeliveryStore();
+    const sink = new HostWebhookSink({
+      webhookUrl: 'https://example.com/hook',
+      signingSecret: 's',
+      maxAttempts: 2,
+      backoffBaseMs: 1,
+      sleep: vi.fn().mockResolvedValue(undefined),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      deliveryStore: store,
+      batchIdFactory: () => 'batch-2',
+    });
+
+    await sink.deliver([makeEvent()]);
+
+    const rec = await store.get('t1', 'batch-2');
+    expect(rec!.status).toBe('failed');
+    expect(rec!.ok).toBe(false);
+    expect(rec!.statusCode).toBe(502);
+    expect(rec!.attemptCount).toBe(2);
+    expect(rec!.errorMessage).toMatch(/502/);
+  });
+
+  it('replayBatch re-POSTs with the same idempotency key and updates the existing record', async () => {
+    // First call fails 3x, second call (replay) succeeds.
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+      .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+      .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+    const store = new InMemoryWebhookDeliveryStore();
+    const sink = new HostWebhookSink({
+      webhookUrl: 'https://example.com/hook',
+      signingSecret: 's',
+      maxAttempts: 3,
+      backoffBaseMs: 1,
+      sleep: vi.fn().mockResolvedValue(undefined),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      deliveryStore: store,
+      batchIdFactory: () => 'batch-3',
+    });
+
+    const events = [makeEvent()];
+    await sink.deliver(events);
+    const failed = await store.get('t1', 'batch-3');
+    expect(failed!.status).toBe('failed');
+
+    // Replay using cached events on the sink.
+    const cached = sink.getCachedBatch('batch-3');
+    expect(cached).toBeDefined();
+    const updated = await sink.replayBatch(cached!, 'batch-3');
+
+    expect(updated!.status).toBe('ok');
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    // All 4 calls used the same idempotency key.
+    for (const call of fetchImpl.mock.calls) {
+      const init = call[1] as { headers: Record<string, string> };
+      expect(init.headers['X-AuraPix-Idempotency-Key']).toBe('batch-3');
+    }
+    // Single record (no duplicate row).
+    const all = await store.list('t1');
+    expect(all.items).toHaveLength(1);
+    expect(all.items[0]!.batchId).toBe('batch-3');
+  });
+
+  it('concurrent replays for the same batchId do not double-POST', async () => {
+    let resolveFirst: (value: Response) => void = () => {};
+    const firstPromise = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockImplementationOnce(() => firstPromise)
+      .mockResolvedValue({ ok: true, status: 200 } as Response);
+    const store = new InMemoryWebhookDeliveryStore();
+    const sink = new HostWebhookSink({
+      webhookUrl: 'https://example.com/hook',
+      signingSecret: 's',
+      maxAttempts: 1,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      deliveryStore: store,
+      batchIdFactory: () => 'batch-4',
+    });
+
+    const events = [makeEvent()];
+    const first = sink.deliver(events);
+    // Second call lands while the first is still in flight.
+    const second = sink.replayBatch(events, 'batch-4');
+    // Release the first call.
+    resolveFirst({ ok: true, status: 200 } as Response);
+    await Promise.all([first, second]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });

--- a/functions/src/services/metering/HostWebhookSink.ts
+++ b/functions/src/services/metering/HostWebhookSink.ts
@@ -1,9 +1,14 @@
-import { createHmac } from 'crypto';
+import { createHash, createHmac, randomUUID } from 'crypto';
 import { logger } from '../../utils/logger.js';
 import type {
   MeteringSink,
   NormalizedMeteringEvent,
 } from './MeteringBus.js';
+import {
+  computeDeliveryExpiry,
+  type WebhookDeliveryRecord,
+  type WebhookDeliveryStore,
+} from './WebhookDeliveryStore.js';
 
 export interface HostWebhookSinkOptions {
   /** Endpoint to POST batched events. If unset, sink is a no-op. */
@@ -20,10 +25,28 @@ export interface HostWebhookSinkOptions {
   fetchImpl?: typeof fetch;
   /** Inject sleep for tests. */
   sleep?: (ms: number) => Promise<void>;
+  /**
+   * Optional store for per-batch delivery observability (issue #144).
+   * When set, the sink writes a record on first attempt and updates it
+   * after each attempt (success or failure).
+   */
+  deliveryStore?: WebhookDeliveryStore;
+  /** Inject batch id generation (tests). */
+  batchIdFactory?: () => string;
+  /**
+   * How to resolve a tenant id for a batch. The bus today does not enforce
+   * a single tenant per batch; if events span tenants, the most-common
+   * tenantId in the batch is used. Defaults to that built-in behavior.
+   */
+  tenantIdResolver?: (events: NormalizedMeteringEvent[]) => string;
+  /** Maximum batches retained in the in-process replay cache. Default 256. */
+  recentBatchCap?: number;
 }
 
 const SIGNATURE_HEADER = 'X-AuraPix-Signature';
+const IDEMPOTENCY_HEADER = 'X-AuraPix-Idempotency-Key';
 const SIGNATURE_VERSION = 'v1';
+const ERROR_MESSAGE_MAX = 500;
 
 /**
  * Compute the value of the `X-AuraPix-Signature` header for a request body.
@@ -38,13 +61,47 @@ export function computeWebhookSignature(
   return `${SIGNATURE_VERSION}=${mac}`;
 }
 
+/** SHA-256 hex of the raw body. Stored on delivery records (no body kept). */
+export function computeContentHash(body: string): string {
+  return createHash('sha256').update(body).digest('hex');
+}
+
+function pickTenantId(events: NormalizedMeteringEvent[]): string {
+  if (events.length === 0) return 'lib:unknown';
+  if (events.length === 1) return events[0]!.tenantId;
+  const counts = new Map<string, number>();
+  for (const e of events) {
+    counts.set(e.tenantId, (counts.get(e.tenantId) ?? 0) + 1);
+  }
+  let bestId = events[0]!.tenantId;
+  let bestCount = -1;
+  for (const [id, n] of counts) {
+    if (n > bestCount) {
+      bestCount = n;
+      bestId = id;
+    }
+  }
+  return bestId;
+}
+
+function truncateError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.length > ERROR_MESSAGE_MAX
+    ? msg.slice(0, ERROR_MESSAGE_MAX)
+    : msg;
+}
+
 /**
  * Sink that POSTs batched metering events to a host-supplied webhook URL.
  *
  * - HMAC-SHA256 signature in `X-AuraPix-Signature` header.
+ * - Stable batch id sent in `X-AuraPix-Idempotency-Key` so hosts can dedupe
+ *   (especially across manual replays).
  * - Retries up to `maxAttempts` with exponential backoff.
  * - Drops the batch on exhaustion and logs; never throws.
  * - When `webhookUrl` is unset, behaves as a no-op.
+ * - When a `deliveryStore` is configured, persists a delivery record per
+ *   batch and updates it after each attempt (see issue #144).
  */
 export class HostWebhookSink implements MeteringSink {
   private readonly webhookUrl?: string;
@@ -54,6 +111,18 @@ export class HostWebhookSink implements MeteringSink {
   private readonly backoffBaseMs: number;
   private readonly fetchImpl: typeof fetch;
   private readonly sleep: (ms: number) => Promise<void>;
+  private readonly deliveryStore?: WebhookDeliveryStore;
+  private readonly batchIdFactory: () => string;
+  private readonly tenantIdResolver: (events: NormalizedMeteringEvent[]) => string;
+  /** In-flight batchIds (idempotency guard for concurrent replay). */
+  private readonly inflightBatches = new Set<string>();
+  /**
+   * Small bounded cache of recently-sent batches keyed by batchId, used to
+   * service manual replay (issue #144). Bodies are intentionally NOT
+   * persisted to Firestore; this cache lives only in-process.
+   */
+  private readonly recentBatches = new Map<string, NormalizedMeteringEvent[]>();
+  private readonly recentBatchCap: number;
 
   constructor(opts: HostWebhookSinkOptions) {
     this.webhookUrl = opts.webhookUrl;
@@ -64,6 +133,27 @@ export class HostWebhookSink implements MeteringSink {
     this.fetchImpl = opts.fetchImpl ?? ((...args) => fetch(...args));
     this.sleep =
       opts.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.deliveryStore = opts.deliveryStore;
+    this.batchIdFactory = opts.batchIdFactory ?? (() => randomUUID());
+    this.tenantIdResolver = opts.tenantIdResolver ?? pickTenantId;
+    this.recentBatchCap = opts.recentBatchCap ?? 256;
+  }
+
+  /** Look up the cached events for a recently-sent batch (replay helper). */
+  getCachedBatch(batchId: string): NormalizedMeteringEvent[] | undefined {
+    const events = this.recentBatches.get(batchId);
+    return events ? events.map((e) => ({ ...e })) : undefined;
+  }
+
+  private cacheBatch(batchId: string, events: NormalizedMeteringEvent[]): void {
+    // FIFO eviction.
+    if (this.recentBatches.has(batchId)) {
+      this.recentBatches.delete(batchId);
+    } else if (this.recentBatches.size >= this.recentBatchCap) {
+      const oldest = this.recentBatches.keys().next().value;
+      if (oldest !== undefined) this.recentBatches.delete(oldest);
+    }
+    this.recentBatches.set(batchId, events.map((e) => ({ ...e })));
   }
 
   /** True when a webhook URL is configured. */
@@ -75,72 +165,197 @@ export class HostWebhookSink implements MeteringSink {
     if (!this.webhookUrl || events.length === 0) {
       return;
     }
+    const batchId = this.batchIdFactory();
+    await this.sendBatch(events, batchId, /* isReplay */ false);
+  }
 
-    const body = JSON.stringify({
-      version: SIGNATURE_VERSION,
-      sentAt: new Date().toISOString(),
-      events,
-    });
-    const signature = computeWebhookSignature(body, this.signingSecret);
-
-    let lastError: unknown = null;
-    for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
-      try {
-        const response = await this.fetchImpl(this.webhookUrl, {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            [SIGNATURE_HEADER]: signature,
-          },
-          body,
-          signal: controller.signal,
-        });
-        if (response.ok) {
-          return;
-        }
-        lastError = new Error(
-          `Webhook returned non-2xx status ${response.status}`
-        );
-        logger.warn(
-          {
-            attempt,
-            status: response.status,
-            webhookUrl: this.webhookUrl,
-            eventCount: events.length,
-          },
-          'Metering webhook returned non-2xx; will retry if attempts remain'
-        );
-      } catch (err) {
-        lastError = err;
-        logger.warn(
-          {
-            attempt,
-            err,
-            webhookUrl: this.webhookUrl,
-            eventCount: events.length,
-          },
-          'Metering webhook delivery failed; will retry if attempts remain'
-        );
-      } finally {
-        clearTimeout(timeout);
-      }
-
-      if (attempt < this.maxAttempts) {
-        const delay = this.backoffBaseMs * 2 ** (attempt - 1);
-        await this.sleep(delay);
-      }
+  /**
+   * Re-send a previously-recorded batch. Reconstructs the body from the
+   * provided events, reuses the original `batchId` (so the idempotency
+   * header matches), and updates the existing delivery record in place.
+   *
+   * Concurrent calls for the same `batchId` are coalesced: the second call
+   * returns immediately without POSTing.
+   *
+   * Returns the latest delivery record (after the replay attempts) or
+   * `null` if no store is configured.
+   */
+  async replayBatch(
+    events: NormalizedMeteringEvent[],
+    batchId: string
+  ): Promise<WebhookDeliveryRecord | null> {
+    if (!this.webhookUrl) {
+      return this.deliveryStore?.get(this.tenantIdResolver(events), batchId) ?? null;
     }
+    await this.sendBatch(events, batchId, /* isReplay */ true);
+    if (!this.deliveryStore) return null;
+    return this.deliveryStore.get(this.tenantIdResolver(events), batchId);
+  }
 
-    logger.error(
-      {
-        err: lastError,
-        webhookUrl: this.webhookUrl,
-        eventCount: events.length,
-        droppedTypes: Array.from(new Set(events.map((e) => e.type))),
-      },
-      'Metering webhook exhausted retries; dropping batch'
-    );
+  private async sendBatch(
+    events: NormalizedMeteringEvent[],
+    batchId: string,
+    isReplay: boolean
+  ): Promise<void> {
+    if (this.inflightBatches.has(batchId)) {
+      // Idempotency: another caller is already POSTing this batch.
+      logger.info(
+        { batchId, isReplay },
+        'Webhook batch already in flight; skipping duplicate send'
+      );
+      return;
+    }
+    this.inflightBatches.add(batchId);
+    try {
+      // Cache the event payload so a manual replay can rebuild the body.
+      this.cacheBatch(batchId, events);
+      const sentAt = new Date().toISOString();
+      const body = JSON.stringify({
+        version: SIGNATURE_VERSION,
+        sentAt,
+        batchId,
+        events,
+      });
+      const signature = computeWebhookSignature(body, this.signingSecret);
+      const contentHash = computeContentHash(body);
+      const tenantId = this.tenantIdResolver(events);
+
+      // Seed (or refresh) the delivery record up front so failures are visible.
+      if (this.deliveryStore) {
+        if (isReplay) {
+          await this.deliveryStore.update(tenantId, batchId, {
+            status: 'pending',
+            updatedAt: sentAt,
+          });
+        } else {
+          const record: WebhookDeliveryRecord = {
+            batchId,
+            tenantId,
+            sentAt,
+            statusCode: null,
+            ok: false,
+            attemptCount: 0,
+            eventCount: events.length,
+            contentHash,
+            status: 'pending',
+            updatedAt: sentAt,
+            expiresAt: computeDeliveryExpiry(sentAt),
+          };
+          await this.deliveryStore.create(record);
+        }
+      }
+
+      let lastError: unknown = null;
+      let lastStatus: number | null = null;
+      let attemptCount = 0;
+      for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
+        attemptCount = attempt;
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+        try {
+          const response = await this.fetchImpl(this.webhookUrl!, {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              [SIGNATURE_HEADER]: signature,
+              [IDEMPOTENCY_HEADER]: batchId,
+            },
+            body,
+            signal: controller.signal,
+          });
+          lastStatus = response.status;
+          if (response.ok) {
+            await this.recordOutcome(tenantId, batchId, {
+              status: 'ok',
+              statusCode: response.status,
+              ok: true,
+              attemptCount,
+              errorMessage: undefined,
+            });
+            return;
+          }
+          lastError = new Error(
+            `Webhook returned non-2xx status ${response.status}`
+          );
+          logger.warn(
+            {
+              attempt,
+              batchId,
+              status: response.status,
+              webhookUrl: this.webhookUrl,
+              eventCount: events.length,
+              isReplay,
+            },
+            'Metering webhook returned non-2xx; will retry if attempts remain'
+          );
+        } catch (err) {
+          lastError = err;
+          logger.warn(
+            {
+              attempt,
+              batchId,
+              err,
+              webhookUrl: this.webhookUrl,
+              eventCount: events.length,
+              isReplay,
+            },
+            'Metering webhook delivery failed; will retry if attempts remain'
+          );
+        } finally {
+          clearTimeout(timeout);
+        }
+
+        if (attempt < this.maxAttempts) {
+          const delay = this.backoffBaseMs * 2 ** (attempt - 1);
+          await this.sleep(delay);
+        }
+      }
+
+      logger.error(
+        {
+          err: lastError,
+          batchId,
+          webhookUrl: this.webhookUrl,
+          eventCount: events.length,
+          droppedTypes: Array.from(new Set(events.map((e) => e.type))),
+          isReplay,
+        },
+        'Metering webhook exhausted retries; dropping batch'
+      );
+      await this.recordOutcome(tenantId, batchId, {
+        status: 'failed',
+        statusCode: lastStatus,
+        ok: false,
+        attemptCount,
+        errorMessage: truncateError(lastError),
+      });
+    } finally {
+      this.inflightBatches.delete(batchId);
+    }
+  }
+
+  private async recordOutcome(
+    tenantId: string,
+    batchId: string,
+    patch: {
+      status: 'ok' | 'failed';
+      statusCode: number | null;
+      ok: boolean;
+      attemptCount: number;
+      errorMessage?: string;
+    }
+  ): Promise<void> {
+    if (!this.deliveryStore) return;
+    try {
+      await this.deliveryStore.update(tenantId, batchId, {
+        ...patch,
+        updatedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      logger.warn(
+        { err, batchId, tenantId },
+        'Failed to persist webhook delivery record'
+      );
+    }
   }
 }

--- a/functions/src/services/metering/WebhookDeliveryStore.test.ts
+++ b/functions/src/services/metering/WebhookDeliveryStore.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InMemoryWebhookDeliveryStore,
+  computeDeliveryExpiry,
+  WEBHOOK_DELIVERY_TTL_DAYS,
+  type WebhookDeliveryRecord,
+} from './WebhookDeliveryStore.js';
+
+function makeRecord(
+  overrides: Partial<WebhookDeliveryRecord> = {}
+): WebhookDeliveryRecord {
+  const sentAt = overrides.sentAt ?? '2025-01-01T00:00:00.000Z';
+  return {
+    batchId: 'b1',
+    tenantId: 't1',
+    sentAt,
+    statusCode: null,
+    ok: false,
+    attemptCount: 0,
+    eventCount: 1,
+    contentHash: 'a'.repeat(64),
+    status: 'pending',
+    updatedAt: sentAt,
+    expiresAt: computeDeliveryExpiry(sentAt),
+    ...overrides,
+  };
+}
+
+describe('computeDeliveryExpiry', () => {
+  it('returns sentAt + 30 days', () => {
+    const sentAt = '2025-01-01T00:00:00.000Z';
+    const expiry = computeDeliveryExpiry(sentAt);
+    const days =
+      (new Date(expiry).getTime() - new Date(sentAt).getTime()) /
+      (24 * 60 * 60 * 1000);
+    expect(days).toBe(WEBHOOK_DELIVERY_TTL_DAYS);
+  });
+});
+
+describe('InMemoryWebhookDeliveryStore', () => {
+  it('create is idempotent on batchId', async () => {
+    const store = new InMemoryWebhookDeliveryStore();
+    await store.create(makeRecord({ batchId: 'b1', status: 'pending' }));
+    await store.create(makeRecord({ batchId: 'b1', status: 'failed' }));
+    const got = await store.get('t1', 'b1');
+    expect(got?.status).toBe('pending');
+  });
+
+  it('update patches existing record and returns the new one', async () => {
+    const store = new InMemoryWebhookDeliveryStore();
+    await store.create(makeRecord({ batchId: 'b1' }));
+    const updated = await store.update('t1', 'b1', {
+      status: 'ok',
+      statusCode: 200,
+      ok: true,
+      attemptCount: 1,
+    });
+    expect(updated?.status).toBe('ok');
+    expect(updated?.statusCode).toBe(200);
+    expect(updated?.ok).toBe(true);
+    const fetched = await store.get('t1', 'b1');
+    expect(fetched?.status).toBe('ok');
+  });
+
+  it('update on a missing record returns null', async () => {
+    const store = new InMemoryWebhookDeliveryStore();
+    const updated = await store.update('t1', 'missing', { status: 'failed' });
+    expect(updated).toBeNull();
+  });
+
+  it('list filters by status and orders newest first', async () => {
+    const store = new InMemoryWebhookDeliveryStore();
+    await store.create(makeRecord({ batchId: 'a', sentAt: '2025-01-01T00:00:00.000Z', status: 'ok' }));
+    await store.create(makeRecord({ batchId: 'b', sentAt: '2025-01-02T00:00:00.000Z', status: 'failed' }));
+    await store.create(makeRecord({ batchId: 'c', sentAt: '2025-01-03T00:00:00.000Z', status: 'failed' }));
+
+    const failed = await store.list('t1', { status: 'failed' });
+    expect(failed.items.map((r) => r.batchId)).toEqual(['c', 'b']);
+
+    const all = await store.list('t1');
+    expect(all.items.map((r) => r.batchId)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('list filters by since and paginates with cursor', async () => {
+    const store = new InMemoryWebhookDeliveryStore();
+    for (let i = 0; i < 5; i++) {
+      await store.create(
+        makeRecord({
+          batchId: `b${i}`,
+          sentAt: `2025-01-0${i + 1}T00:00:00.000Z`,
+        })
+      );
+    }
+    const sincePage = await store.list('t1', {
+      since: '2025-01-03T00:00:00.000Z',
+      limit: 2,
+    });
+    expect(sincePage.items.map((r) => r.batchId)).toEqual(['b4', 'b3']);
+    expect(sincePage.nextCursor).toBe('b3');
+
+    const next = await store.list('t1', {
+      since: '2025-01-03T00:00:00.000Z',
+      limit: 2,
+      cursor: sincePage.nextCursor,
+    });
+    expect(next.items.map((r) => r.batchId)).toEqual(['b2']);
+    expect(next.nextCursor).toBeUndefined();
+  });
+
+  it('list scopes per tenant', async () => {
+    const store = new InMemoryWebhookDeliveryStore();
+    await store.create(makeRecord({ tenantId: 't1', batchId: 'b1' }));
+    await store.create(makeRecord({ tenantId: 't2', batchId: 'b2' }));
+    const t1 = await store.list('t1');
+    const t2 = await store.list('t2');
+    expect(t1.items.map((r) => r.batchId)).toEqual(['b1']);
+    expect(t2.items.map((r) => r.batchId)).toEqual(['b2']);
+  });
+});

--- a/functions/src/services/metering/WebhookDeliveryStore.ts
+++ b/functions/src/services/metering/WebhookDeliveryStore.ts
@@ -1,0 +1,180 @@
+/**
+ * WebhookDeliveryStore — persistence for outbound host-webhook delivery
+ * records. One record per batch (NOT per attempt within a batch); the record
+ * is updated in place as attempts succeed or fail.
+ *
+ * Records live under `tenants/{tenantId}/webhookDeliveries/{batchId}` in
+ * Firestore. A Firestore TTL policy on `expiresAt` purges records after
+ * 30 days. We deliberately do NOT persist event bodies (privacy + cost);
+ * `contentHash` is stored so an operator can correlate a record with a
+ * specific payload if the upstream caller logs the same hash.
+ *
+ * See docs/features/metering-events.md → "Delivery observability".
+ *
+ * Tracking issue: #144.
+ */
+
+export type WebhookDeliveryStatus = 'pending' | 'ok' | 'failed';
+
+export interface WebhookDeliveryRecord {
+  /** Stable batch id (uuid). Used as Firestore doc id and idempotency key. */
+  batchId: string;
+  /** Tenant the batch was destined for. */
+  tenantId: string;
+  /** ISO-8601 of the first POST attempt. */
+  sentAt: string;
+  /** Last observed HTTP status code, or null if no response (network err). */
+  statusCode: number | null;
+  /** Convenience boolean: true iff statusCode is 2xx. */
+  ok: boolean;
+  /** Number of POST attempts so far (success or failure). */
+  attemptCount: number;
+  /** Number of metering events in the batch. */
+  eventCount: number;
+  /** SHA-256 hex digest of the raw POST body. */
+  contentHash: string;
+  /** Current state. `pending` is transient (in-flight). */
+  status: WebhookDeliveryStatus;
+  /** Truncated error message on the most recent failure. */
+  errorMessage?: string;
+  /** ISO-8601 of last attempt (success or failure). */
+  updatedAt: string;
+  /** ISO-8601 expiry for Firestore TTL (30 days from sentAt). */
+  expiresAt: string;
+}
+
+export interface WebhookDeliveryListOptions {
+  /** Filter by status. */
+  status?: WebhookDeliveryStatus;
+  /** Inclusive lower bound on `sentAt` (ISO-8601). */
+  since?: string;
+  /** Max records to return. Default 50, capped at 200. */
+  limit?: number;
+  /** Opaque pagination cursor (batchId of last item from previous page). */
+  cursor?: string;
+}
+
+export interface WebhookDeliveryListResult {
+  items: WebhookDeliveryRecord[];
+  /** Set when more results may exist; pass as `cursor` to the next call. */
+  nextCursor?: string;
+}
+
+export interface WebhookDeliveryStore {
+  /** Insert a new delivery record (or no-op if one already exists for batchId). */
+  create(record: WebhookDeliveryRecord): Promise<void>;
+  /** Update an existing delivery record by batchId. */
+  update(
+    tenantId: string,
+    batchId: string,
+    patch: Partial<Omit<WebhookDeliveryRecord, 'batchId' | 'tenantId'>>
+  ): Promise<WebhookDeliveryRecord | null>;
+  /** Fetch a single record (returns null if missing). */
+  get(
+    tenantId: string,
+    batchId: string
+  ): Promise<WebhookDeliveryRecord | null>;
+  /** List records for a tenant, newest first. */
+  list(
+    tenantId: string,
+    opts?: WebhookDeliveryListOptions
+  ): Promise<WebhookDeliveryListResult>;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+/**
+ * In-memory store. Used by local-mode/dev and by tests; production swaps in
+ * a Firestore-backed implementation in a follow-up.
+ */
+export class InMemoryWebhookDeliveryStore implements WebhookDeliveryStore {
+  // tenantId -> batchId -> record
+  private readonly byTenant = new Map<
+    string,
+    Map<string, WebhookDeliveryRecord>
+  >();
+
+  async create(record: WebhookDeliveryRecord): Promise<void> {
+    const bucket = this.bucket(record.tenantId);
+    if (!bucket.has(record.batchId)) {
+      bucket.set(record.batchId, { ...record });
+    }
+  }
+
+  async update(
+    tenantId: string,
+    batchId: string,
+    patch: Partial<Omit<WebhookDeliveryRecord, 'batchId' | 'tenantId'>>
+  ): Promise<WebhookDeliveryRecord | null> {
+    const bucket = this.byTenant.get(tenantId);
+    if (!bucket) return null;
+    const existing = bucket.get(batchId);
+    if (!existing) return null;
+    const next: WebhookDeliveryRecord = { ...existing, ...patch };
+    bucket.set(batchId, next);
+    return { ...next };
+  }
+
+  async get(
+    tenantId: string,
+    batchId: string
+  ): Promise<WebhookDeliveryRecord | null> {
+    const rec = this.byTenant.get(tenantId)?.get(batchId);
+    return rec ? { ...rec } : null;
+  }
+
+  async list(
+    tenantId: string,
+    opts: WebhookDeliveryListOptions = {}
+  ): Promise<WebhookDeliveryListResult> {
+    const bucket = this.byTenant.get(tenantId);
+    if (!bucket) return { items: [] };
+
+    const limit = Math.min(MAX_LIMIT, Math.max(1, opts.limit ?? DEFAULT_LIMIT));
+    let all = Array.from(bucket.values());
+    if (opts.status) {
+      all = all.filter((r) => r.status === opts.status);
+    }
+    if (opts.since) {
+      const since = opts.since;
+      all = all.filter((r) => r.sentAt >= since);
+    }
+    // Newest first by sentAt; batchId tiebreak for stable order.
+    all.sort((a, b) => {
+      if (a.sentAt === b.sentAt) return a.batchId.localeCompare(b.batchId);
+      return b.sentAt.localeCompare(a.sentAt);
+    });
+
+    let startIdx = 0;
+    if (opts.cursor) {
+      const idx = all.findIndex((r) => r.batchId === opts.cursor);
+      startIdx = idx >= 0 ? idx + 1 : 0;
+    }
+    const page = all.slice(startIdx, startIdx + limit);
+    const result: WebhookDeliveryListResult = { items: page.map((r) => ({ ...r })) };
+    if (startIdx + page.length < all.length) {
+      result.nextCursor = page[page.length - 1]!.batchId;
+    }
+    return result;
+  }
+
+  private bucket(tenantId: string): Map<string, WebhookDeliveryRecord> {
+    let b = this.byTenant.get(tenantId);
+    if (!b) {
+      b = new Map();
+      this.byTenant.set(tenantId, b);
+    }
+    return b;
+  }
+}
+
+export const WEBHOOK_DELIVERIES_COLLECTION = 'webhookDeliveries';
+export const WEBHOOK_DELIVERY_TTL_DAYS = 30;
+
+/** Compute a 30-day TTL expiry from a sentAt timestamp. */
+export function computeDeliveryExpiry(sentAtIso: string): string {
+  const t = new Date(sentAtIso).getTime();
+  const expiry = new Date(t + WEBHOOK_DELIVERY_TTL_DAYS * 24 * 60 * 60 * 1000);
+  return expiry.toISOString();
+}

--- a/functions/src/services/metering/index.ts
+++ b/functions/src/services/metering/index.ts
@@ -1,6 +1,10 @@
 import { signingConfig } from '../../config/index.js';
 import { HostWebhookSink } from './HostWebhookSink.js';
 import {
+  InMemoryWebhookDeliveryStore,
+  type WebhookDeliveryStore,
+} from './WebhookDeliveryStore.js';
+import {
   MeteringBus,
   NoopMeteringSink,
   type MeteringEvent,
@@ -31,16 +35,50 @@ export function resolveTenantId(opts: {
 }
 
 let busInstance: MeteringBus | null = null;
+let sinkInstance: HostWebhookSink | null = null;
+let deliveryStoreInstance: WebhookDeliveryStore | null = null;
+
+/**
+ * Process-wide delivery store used by the host webhook sink. Records are
+ * scoped to `tenants/{tenantId}/webhookDeliveries/{batchId}` and surfaced
+ * through the `/v1/tenants/:id/webhooks/deliveries*` routes (issue #144).
+ */
+export function getWebhookDeliveryStore(): WebhookDeliveryStore {
+  if (!deliveryStoreInstance) {
+    deliveryStoreInstance = new InMemoryWebhookDeliveryStore();
+  }
+  return deliveryStoreInstance;
+}
+
+export function setWebhookDeliveryStore(store: WebhookDeliveryStore | null): void {
+  deliveryStoreInstance = store;
+  // Force the sink to be rebuilt next time getHostWebhookSink() is called.
+  sinkInstance = null;
+  busInstance = null;
+}
 
 function buildSink(): MeteringSink {
   const webhookUrl = process.env.HOST_METERING_WEBHOOK_URL?.trim();
   if (!webhookUrl) {
     return new NoopMeteringSink();
   }
-  return new HostWebhookSink({
+  sinkInstance = new HostWebhookSink({
     webhookUrl,
     signingSecret: signingConfig.masterSecret,
+    deliveryStore: getWebhookDeliveryStore(),
   });
+  return sinkInstance;
+}
+
+/**
+ * Returns the host webhook sink instance (or null when metering is
+ * disabled / no webhook URL is configured). Exposed so the replay route
+ * (issue #144) can reuse the in-process batch cache.
+ */
+export function getHostWebhookSink(): HostWebhookSink | null {
+  // Ensure the bus has been initialized so sinkInstance is populated.
+  getMeteringBus();
+  return sinkInstance;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds delivery observability for the outbound host metering webhook so hosts can see what failed during a billing-service outage and manually replay missed batches — closing the silent-undercount loop called out in #144.

## Changes

- **`WebhookDeliveryStore`** (new): interface + in-memory implementation. Records live under `tenants/{tenantId}/webhookDeliveries/{batchId}`. No event bodies are stored — just a SHA-256 `contentHash`, status, attempt count, event count, error message, and a 30-day `expiresAt` for Firestore TTL.
- **`HostWebhookSink`** (updated):
  - Generates a stable `batchId` per send and includes `X-AuraPix-Idempotency-Key: <batchId>` so hosts can dedupe across automatic retries and manual replays.
  - Persists a single delivery record per batch and updates it after each attempt (success or failure) — no duplicate rows.
  - New `replayBatch(events, batchId)` re-POSTs using the original `batchId` and updates the existing record in place.
  - In-flight `batchId` set coalesces concurrent replays (no double-POST within the in-flight window).
  - Small bounded in-process cache (default 256 batches) holds raw events for replay; outside the window the replay endpoint returns 410.
- **`webhooks.write` scope** added to `TenantApiKey` scopes.
- **`GET /api/v1/tenants/:tenantId/webhooks/deliveries`** — paginated, filters by `status` / `since` / `cursor` / `limit` (default 50, max 200). Host-key authenticated.
- **`POST /api/v1/tenants/:tenantId/webhooks/deliveries/:batchId:replay`** — re-sends the cached batch, idempotent on `batchId`, updates the same record.
- **Firestore TTL** field override on `webhookDeliveries.expiresAt` (30 days) plus composite indexes for the list query.
- **Docs**: new “Delivery observability” section in `docs/features/metering-events.md` covering record shape, endpoints, idempotency, and the 410 replay-cache behavior.

## Acceptance criteria mapping

- [x] `webhookDeliveries` writes happen on every POST attempt (success and failure) — sink seeds on first attempt and updates after each attempt.
- [x] `GET .../deliveries` paginates and filters by status (and `since`).
- [x] `POST .../deliveries/:batchId:replay` re-sends and updates the existing record (no duplicate row).
- [x] Replay is idempotent: in-flight set prevents double-POST; idempotency key on the wire lets the host dedupe too.
- [x] Firestore TTL configured for 30-day auto-purge (`fieldOverrides[].ttl: true`).
- [x] Documented in `docs/features/metering-events.md` under a new “Delivery observability” section.

The in-memory store is wired in `server.ts` for local/dev mode, matching the existing pattern for the daily-usage rollup; the Firestore-backed implementation will follow in a separate issue (same pattern as `InMemoryDailyDocStore`).

## Testing

- 7 new unit tests for `InMemoryWebhookDeliveryStore` (create idempotency, update, filtering, pagination cursor, per-tenant scoping, TTL math).
- 5 new sink integration tests: writes ok record on success, writes failed record after retry exhaustion, replay re-POSTs with the same idempotency key and updates the existing record (no duplicate row), concurrent replays for the same `batchId` don’t double-POST.
- Updated the existing signature test to assert the new `batchId` field in the body and the `X-AuraPix-Idempotency-Key` header.
- Full suite: **170 passed**, no regressions.

Fixes rwrife/AuraPix#144