### PR TITLE
fix: emit share.viewed and plugin.ran metering events

### DIFF
--- a/docs/features/metering-events.md
+++ b/docs/features/metering-events.md
@@ -41,9 +41,10 @@ type MeteringEvent = {
 | `image.processed` | `handlers/thumbnails/generate.ts` after derivatives are written | one event per derivative variant (7 today: small/medium/large × webp+jpeg + preview_jpeg), `resourceId=photoId`, `meta.stage='thumbnail'` |
 | `signed_url.issued` | `routes/signing.ts` user and share grants | `resourceId=signingKey.keyId`, `meta.grantType='user'\|'share'` |
 | `edit.applied` | `handlers/edits/applyEdits.ts` after a non-destructive edit version is committed | `resourceId=photoId`, `meta.version`, `meta.operationCount` |
+| `share.viewed` | `services/imageAuth/ImageAuthorizer.ts` after a share token passes auth, expiry, max-uses, and resource-scope checks (i.e. an access is actually granted; failed accesses are not counted) | `count=1`, `resourceId=shareLink.id`, `meta.photoId`, `meta.libraryId`, `meta.grantType='album'\|'photo'\|'library'` |
+| `plugin.ran` | `handlers/edits/applyEdits.ts` once per edit operation in the recipe, on both success and failure | `count=1`, `resourceId=photoId`, `meta.pluginId`, `meta.durationMs`, `meta.success` |
 
-Reserved for follow-ups (not emitted yet): `plugin.ran`, `user.active`,
-`share.viewed`.
+Reserved for follow-ups (not emitted yet): `user.active`.
 
 ## Tenant resolution
 

--- a/functions/src/handlers/edits/applyEdits.metering.test.ts
+++ b/functions/src/handlers/edits/applyEdits.metering.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleApplyEdits } from './applyEdits.js';
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+import type { StorageAdapter } from '../../adapters/storage/StorageAdapter.js';
+import type { Photo } from '../../models/Photo.js';
+import {
+  MeteringBus,
+  type MeteringSink,
+  type NormalizedMeteringEvent,
+} from '../../services/metering/MeteringBus.js';
+import { setMeteringBus } from '../../services/metering/index.js';
+
+class CapturingSink implements MeteringSink {
+  events: NormalizedMeteringEvent[] = [];
+  async deliver(events: NormalizedMeteringEvent[]): Promise<void> {
+    this.events.push(...events);
+  }
+}
+
+function createPhoto(): Photo {
+  return {
+    id: 'photo-1',
+    libraryId: 'lib-1',
+    albumIds: [],
+    originalName: 'test.jpg',
+    metadata: { width: 100, height: 100, mimeType: 'image/jpeg', sizeBytes: 123 },
+    status: 'ready',
+    currentEditVersion: 0,
+    editHistory: [],
+    thumbnailsOutdated: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function makeDataAdapter(photo: Photo | null, updateImpl?: () => Promise<void>): DataAdapter {
+  return {
+    storeData: vi.fn(async () => {}),
+    fetchData: vi.fn(async () => photo),
+    queryData: vi.fn(async () => []),
+    updateData: vi.fn(updateImpl ?? (async () => {})),
+    deleteData: vi.fn(async () => {}),
+    exists: vi.fn(async () => true),
+    listIds: vi.fn(async () => []),
+    getPhoto: vi.fn(async () => photo),
+  } as unknown as DataAdapter;
+}
+
+function makeStorage(): StorageAdapter {
+  return {
+    storeFile: vi.fn(),
+    readFile: vi.fn(async () => Buffer.alloc(0)),
+    fileExists: vi.fn(async () => true),
+    deleteFile: vi.fn(),
+    listFiles: vi.fn(async () => []),
+    getFileSize: vi.fn(async () => 0),
+  } as unknown as StorageAdapter;
+}
+
+function makeRes() {
+  const res: any = { status: vi.fn(), json: vi.fn() };
+  res.status.mockReturnValue(res);
+  return res;
+}
+
+function makeReq(operations: { type: string; params: Record<string, unknown>; order: number }[]) {
+  return {
+    params: { libraryId: 'lib-1', photoId: 'photo-1' },
+    user: { uid: 'user-1' },
+    header: () => undefined,
+    body: { recipeVersion: 1, operations },
+    app: {
+      locals: {
+        dataAdapter: undefined as unknown as DataAdapter,
+        storageAdapter: undefined as unknown as StorageAdapter,
+      },
+    },
+  };
+}
+
+describe('applyEdits plugin.ran metering', () => {
+  let sink: CapturingSink;
+  let bus: MeteringBus;
+
+  beforeEach(() => {
+    sink = new CapturingSink();
+    bus = new MeteringBus({ sink, flushIntervalMs: 10, maxBatchSize: 1 });
+    setMeteringBus(bus);
+  });
+
+  afterEach(() => {
+    setMeteringBus(null);
+    vi.restoreAllMocks();
+  });
+
+  it('emits one plugin.ran event per operation on success', async () => {
+    const photo = createPhoto();
+    const data = makeDataAdapter(photo);
+    const storage = makeStorage();
+    const req: any = makeReq([
+      { type: 'rotate', params: { degrees: 90 }, order: 0 },
+      { type: 'filter', params: { filterName: 'grayscale' }, order: 1 },
+    ]);
+    req.app.locals.dataAdapter = data;
+    req.app.locals.storageAdapter = storage;
+    const res = makeRes();
+
+    await handleApplyEdits(req, res);
+    await bus.flush();
+
+    const pluginEvents = sink.events.filter((e) => e.type === 'plugin.ran');
+    expect(pluginEvents).toHaveLength(2);
+    for (const ev of pluginEvents) {
+      expect(ev.tenantId).toBe('lib:lib-1');
+      expect(ev.resourceId).toBe('photo-1');
+      expect(ev.meta).toMatchObject({ libraryId: 'lib-1', success: true });
+      expect(typeof (ev.meta as any).durationMs).toBe('number');
+      expect(typeof (ev.meta as any).pluginId).toBe('string');
+    }
+    expect(pluginEvents.map((e) => (e.meta as any).pluginId).sort()).toEqual(['filter', 'rotate']);
+  });
+
+  it('emits plugin.ran with success=false when the commit fails, exactly once per op', async () => {
+    const photo = createPhoto();
+    const data = makeDataAdapter(photo, async () => {
+      throw new Error('boom');
+    });
+    const storage = makeStorage();
+    const req: any = makeReq([
+      { type: 'rotate', params: { degrees: 90 }, order: 0 },
+      { type: 'filter', params: { filterName: 'sepia' }, order: 1 },
+    ]);
+    req.app.locals.dataAdapter = data;
+    req.app.locals.storageAdapter = storage;
+    const res = makeRes();
+
+    await expect(handleApplyEdits(req, res)).rejects.toBeDefined();
+    await bus.flush();
+
+    const pluginEvents = sink.events.filter((e) => e.type === 'plugin.ran');
+    expect(pluginEvents).toHaveLength(2);
+    for (const ev of pluginEvents) {
+      expect(ev.meta).toMatchObject({ libraryId: 'lib-1', success: false });
+    }
+    // No `edit.applied` should have leaked through on failure.
+    expect(sink.events.filter((e) => e.type === 'edit.applied')).toHaveLength(0);
+  });
+
+  it('does NOT emit plugin.ran when validation fails (no plugin actually ran)', async () => {
+    const photo = createPhoto();
+    const data = makeDataAdapter(photo);
+    const storage = makeStorage();
+    // crop missing required fields -> validateOperations rejects before commit
+    const req: any = makeReq([{ type: 'crop', params: {}, order: 0 }]);
+    req.app.locals.dataAdapter = data;
+    req.app.locals.storageAdapter = storage;
+    const res = makeRes();
+
+    await expect(handleApplyEdits(req, res)).rejects.toBeDefined();
+    await bus.flush();
+
+    expect(sink.events.filter((e) => e.type === 'plugin.ran')).toHaveLength(0);
+  });
+});

--- a/functions/src/handlers/edits/applyEdits.ts
+++ b/functions/src/handlers/edits/applyEdits.ts
@@ -50,6 +50,38 @@ function assertEditVersionMatch(
   }
 }
 
+/**
+ * Emit a `plugin.ran` metering event for every operation in the recipe.
+ * Called once for an entire apply attempt: success=true after the version
+ * is committed, success=false if the apply fails after validation.
+ * `durationMs` is the elapsed wall-clock time of the apply attempt and is
+ * reported per-op (a coarse but stable proxy at this scope).
+ */
+function emitPluginRanEvents(opts: {
+  libraryId: string;
+  photoId: string;
+  operations: { type: string }[];
+  durationMs: number;
+  success: boolean;
+}): void {
+  const { libraryId, photoId, operations, durationMs, success } = opts;
+  const tenantId = resolveTenantId({ libraryId });
+  for (const op of operations) {
+    emitMeteringEvent({
+      tenantId,
+      type: 'plugin.ran',
+      count: 1,
+      resourceId: photoId,
+      meta: {
+        libraryId,
+        pluginId: op.type,
+        durationMs,
+        success,
+      },
+    });
+  }
+}
+
 
 /**
  * List edit plugins and recipe contract version
@@ -166,6 +198,22 @@ export async function handleApplyEdits(
 
     assertEditVersionMatch(expectedCurrentVersion, photo.currentEditVersion);
 
+    const pluginStartedAt = Date.now();
+    let pluginRanEmitted = false;
+
+    const onPluginFailure = (): void => {
+      if (pluginRanEmitted) return;
+      pluginRanEmitted = true;
+      emitPluginRanEvents({
+        libraryId,
+        photoId,
+        operations,
+        durationMs: Date.now() - pluginStartedAt,
+        success: false,
+      });
+    };
+
+    try {
     // Create new edit version
     const newVersion: EditVersion = {
       version: photo.currentEditVersion + 1,
@@ -207,6 +255,18 @@ export async function handleApplyEdits(
         operationCount: operations.length,
       },
     });
+
+    // Emit one `plugin.ran` event per operation. We emit exactly once
+    // per op per apply attempt; the failure-path emission is guarded by
+    // `pluginRanEmitted` to prevent double counting.
+    emitPluginRanEvents({
+      libraryId,
+      photoId,
+      operations,
+      durationMs: Date.now() - pluginStartedAt,
+      success: true,
+    });
+    pluginRanEmitted = true;
 
     const responseBody = {
       photoId,
@@ -266,6 +326,10 @@ export async function handleApplyEdits(
         );
       }
     });
+    } catch (innerError) {
+      onPluginFailure();
+      throw innerError;
+    }
   } catch (error) {
     if (error instanceof AppError) {
       throw error;

--- a/functions/src/services/imageAuth/ImageAuthorizer.metering.test.ts
+++ b/functions/src/services/imageAuth/ImageAuthorizer.metering.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ImageAuthorizer } from './ImageAuthorizer.js';
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+import type { Photo } from '../../models/Photo.js';
+import {
+  MeteringBus,
+  type MeteringSink,
+  type NormalizedMeteringEvent,
+} from '../metering/MeteringBus.js';
+import { setMeteringBus } from '../metering/index.js';
+
+class CapturingSink implements MeteringSink {
+  events: NormalizedMeteringEvent[] = [];
+  async deliver(events: NormalizedMeteringEvent[]): Promise<void> {
+    this.events.push(...events);
+  }
+}
+
+function photoFixture(overrides: Partial<Photo> = {}): Photo {
+  return {
+    id: 'photo-1',
+    libraryId: 'lib-1',
+    albumIds: ['album-1'],
+    originalName: 'a.jpg',
+    metadata: { width: 1, height: 1, mimeType: 'image/jpeg', sizeBytes: 1 },
+    status: 'ready',
+    currentEditVersion: 0,
+    editHistory: [],
+    thumbnailsOutdated: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as Photo;
+}
+
+interface FakeShareLink {
+  id: string;
+  token: string;
+  resourceType: 'album' | 'photo' | 'library';
+  resourceId: string;
+  revoked: boolean;
+  policy: { expiresAt: string | null; maxUses: number | null };
+  useCount: number;
+}
+
+function makeDataAdapter(shareLinks: FakeShareLink[]): DataAdapter {
+  return {
+    storeData: vi.fn(async () => {}),
+    fetchData: vi.fn(async () => null),
+    queryData: vi.fn(async (_coll: string) => shareLinks as unknown as never[]),
+    updateData: vi.fn(async () => {}),
+    deleteData: vi.fn(async () => {}),
+    exists: vi.fn(async () => false),
+    listIds: vi.fn(async () => []),
+    getPhoto: vi.fn(async () => null),
+  } as unknown as DataAdapter;
+}
+
+describe('ImageAuthorizer share.viewed metering', () => {
+  let sink: CapturingSink;
+  let bus: MeteringBus;
+
+  beforeEach(() => {
+    sink = new CapturingSink();
+    bus = new MeteringBus({ sink, flushIntervalMs: 10, maxBatchSize: 1 });
+    setMeteringBus(bus);
+  });
+
+  afterEach(() => {
+    setMeteringBus(null);
+    vi.restoreAllMocks();
+  });
+
+  it('emits share.viewed on a successful album share access', async () => {
+    const photo = photoFixture();
+    const link: FakeShareLink = {
+      id: 'link-1',
+      token: 'tok-abc',
+      resourceType: 'album',
+      resourceId: 'album-1',
+      revoked: false,
+      policy: { expiresAt: null, maxUses: null },
+      useCount: 0,
+    };
+    const data = makeDataAdapter([link]);
+    const authz = new ImageAuthorizer(data);
+
+    const granted = await authz.checkShareAccess('tok-abc', photo);
+    await bus.flush();
+
+    expect(granted).toBe(true);
+    const evts = sink.events.filter((e) => e.type === 'share.viewed');
+    expect(evts).toHaveLength(1);
+    expect(evts[0]!.tenantId).toBe('lib:lib-1');
+    expect(evts[0]!.resourceId).toBe('link-1');
+    expect(evts[0]!.meta).toMatchObject({
+      photoId: 'photo-1',
+      libraryId: 'lib-1',
+      grantType: 'album',
+    });
+  });
+
+  it('does NOT emit share.viewed for a revoked share link', async () => {
+    const link: FakeShareLink = {
+      id: 'link-2',
+      token: 'tok-rev',
+      resourceType: 'photo',
+      resourceId: 'photo-1',
+      revoked: true,
+      policy: { expiresAt: null, maxUses: null },
+      useCount: 0,
+    };
+    const authz = new ImageAuthorizer(makeDataAdapter([link]));
+    const granted = await authz.checkShareAccess('tok-rev', photoFixture());
+    await bus.flush();
+
+    expect(granted).toBe(false);
+    expect(sink.events.filter((e) => e.type === 'share.viewed')).toHaveLength(0);
+  });
+
+  it('does NOT emit share.viewed for an expired share link', async () => {
+    const link: FakeShareLink = {
+      id: 'link-3',
+      token: 'tok-exp',
+      resourceType: 'photo',
+      resourceId: 'photo-1',
+      revoked: false,
+      policy: { expiresAt: new Date(Date.now() - 1000).toISOString(), maxUses: null },
+      useCount: 0,
+    };
+    const authz = new ImageAuthorizer(makeDataAdapter([link]));
+    const granted = await authz.checkShareAccess('tok-exp', photoFixture());
+    await bus.flush();
+
+    expect(granted).toBe(false);
+    expect(sink.events.filter((e) => e.type === 'share.viewed')).toHaveLength(0);
+  });
+
+  it('does NOT emit share.viewed when photo is outside the shared resource', async () => {
+    const link: FakeShareLink = {
+      id: 'link-4',
+      token: 'tok-mis',
+      resourceType: 'album',
+      resourceId: 'album-other',
+      revoked: false,
+      policy: { expiresAt: null, maxUses: null },
+      useCount: 0,
+    };
+    const authz = new ImageAuthorizer(makeDataAdapter([link]));
+    const granted = await authz.checkShareAccess('tok-mis', photoFixture());
+    await bus.flush();
+
+    expect(granted).toBe(false);
+    expect(sink.events.filter((e) => e.type === 'share.viewed')).toHaveLength(0);
+  });
+
+  it('does NOT emit share.viewed when share token is unknown', async () => {
+    const authz = new ImageAuthorizer(makeDataAdapter([]));
+    const granted = await authz.checkShareAccess('tok-nope', photoFixture());
+    await bus.flush();
+
+    expect(granted).toBe(false);
+    expect(sink.events.filter((e) => e.type === 'share.viewed')).toHaveLength(0);
+  });
+});

--- a/functions/src/services/imageAuth/ImageAuthorizer.ts
+++ b/functions/src/services/imageAuth/ImageAuthorizer.ts
@@ -3,6 +3,10 @@ import type { Photo } from '../../models/Photo.js';
 import type { Library } from '../../models/Library.js';
 import type { ImageSignature, ImageAuthResult } from '../../models/ImageAuth.js';
 import { logger } from '../../utils/logger.js';
+import {
+  emitMeteringEvent,
+  resolveTenantId,
+} from '../metering/index.js';
 
 // Share link types (subset needed for authorization)
 interface ShareLink {
@@ -187,6 +191,21 @@ export class ImageAuthorizer {
       if (hasAccess) {
         // Log successful access for compliance/analytics
         await this.logShareAccess(shareLink.id, shareToken, 'granted');
+
+        // Emit metering event for billable share view. We only emit here
+        // (after auth/expiry/maxUses/scope checks pass) so failed accesses
+        // are NOT counted.
+        emitMeteringEvent({
+          tenantId: resolveTenantId({ libraryId: photo.libraryId }),
+          type: 'share.viewed',
+          count: 1,
+          resourceId: shareLink.id,
+          meta: {
+            photoId: photo.id,
+            libraryId: photo.libraryId,
+            grantType: shareLink.resourceType,
+          },
+        });
       }
 
       return hasAccess;

--- a/functions/src/services/metering/MeteringBus.ts
+++ b/functions/src/services/metering/MeteringBus.ts
@@ -11,11 +11,11 @@ export type MeteringEventType =
   | 'upload.accepted'
   | 'image.processed'
   | 'signed_url.issued'
-  | 'edit.applied';
+  | 'edit.applied'
+  | 'share.viewed'
+  | 'plugin.ran';
 // Future (placeholder; not emitted in this PR):
-//   | 'plugin.ran'
 //   | 'user.active'
-//   | 'share.viewed'
 
 export interface MeteringEvent {
   /**


### PR DESCRIPTION
## Summary

Moves `share.viewed` and `plugin.ran` from the "reserved" section of the metering catalog (#130) to the emitted set, so hosts can bill per share view (engagement) and per plugin run (compute) without instrumenting outside AuraPix. `user.active` remains reserved for a follow-up.

## Changes

- `services/metering/MeteringBus.ts`: add `share.viewed` and `plugin.ran` to `MeteringEventType`.
- `services/imageAuth/ImageAuthorizer.ts`: emit `share.viewed` only after a share token passes the revoked / expiry / max-uses / resource-scope checks (i.e. on a granted access). Failed accesses are not counted.
  - `tenantId = resolveTenantId({ libraryId: photo.libraryId })`, `resourceId = shareLink.id`, `meta = { photoId, libraryId, grantType: shareLink.resourceType }`.
- `handlers/edits/applyEdits.ts`: emit one `plugin.ran` event per operation in the recipe, exactly once per apply attempt. Success path emits after the version commits (`meta.success=true`); failure path emits in the surrounding catch with `meta.success=false`. A `pluginRanEmitted` guard prevents double-emission when an edit applies multiple ops.
  - `tenantId = resolveTenantId({ libraryId })`, `resourceId = photoId`, `meta = { libraryId, pluginId, durationMs, success }`.
- `docs/features/metering-events.md`: catalog table updated; reserved list now contains only `user.active`.

## Testing

New vitest suites:
- `services/imageAuth/ImageAuthorizer.metering.test.ts` (5 tests): asserts `share.viewed` lands on the bus with correct `tenantId`/`resourceId`/`meta` for a granted album share, and asserts no event for revoked, expired, out-of-scope, and unknown tokens.
- `handlers/edits/applyEdits.metering.test.ts` (3 tests): asserts one `plugin.ran` per op on success (with correct `tenantId`/`resourceId`/`meta` and a numeric `durationMs`), one `plugin.ran` per op with `success=false` when the commit fails, and no `plugin.ran` when validation rejects the recipe (no plugin actually ran).

All 167 tests in `functions/` pass. (Three pre-existing failures in `src/adapters/uploads/FirebaseUploadService.emulator.test.ts` are emulator-dependent and reproduce on `main`.)

Fixes rwrife/AuraPix#140