### PR TITLE
fix: Soft-delete (Trash) for photos with TTL purge + metering events

### DIFF
--- a/contracts/openapi/photos.openapi.json
+++ b/contracts/openapi/photos.openapi.json
@@ -1,0 +1,163 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AuraPix Photos API",
+    "version": "1.0.0",
+    "description": "Soft-delete (Trash) lifecycle for photos. See issue #152."
+  },
+  "servers": [
+    { "url": "https://api.aurapix.example" }
+  ],
+  "paths": {
+    "/v1/photos": {
+      "get": {
+        "operationId": "listPhotos",
+        "summary": "List photos for the caller's tenant",
+        "parameters": [
+          {
+            "name": "trashed",
+            "in": "query",
+            "description": "When true, returns only photos currently in Trash.",
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Photos page",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ListPhotosResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/v1/photos/{id}": {
+      "delete": {
+        "operationId": "trashPhoto",
+        "summary": "Soft-delete (Trash) a photo",
+        "description": "Sets `trashedAt = now`; the photo is removed from default list queries but bytes are retained until the TTL purge job runs.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trashed",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TrashStateResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/v1/photos/{id}/restore": {
+      "post": {
+        "operationId": "restorePhoto",
+        "summary": "Restore a trashed photo",
+        "description": "Clears `trashedAt` / `trashedBy`. Cross-tenant restore returns 403.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Restored",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TrashStateResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PhotoSummary": {
+        "type": "object",
+        "required": ["id", "libraryId", "originalName", "status", "createdAt", "updatedAt"],
+        "properties": {
+          "id": { "type": "string" },
+          "libraryId": { "type": "string" },
+          "originalName": { "type": "string" },
+          "status": { "type": "string" },
+          "trashedAt": { "type": ["string", "null"], "format": "date-time" },
+          "trashedBy": { "type": ["string", "null"] },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "ListPhotosResponse": {
+        "type": "object",
+        "required": ["photos"],
+        "properties": {
+          "photos": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/PhotoSummary" }
+          }
+        }
+      },
+      "TrashStateResponse": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "string" },
+          "trashedAt": { "type": ["string", "null"], "format": "date-time" },
+          "trashedBy": { "type": ["string", "null"] }
+        }
+      },
+      "ErrorEnvelope": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "message", "requestId"],
+            "properties": {
+              "code": { "type": "string" },
+              "message": { "type": "string" },
+              "requestId": { "type": "string" },
+              "details": { "type": ["object", "null"] }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Missing or invalid authentication",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Cross-tenant access denied",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Photo not found",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/features/library-and-organization.md
+++ b/docs/features/library-and-organization.md
@@ -9,9 +9,62 @@ Allow users to organize photos into albums and collections with fast browsing an
 - Collections (albums grouped logically)
 - Metadata display and search filters
 - Favorites, tags, and quick views
+- **Trash (soft-delete) with TTL purge** — recoverable photo deletion (issue #152)
 
 ## Planned detail expansion
 - Firestore schema for albums, collections, and photo references
 - UI layout patterns and pagination strategy
 - Indexing strategy for common filter combinations
 - Bulk actions and conflict handling
+
+## Trash (soft-delete) for photos
+
+_Tracking issue: [#152](https://github.com/rwrife/AuraPix/issues/152)._
+
+AuraPix supports a recoverable Trash for photos, matching the UX users
+expect from Lightroom, Apple Photos, and Google Photos. Deletes go to
+Trash first; bytes are kept until a scheduled purge job hard-deletes
+them after a retention window.
+
+### Data model
+
+Each `photo` document carries:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `trashedAt` | ISO-8601 string \| null | Set when soft-deleted; `null` when active. |
+| `trashedBy` | string \| null | User id (or tenant subject) that initiated the delete. |
+
+### Endpoints
+
+| Method | Path | Behavior |
+| --- | --- | --- |
+| `DELETE` | `/v1/photos/:id` | **Soft delete.** Sets `trashedAt = now`; the photo no longer appears in default list queries. Returns `200`. |
+| `POST` | `/v1/photos/:id/restore` | Clears `trashedAt` / `trashedBy`. Cross-tenant restore returns `403`. |
+| `GET` | `/v1/photos?trashed=true` | Lists the caller's tenant's trash. |
+| `GET` | `/v1/photos` | Lists active (non-trashed) photos for the caller's tenant. |
+
+All routes are tenant-scoped via the existing `resolveTenant`
+middleware and enforce `assertSameTenant` in the service layer.
+
+### TTL purge job
+
+A scheduled job (`functions/src/jobs/purgeTrash.ts`) hard-deletes photos
+whose `trashedAt` is older than `TRASH_RETENTION_DAYS` (default **30**,
+env-configurable per deployment). The job:
+
+- Iterates **per-tenant** so one noisy tenant cannot starve others.
+- Reuses the storage-cleanup path on the existing `StorageAdapter`
+  (no new storage code).
+- Caps work per tenant per run via `perTenantLimit` (default 1000).
+- Emits `photo.purged` exactly once per photo (see
+  [Metering Events](./metering-events.md)).
+
+### Multi-tenant considerations
+
+- `TRASH_RETENTION_DAYS` is a deployment-wide default; a follow-up may
+  move it onto the tenant config doc when a host requests per-tenant
+  retention.
+- The purge job's per-tenant iteration is a soft fairness guarantee
+  driven by `perTenantLimit`; production wiring should run the job on a
+  cadence short enough that the limit drains backlogs within SLA.

--- a/docs/features/metering-events.md
+++ b/docs/features/metering-events.md
@@ -43,6 +43,8 @@ type MeteringEvent = {
 | `edit.applied` | `handlers/edits/applyEdits.ts` after a non-destructive edit version is committed | `resourceId=photoId`, `meta.version`, `meta.operationCount` |
 | `share.viewed` | `services/imageAuth/ImageAuthorizer.ts` after a share token passes auth, expiry, max-uses, and resource-scope checks (i.e. an access is actually granted; failed accesses are not counted) | `count=1`, `resourceId=shareLink.id`, `meta.photoId`, `meta.libraryId`, `meta.grantType='album'\|'photo'\|'library'` |
 | `plugin.ran` | `handlers/edits/applyEdits.ts` once per edit operation in the recipe, on both success and failure | `count=1`, `resourceId=photoId`, `meta.pluginId`, `meta.durationMs`, `meta.success` |
+| `photo.trashed` | `domain/photos/PhotosService.softDelete` (`DELETE /v1/photos/:id`) | `count=1`, `bytes=original.sizeBytes`, `resourceId=photoId`, `meta.libraryId`, `meta.actor`. Hosts that bill on "active storage" can decrement immediately; hosts that bill on "stored bytes" can ignore. |
+| `photo.purged` | `jobs/purgeTrash.ts` after bytes are freed | `count=1`, **`bytes=-original.sizeBytes`** (negative), `resourceId=photoId`, `meta.libraryId`, `meta.trashedAt`. The daily `storageBytesDelta` rollup decrements on this event, not on `photo.trashed`. Emitted **exactly once** per photo. |
 
 Reserved for follow-ups (not emitted yet): `user.active`.
 

--- a/functions/src/domain/photos/PhotosService.test.ts
+++ b/functions/src/domain/photos/PhotosService.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import type { DataAdapter, QueryFilter } from '../../adapters/data/DataAdapter.js';
+import type { StorageAdapter } from '../../adapters/storage/StorageAdapter.js';
+import {
+  PhotosService,
+  PhotoNotFoundError,
+  collectStoragePaths,
+} from './PhotosService.js';
+import { CrossTenantAccessError } from '../tenant/Tenant.js';
+import {
+  setMeteringBus,
+  setWebhookDeliveryStore,
+} from '../../services/metering/index.js';
+import {
+  MeteringBus,
+  type MeteringSink,
+  type NormalizedMeteringEvent,
+} from '../../services/metering/MeteringBus.js';
+import { InMemoryUsageMeteringBus } from '../../services/metering/UsageMeteringBus.js';
+import type { Photo } from '../../models/Photo.js';
+
+class InMemoryData implements DataAdapter {
+  public docs = new Map<string, Map<string, any>>();
+  private col(c: string) {
+    let m = this.docs.get(c);
+    if (!m) {
+      m = new Map();
+      this.docs.set(c, m);
+    }
+    return m;
+  }
+  async storeData<T>(c: string, id: string, data: T) { this.col(c).set(id, data); }
+  async fetchData<T>(c: string, id: string) {
+    return (this.col(c).get(id) as T) ?? null;
+  }
+  async queryData<T>(c: string, filters: QueryFilter[]): Promise<T[]> {
+    const all = Array.from(this.col(c).values()) as T[];
+    return all.filter((d) =>
+      filters.every((f) => {
+        const v = (d as any)[f.field];
+        switch (f.operator) {
+          case '==': return v === f.value;
+          case '!=': return v !== f.value;
+          case '>': return v > f.value;
+          case '>=': return v >= f.value;
+          case '<': return v < f.value;
+          case '<=': return v <= f.value;
+          default: return false;
+        }
+      })
+    );
+  }
+  async updateData<T>(c: string, id: string, updates: Partial<T>) {
+    const cur = this.col(c).get(id);
+    if (!cur) throw new Error('not found');
+    this.col(c).set(id, { ...cur, ...updates });
+  }
+  async deleteData(c: string, id: string) { this.col(c).delete(id); }
+  async exists(c: string, id: string) { return this.col(c).has(id); }
+  async listIds(c: string) { return Array.from(this.col(c).keys()); }
+  async getPhoto() { return null; }
+}
+
+class CapturingStorage implements StorageAdapter {
+  public deleted: string[] = [];
+  public failPaths = new Set<string>();
+  async storeFile() {}
+  async readFile() { return Buffer.alloc(0); }
+  async fileExists() { return true; }
+  async deleteFile(p: string) {
+    if (this.failPaths.has(p)) throw new Error('boom');
+    this.deleted.push(p);
+  }
+  async listFiles() { return []; }
+  async getFileSize() { return 0; }
+}
+
+class CapturingSink implements MeteringSink {
+  batches: NormalizedMeteringEvent[][] = [];
+  async deliver(events: NormalizedMeteringEvent[]) {
+    this.batches.push(events);
+  }
+  all(): NormalizedMeteringEvent[] {
+    return this.batches.flat();
+  }
+}
+
+function makePhoto(overrides: Partial<Photo> = {}): Photo {
+  const now = new Date('2025-01-01T00:00:00Z').toISOString();
+  return {
+    id: overrides.id ?? 'p1',
+    libraryId: overrides.libraryId ?? 'lib1',
+    tenantId: overrides.tenantId ?? 'acme',
+    albumIds: [],
+    originalName: 'a.jpg',
+    storagePaths: {
+      original: 'orig/p1.jpg',
+      derivatives: {
+        small_webp: 'd/p1.s.webp',
+        small_jpeg: 'd/p1.s.jpg',
+        medium_webp: 'd/p1.m.webp',
+        medium_jpeg: 'd/p1.m.jpg',
+        large_webp: 'd/p1.l.webp',
+        large_jpeg: 'd/p1.l.jpg',
+        preview_jpeg: 'd/p1.p.jpg',
+      },
+    },
+    metadata: {
+      width: 100,
+      height: 100,
+      mimeType: 'image/jpeg',
+      sizeBytes: 1000,
+    },
+    status: 'ready',
+    currentEditVersion: 0,
+    editHistory: [],
+    thumbnailsOutdated: false,
+    createdAt: now,
+    updatedAt: now,
+    trashedAt: null,
+    trashedBy: null,
+    ...overrides,
+  };
+}
+
+describe('PhotosService', () => {
+  let data: InMemoryData;
+  let sink: CapturingSink;
+
+  beforeEach(() => {
+    data = new InMemoryData();
+    sink = new CapturingSink();
+    setWebhookDeliveryStore(null); // reset metering wiring
+    setMeteringBus(new MeteringBus({ sink, flushIntervalMs: 10, maxBatchSize: 50 }));
+  });
+
+  afterEach(() => {
+    setMeteringBus(null);
+  });
+
+  it('soft-delete sets trashedAt and emits photo.trashed', async () => {
+    await data.storeData('photos', 'p1', makePhoto());
+    const svc = new PhotosService({ dataAdapter: data });
+
+    const out = await svc.softDelete('p1', 'acme', 'user-7');
+    expect(out.trashedAt).toBeTruthy();
+    expect(out.trashedBy).toBe('user-7');
+
+    // Force flush by waiting
+    await new Promise((r) => setTimeout(r, 30));
+    const events = sink.all();
+    expect(events.some((e) => e.type === 'photo.trashed' && e.resourceId === 'p1')).toBe(true);
+  });
+
+  it('soft-delete is idempotent', async () => {
+    await data.storeData('photos', 'p1', makePhoto({ trashedAt: '2025-01-01T00:00:00Z' }));
+    const svc = new PhotosService({ dataAdapter: data });
+    const out = await svc.softDelete('p1', 'acme', 'user-1');
+    expect(out.trashedAt).toBe('2025-01-01T00:00:00Z');
+  });
+
+  it('restore clears trashedAt', async () => {
+    await data.storeData('photos', 'p1', makePhoto({ trashedAt: '2025-01-01T00:00:00Z', trashedBy: 'u' }));
+    const svc = new PhotosService({ dataAdapter: data });
+    const out = await svc.restore('p1', 'acme');
+    expect(out.trashedAt).toBeNull();
+    expect(out.trashedBy).toBeNull();
+  });
+
+  it('cross-tenant restore returns 403 (CrossTenantAccessError)', async () => {
+    await data.storeData('photos', 'p1', makePhoto({ tenantId: 'acme', trashedAt: '2025-01-01T00:00:00Z' }));
+    const svc = new PhotosService({ dataAdapter: data });
+    await expect(svc.restore('p1', 'globex')).rejects.toBeInstanceOf(CrossTenantAccessError);
+  });
+
+  it('missing photo throws PhotoNotFoundError', async () => {
+    const svc = new PhotosService({ dataAdapter: data });
+    await expect(svc.softDelete('missing', 'acme', null)).rejects.toBeInstanceOf(PhotoNotFoundError);
+  });
+
+  it('list hides trashed by default; returns only trash when trashed=true', async () => {
+    await data.storeData('photos', 'a', makePhoto({ id: 'a' }));
+    await data.storeData('photos', 'b', makePhoto({ id: 'b', trashedAt: '2025-01-01T00:00:00Z' }));
+    const svc = new PhotosService({ dataAdapter: data });
+
+    const active = await svc.list('acme');
+    expect(active.map((p) => p.id)).toEqual(['a']);
+
+    const trashed = await svc.list('acme', { trashed: true });
+    expect(trashed.map((p) => p.id)).toEqual(['b']);
+  });
+
+  it('list is tenant-scoped', async () => {
+    await data.storeData('photos', 'a', makePhoto({ id: 'a', tenantId: 'acme' }));
+    await data.storeData('photos', 'c', makePhoto({ id: 'c', tenantId: 'globex' }));
+    const svc = new PhotosService({ dataAdapter: data });
+    const active = await svc.list('acme');
+    expect(active.map((p) => p.id)).toEqual(['a']);
+  });
+
+  describe('purgeExpired (fake clock)', () => {
+    it('only purges items older than retention; emits photo.purged once each', async () => {
+      // p1 trashed 40 days ago, p2 trashed 5 days ago, retention=30d
+      const now = new Date('2025-06-01T00:00:00Z');
+      const dayMs = 24 * 60 * 60 * 1000;
+      await data.storeData('photos', 'p1', makePhoto({
+        id: 'p1',
+        trashedAt: new Date(now.getTime() - 40 * dayMs).toISOString(),
+      }));
+      await data.storeData('photos', 'p2', makePhoto({
+        id: 'p2',
+        trashedAt: new Date(now.getTime() - 5 * dayMs).toISOString(),
+      }));
+      await data.storeData('photos', 'p3', makePhoto({
+        id: 'p3', // not trashed
+      }));
+
+      const storage = new CapturingStorage();
+      const usageBus = new InMemoryUsageMeteringBus();
+      const rollupEvents: any[] = [];
+      usageBus.subscribe((e) => { rollupEvents.push(e); });
+
+      const svc = new PhotosService({
+        dataAdapter: data,
+        storageAdapter: storage,
+        usageBus,
+        now: () => now,
+      });
+
+      const results = await svc.purgeExpired({ retentionDays: 30 });
+      expect(results).toHaveLength(1);
+      expect(results[0]!.photoIds).toEqual(['p1']);
+
+      // Doc removed for purged photo only.
+      expect(await data.fetchData('photos', 'p1')).toBeNull();
+      expect(await data.fetchData('photos', 'p2')).not.toBeNull();
+      expect(await data.fetchData('photos', 'p3')).not.toBeNull();
+
+      // Storage cleanup happened.
+      expect(storage.deleted).toContain('orig/p1.jpg');
+
+      // photo.purged emitted exactly once.
+      await new Promise((r) => setTimeout(r, 30));
+      const purgedEvents = sink.all().filter((e) => e.type === 'photo.purged');
+      expect(purgedEvents).toHaveLength(1);
+      expect(purgedEvents[0]!.resourceId).toBe('p1');
+      expect(purgedEvents[0]!.bytes).toBe(-1000);
+
+      // storageBytesDelta rollup decrements (not on trash).
+      expect(rollupEvents).toHaveLength(1);
+      expect(rollupEvents[0]!.counter).toBe('storageBytesDelta');
+      expect(rollupEvents[0]!.value).toBe(-1000);
+      expect(rollupEvents[0]!.eventId).toBe('photo.purged:p1');
+    });
+
+    it('iterates per-tenant so one tenant cannot starve others', async () => {
+      const now = new Date('2025-06-01T00:00:00Z');
+      const old = new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000).toISOString();
+
+      // Tenant "noisy" has many trashed photos; tenant "quiet" has one.
+      for (let i = 0; i < 5; i++) {
+        await data.storeData('photos', `n${i}`, makePhoto({
+          id: `n${i}`, tenantId: 'noisy', trashedAt: old,
+        }));
+      }
+      await data.storeData('photos', 'q1', makePhoto({
+        id: 'q1', tenantId: 'quiet', trashedAt: old,
+      }));
+
+      const svc = new PhotosService({
+        dataAdapter: data,
+        now: () => now,
+      });
+
+      const results = await svc.purgeExpired({ retentionDays: 30, perTenantLimit: 2 });
+      const byTenant = Object.fromEntries(
+        results.map((r) => [r.tenantId, r.photoIds.length])
+      );
+      // noisy capped at 2, quiet still gets its 1 in the same run.
+      expect(byTenant.noisy).toBe(2);
+      expect(byTenant.quiet).toBe(1);
+    });
+  });
+});
+
+describe('collectStoragePaths', () => {
+  it('includes original + every derivative', () => {
+    const p = makePhoto();
+    const paths = collectStoragePaths(p);
+    expect(paths).toContain('orig/p1.jpg');
+    expect(paths).toContain('d/p1.p.jpg');
+    expect(paths.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('handles legacy single storagePath', () => {
+    const p = makePhoto({ storagePaths: undefined, storagePath: 'legacy/p1.jpg' });
+    expect(collectStoragePaths(p)).toEqual(['legacy/p1.jpg']);
+  });
+});

--- a/functions/src/domain/photos/PhotosService.ts
+++ b/functions/src/domain/photos/PhotosService.ts
@@ -1,0 +1,301 @@
+/**
+ * PhotosService — soft-delete (Trash) lifecycle for photos.
+ *
+ * Implements the Trash feature from issue #152:
+ *   - softDelete: sets `trashedAt` / `trashedBy`; bytes are kept.
+ *   - restore:   clears `trashedAt` / `trashedBy`.
+ *   - list:      lists active or trashed photos for a tenant.
+ *   - purgeExpired: hard-deletes photos whose `trashedAt` exceeds the
+ *     retention window. Reuses the existing storage adapter for cleanup.
+ *
+ * Tenant scoping is enforced via `assertSameTenant` so cross-tenant
+ * restores/deletes return 403.
+ *
+ * Metering: emits `photo.trashed` on soft-delete and `photo.purged` when
+ * bytes are actually freed (purge job). Per the metering contract, the
+ * `storageBytesDelta` rollup decrements on `photo.purged`, not on
+ * `photo.trashed`, so a separate UsageMeteringBus publish is performed in
+ * the purge job.
+ */
+
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+import type { StorageAdapter } from '../../adapters/storage/StorageAdapter.js';
+import type { Photo } from '../../models/Photo.js';
+import { logger } from '../../utils/logger.js';
+import {
+  assertSameTenant,
+  DEFAULT_TENANT_ID,
+  type TenantId,
+} from '../tenant/Tenant.js';
+import { emitMeteringEvent } from '../../services/metering/index.js';
+import type { UsageMeteringBus } from '../../services/metering/UsageMeteringBus.js';
+
+const PHOTOS_COLLECTION = 'photos';
+
+export interface PhotosServiceOptions {
+  dataAdapter: DataAdapter;
+  storageAdapter?: StorageAdapter;
+  /** Optional rollup bus used to decrement `storageBytesDelta` on purge. */
+  usageBus?: UsageMeteringBus;
+  /** Override clock for tests. */
+  now?: () => Date;
+}
+
+export class PhotoNotFoundError extends Error {
+  public readonly status = 404;
+  public readonly code = 'photo-not-found';
+  constructor(public readonly photoId: string) {
+    super(`Photo ${photoId} not found`);
+    this.name = 'PhotoNotFoundError';
+  }
+}
+
+export class PhotosService {
+  private readonly data: DataAdapter;
+  private readonly storage: StorageAdapter | undefined;
+  private readonly usageBus: UsageMeteringBus | undefined;
+  private readonly now: () => Date;
+
+  constructor(opts: PhotosServiceOptions) {
+    this.data = opts.dataAdapter;
+    this.storage = opts.storageAdapter;
+    this.usageBus = opts.usageBus;
+    this.now = opts.now ?? (() => new Date());
+  }
+
+  /** Fetch a photo, asserting tenant scope. Throws if missing or cross-tenant. */
+  async getOwned(photoId: string, callerTenantId: TenantId): Promise<Photo> {
+    const photo = await this.data.fetchData<Photo>(PHOTOS_COLLECTION, photoId);
+    if (!photo) throw new PhotoNotFoundError(photoId);
+    assertSameTenant(photo.tenantId, callerTenantId);
+    return photo;
+  }
+
+  /**
+   * Soft-delete a photo: sets `trashedAt = now`, hides it from default
+   * list queries. Bytes are retained until the purge job runs.
+   */
+  async softDelete(
+    photoId: string,
+    callerTenantId: TenantId,
+    actor: string | null
+  ): Promise<Photo> {
+    const photo = await this.getOwned(photoId, callerTenantId);
+
+    // Idempotent: re-trashing an already-trashed photo is a no-op.
+    if (photo.trashedAt) {
+      return photo;
+    }
+
+    const trashedAt = this.now().toISOString();
+    const updates = {
+      trashedAt,
+      trashedBy: actor,
+      updatedAt: trashedAt,
+    };
+    await this.data.updateData<Photo>(PHOTOS_COLLECTION, photoId, updates);
+
+    const updated: Photo = { ...photo, ...updates };
+
+    emitMeteringEvent({
+      tenantId: photo.tenantId ?? DEFAULT_TENANT_ID,
+      type: 'photo.trashed',
+      count: 1,
+      bytes: photo.metadata?.sizeBytes,
+      resourceId: photoId,
+      occurredAt: trashedAt,
+      meta: {
+        libraryId: photo.libraryId,
+        actor,
+      },
+    });
+
+    return updated;
+  }
+
+  /**
+   * Restore a previously trashed photo. Cross-tenant restore is rejected
+   * by {@link assertSameTenant} (surfaces as HTTP 403).
+   */
+  async restore(photoId: string, callerTenantId: TenantId): Promise<Photo> {
+    const photo = await this.getOwned(photoId, callerTenantId);
+
+    if (!photo.trashedAt) {
+      return photo;
+    }
+
+    const updatedAt = this.now().toISOString();
+    const updates = {
+      trashedAt: null,
+      trashedBy: null,
+      updatedAt,
+    };
+    await this.data.updateData<Photo>(PHOTOS_COLLECTION, photoId, updates);
+
+    return { ...photo, ...updates };
+  }
+
+  /**
+   * List photos for a tenant. By default returns only active (non-trashed)
+   * photos. When `trashed=true`, returns only the tenant's trash.
+   */
+  async list(
+    callerTenantId: TenantId,
+    opts: { trashed?: boolean } = {}
+  ): Promise<Photo[]> {
+    const filterValue = callerTenantId === DEFAULT_TENANT_ID
+      ? undefined
+      : callerTenantId;
+
+    // queryData supports simple equality filters; we filter tenantId here when
+    // it is not the default tenant (legacy docs may have no tenantId field).
+    const all = filterValue
+      ? await this.data.queryData<Photo>(PHOTOS_COLLECTION, [
+          { field: 'tenantId', operator: '==', value: filterValue },
+        ])
+      : await this.data.queryData<Photo>(PHOTOS_COLLECTION, []);
+
+    // For the default tenant, include legacy docs with missing tenantId.
+    const scoped = filterValue
+      ? all
+      : all.filter(
+          (p) => !p.tenantId || p.tenantId === DEFAULT_TENANT_ID
+        );
+
+    const wantTrashed = opts.trashed === true;
+    return scoped.filter((p) => Boolean(p.trashedAt) === wantTrashed);
+  }
+
+  /**
+   * Hard-delete trashed photos whose `trashedAt` is older than
+   * `retentionDays`. Iterates per-tenant so one noisy tenant cannot
+   * starve others. Emits exactly one `photo.purged` event per photo.
+   *
+   * Returns the list of purged photo ids (per tenant) for observability.
+   */
+  async purgeExpired(opts: {
+    retentionDays: number;
+    /** Limit work per tenant per run; default 1000. */
+    perTenantLimit?: number;
+  }): Promise<{ tenantId: TenantId; photoIds: string[] }[]> {
+    const { retentionDays } = opts;
+    if (!Number.isFinite(retentionDays) || retentionDays < 0) {
+      throw new Error('retentionDays must be a non-negative finite number');
+    }
+    const perTenantLimit = opts.perTenantLimit ?? 1000;
+    const cutoff = new Date(this.now().getTime() - retentionDays * 24 * 60 * 60 * 1000);
+
+    // Pull every trashed photo once, then bucket by tenant so we can iterate
+    // tenant-by-tenant. This keeps the operation fair across tenants while
+    // remaining usable on top of the existing queryData filter surface.
+    const all = await this.data.queryData<Photo>(PHOTOS_COLLECTION, []);
+    const byTenant = new Map<TenantId, Photo[]>();
+    for (const photo of all) {
+      if (!photo.trashedAt) continue;
+      const trashedAt = new Date(photo.trashedAt);
+      if (Number.isNaN(trashedAt.getTime())) continue;
+      if (trashedAt >= cutoff) continue;
+      const tenantId = (photo.tenantId ?? DEFAULT_TENANT_ID) as TenantId;
+      const bucket = byTenant.get(tenantId) ?? [];
+      bucket.push(photo);
+      byTenant.set(tenantId, bucket);
+    }
+
+    const results: { tenantId: TenantId; photoIds: string[] }[] = [];
+    for (const [tenantId, bucket] of byTenant) {
+      const purged: string[] = [];
+      // Process up to perTenantLimit; oldest-trashedAt first so retention
+      // pressure releases evenly.
+      bucket.sort((a, b) =>
+        String(a.trashedAt).localeCompare(String(b.trashedAt))
+      );
+      const slice = bucket.slice(0, perTenantLimit);
+
+      for (const photo of slice) {
+        try {
+          await this.hardDelete(photo);
+          purged.push(photo.id);
+        } catch (err) {
+          // Don't let one bad photo block the rest of the tenant's purge.
+          logger.error(
+            { err, photoId: photo.id, tenantId },
+            'purgeTrash: failed to hard-delete photo'
+          );
+        }
+      }
+      results.push({ tenantId, photoIds: purged });
+    }
+
+    return results;
+  }
+
+  /**
+   * Hard-delete a single (already trashed) photo: removes storage bytes,
+   * removes the doc, and emits `photo.purged` exactly once.
+   */
+  private async hardDelete(photo: Photo): Promise<void> {
+    const bytes = photo.metadata?.sizeBytes ?? 0;
+    const tenantId = (photo.tenantId ?? DEFAULT_TENANT_ID) as TenantId;
+
+    // Storage cleanup: best-effort. The storage adapter's deleteFile is
+    // idempotent (ignores missing files in the Firebase adapter).
+    if (this.storage) {
+      const paths = collectStoragePaths(photo);
+      for (const p of paths) {
+        try {
+          await this.storage.deleteFile(p);
+        } catch (err) {
+          logger.warn(
+            { err, photoId: photo.id, path: p },
+            'purgeTrash: storage cleanup failed for path; continuing'
+          );
+        }
+      }
+    }
+
+    await this.data.deleteData(PHOTOS_COLLECTION, photo.id);
+
+    // photo.purged on the host webhook bus (host-visible event).
+    emitMeteringEvent({
+      tenantId,
+      type: 'photo.purged',
+      count: 1,
+      // Negative bytes signals reclaimed storage to hosts that care.
+      bytes: -bytes,
+      resourceId: photo.id,
+      occurredAt: this.now().toISOString(),
+      meta: {
+        libraryId: photo.libraryId,
+        trashedAt: photo.trashedAt ?? null,
+      },
+    });
+
+    // storageBytesDelta rollup decrements here (not on trash).
+    if (this.usageBus && bytes > 0) {
+      await this.usageBus.publish({
+        tenantId,
+        counter: 'storageBytesDelta',
+        value: -bytes,
+        occurredAt: this.now().toISOString(),
+        eventId: `photo.purged:${photo.id}`,
+        meta: { libraryId: photo.libraryId },
+      });
+    }
+  }
+}
+
+/** Internal helper exported for tests. */
+export function collectStoragePaths(photo: Photo): string[] {
+  const paths = new Set<string>();
+  if (photo.storagePath) paths.add(photo.storagePath);
+  if (photo.storagePaths) {
+    paths.add(photo.storagePaths.original);
+    const d = photo.storagePaths.derivatives;
+    if (d) {
+      for (const v of Object.values(d)) {
+        if (v) paths.add(v);
+      }
+    }
+  }
+  return Array.from(paths);
+}

--- a/functions/src/jobs/purgeTrash.test.ts
+++ b/functions/src/jobs/purgeTrash.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { runPurgeTrashJob, resolveTrashRetentionDays, DEFAULT_TRASH_RETENTION_DAYS } from './purgeTrash.js';
+import type { DataAdapter, QueryFilter } from '../adapters/data/DataAdapter.js';
+import {
+  setMeteringBus,
+  setWebhookDeliveryStore,
+} from '../services/metering/index.js';
+import {
+  MeteringBus,
+  type MeteringSink,
+  type NormalizedMeteringEvent,
+} from '../services/metering/MeteringBus.js';
+import { InMemoryUsageMeteringBus } from '../services/metering/UsageMeteringBus.js';
+import type { Photo } from '../models/Photo.js';
+
+class InMemoryData implements DataAdapter {
+  public docs = new Map<string, Map<string, any>>();
+  private col(c: string) {
+    let m = this.docs.get(c);
+    if (!m) { m = new Map(); this.docs.set(c, m); }
+    return m;
+  }
+  async storeData(c: string, id: string, d: any) { this.col(c).set(id, d); }
+  async fetchData(c: string, id: string) { return this.col(c).get(id) ?? null; }
+  async queryData(c: string, filters: QueryFilter[]) {
+    return Array.from(this.col(c).values()).filter((d) =>
+      filters.every((f) => (d as any)[f.field] === f.value)
+    );
+  }
+  async updateData(c: string, id: string, u: any) {
+    const cur = this.col(c).get(id);
+    this.col(c).set(id, { ...cur, ...u });
+  }
+  async deleteData(c: string, id: string) { this.col(c).delete(id); }
+  async exists(c: string, id: string) { return this.col(c).has(id); }
+  async listIds(c: string) { return Array.from(this.col(c).keys()); }
+  async getPhoto() { return null; }
+}
+
+class CapturingSink implements MeteringSink {
+  batches: NormalizedMeteringEvent[][] = [];
+  async deliver(events: NormalizedMeteringEvent[]) { this.batches.push(events); }
+  all() { return this.batches.flat(); }
+}
+
+function makePhoto(p: Partial<Photo> = {}): Photo {
+  return {
+    id: 'p',
+    libraryId: 'lib',
+    tenantId: 'acme',
+    albumIds: [],
+    originalName: 'x.jpg',
+    storagePaths: {
+      original: 'o/x.jpg',
+      derivatives: {
+        small_webp: '',
+        small_jpeg: '',
+        medium_webp: '',
+        medium_jpeg: '',
+        large_webp: '',
+        large_jpeg: '',
+        preview_jpeg: '',
+      },
+    },
+    metadata: { width: 1, height: 1, mimeType: 'image/jpeg', sizeBytes: 500 },
+    status: 'ready',
+    currentEditVersion: 0,
+    editHistory: [],
+    thumbnailsOutdated: false,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    trashedAt: null,
+    trashedBy: null,
+    ...p,
+  };
+}
+
+describe('purgeTrash job', () => {
+  let data: InMemoryData;
+  let sink: CapturingSink;
+
+  beforeEach(() => {
+    data = new InMemoryData();
+    sink = new CapturingSink();
+    setWebhookDeliveryStore(null);
+    setMeteringBus(new MeteringBus({ sink, flushIntervalMs: 10, maxBatchSize: 50 }));
+  });
+
+  afterEach(() => {
+    setMeteringBus(null);
+  });
+
+  it('purges photos older than retention with fake clock', async () => {
+    const now = new Date('2025-06-01T00:00:00Z');
+    const day = 86_400_000;
+    await data.storeData('photos', 'old', makePhoto({
+      id: 'old', trashedAt: new Date(now.getTime() - 40 * day).toISOString(),
+    }));
+    await data.storeData('photos', 'fresh', makePhoto({
+      id: 'fresh', trashedAt: new Date(now.getTime() - 10 * day).toISOString(),
+    }));
+
+    const usageBus = new InMemoryUsageMeteringBus();
+    const result = await runPurgeTrashJob({
+      dataAdapter: data,
+      usageBus,
+      retentionDays: 30,
+      now: () => now,
+    });
+
+    expect(result.totalPurged).toBe(1);
+    expect(result.tenants[0]!.purgedPhotoIds).toEqual(['old']);
+    expect(await data.fetchData('photos', 'old')).toBeNull();
+    expect(await data.fetchData('photos', 'fresh')).not.toBeNull();
+  });
+
+  it('default retention is 30 days when env unset', () => {
+    expect(resolveTrashRetentionDays({})).toBe(DEFAULT_TRASH_RETENTION_DAYS);
+  });
+
+  it('reads TRASH_RETENTION_DAYS env override', () => {
+    expect(resolveTrashRetentionDays({ TRASH_RETENTION_DAYS: '7' })).toBe(7);
+  });
+
+  it('falls back to default on garbage env value', () => {
+    expect(resolveTrashRetentionDays({ TRASH_RETENTION_DAYS: 'banana' })).toBe(
+      DEFAULT_TRASH_RETENTION_DAYS
+    );
+  });
+});

--- a/functions/src/jobs/purgeTrash.ts
+++ b/functions/src/jobs/purgeTrash.ts
@@ -1,0 +1,88 @@
+/**
+ * purgeTrash — scheduled job that hard-deletes photos whose `trashedAt`
+ * timestamp is older than `TRASH_RETENTION_DAYS` (default 30).
+ *
+ * Wired via the scheduler in production; runnable on demand in tests by
+ * calling {@link runPurgeTrashJob} with a fake clock.
+ *
+ * Behavior (issue #152):
+ *   - Iterates per-tenant so one noisy tenant cannot starve others.
+ *   - Reuses the existing storage-cleanup path on the storage adapter.
+ *   - Emits `photo.purged` exactly once per photo (host webhook).
+ *   - Decrements the daily `storageBytesDelta` rollup via the usage bus.
+ */
+
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import type { StorageAdapter } from '../adapters/storage/StorageAdapter.js';
+import { PhotosService } from '../domain/photos/PhotosService.js';
+import type { UsageMeteringBus } from '../services/metering/UsageMeteringBus.js';
+import { logger } from '../utils/logger.js';
+
+export const DEFAULT_TRASH_RETENTION_DAYS = 30;
+
+export function resolveTrashRetentionDays(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  const raw = env.TRASH_RETENTION_DAYS;
+  if (!raw) return DEFAULT_TRASH_RETENTION_DAYS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    logger.warn(
+      { raw },
+      'TRASH_RETENTION_DAYS is not a non-negative number; using default'
+    );
+    return DEFAULT_TRASH_RETENTION_DAYS;
+  }
+  return n;
+}
+
+export interface PurgeTrashJobOptions {
+  dataAdapter: DataAdapter;
+  storageAdapter?: StorageAdapter;
+  usageBus?: UsageMeteringBus;
+  retentionDays?: number;
+  /** Cap per-tenant work per run (default 1000). */
+  perTenantLimit?: number;
+  /** Test hook. */
+  now?: () => Date;
+}
+
+export interface PurgeTrashJobResult {
+  retentionDays: number;
+  tenants: { tenantId: string; purgedPhotoIds: string[] }[];
+  totalPurged: number;
+}
+
+export async function runPurgeTrashJob(
+  opts: PurgeTrashJobOptions
+): Promise<PurgeTrashJobResult> {
+  const retentionDays =
+    opts.retentionDays ?? resolveTrashRetentionDays();
+
+  const service = new PhotosService({
+    dataAdapter: opts.dataAdapter,
+    storageAdapter: opts.storageAdapter,
+    usageBus: opts.usageBus,
+    now: opts.now,
+  });
+
+  const results = await service.purgeExpired({
+    retentionDays,
+    perTenantLimit: opts.perTenantLimit,
+  });
+
+  const totalPurged = results.reduce((acc, r) => acc + r.photoIds.length, 0);
+  logger.info(
+    { retentionDays, totalPurged, tenants: results.length },
+    'purgeTrash job complete'
+  );
+
+  return {
+    retentionDays,
+    tenants: results.map((r) => ({
+      tenantId: r.tenantId,
+      purgedPhotoIds: r.photoIds,
+    })),
+    totalPurged,
+  };
+}

--- a/functions/src/models/Photo.ts
+++ b/functions/src/models/Photo.ts
@@ -84,6 +84,16 @@ export interface Photo {
   thumbnailsOutdated: boolean;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Soft-delete (Trash) timestamp. When non-null, the photo is in the
+   * tenant's trash and is hidden from default list queries until either
+   * restored or hard-deleted by the purge job. See issue #152.
+   */
+  trashedAt?: string | null;
+  /**
+   * User id (or tenant subject) that initiated the soft-delete.
+   */
+  trashedBy?: string | null;
 }
 
 export function createPhotoDocument(
@@ -116,5 +126,7 @@ export function createPhotoDocument(
     thumbnailsOutdated: false,
     createdAt: now,
     updatedAt: now,
+    trashedAt: null,
+    trashedBy: null,
   };
 }

--- a/functions/src/routes/photosV1.ts
+++ b/functions/src/routes/photosV1.ts
@@ -1,0 +1,130 @@
+/**
+ * /v1/photos — Trash (soft-delete) endpoints.
+ *
+ * Routes (issue #152):
+ *   DELETE /v1/photos/:id          → soft-delete (sets trashedAt)
+ *   POST   /v1/photos/:id/restore  → clears trashedAt
+ *   GET    /v1/photos?trashed=true → list trashed photos for caller's tenant
+ *   GET    /v1/photos              → list active photos for caller's tenant
+ */
+import { randomUUID } from 'node:crypto';
+import { Router, type Request, type Response } from 'express';
+import {
+  PhotoNotFoundError,
+  type PhotosService,
+} from '../domain/photos/PhotosService.js';
+import {
+  CrossTenantAccessError,
+  DEFAULT_TENANT_ID,
+  type TenantId,
+} from '../domain/tenant/Tenant.js';
+
+function sendError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> | null = null
+): void {
+  res.status(status).json({
+    error: {
+      code,
+      message,
+      requestId: randomUUID(),
+      details,
+    },
+  });
+}
+
+function callerTenant(req: Request): TenantId {
+  return (req.tenantId as TenantId | undefined) ?? DEFAULT_TENANT_ID;
+}
+
+function callerActor(req: Request): string | null {
+  return req.user?.uid ?? null;
+}
+
+export function createPhotosV1Router(photos: PhotosService): Router {
+  const router = Router();
+
+  router.get('/', async (req, res, next) => {
+    try {
+      if (!req.user) {
+        sendError(res, 401, 'AUTH_REQUIRED', 'Authentication required');
+        return;
+      }
+      const trashed = req.query.trashed === 'true' || req.query.trashed === '1';
+      const items = await photos.list(callerTenant(req), { trashed });
+      res.json({
+        photos: items.map((p) => ({
+          id: p.id,
+          libraryId: p.libraryId,
+          originalName: p.originalName,
+          status: p.status,
+          trashedAt: p.trashedAt ?? null,
+          trashedBy: p.trashedBy ?? null,
+          createdAt: p.createdAt,
+          updatedAt: p.updatedAt,
+        })),
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.delete('/:id', async (req, res, next) => {
+    try {
+      if (!req.user) {
+        sendError(res, 401, 'AUTH_REQUIRED', 'Authentication required');
+        return;
+      }
+      const photo = await photos.softDelete(
+        req.params.id,
+        callerTenant(req),
+        callerActor(req)
+      );
+      res.status(200).json({
+        id: photo.id,
+        trashedAt: photo.trashedAt ?? null,
+        trashedBy: photo.trashedBy ?? null,
+      });
+    } catch (err) {
+      if (err instanceof PhotoNotFoundError) {
+        sendError(res, 404, 'PHOTO_NOT_FOUND', err.message);
+        return;
+      }
+      if (err instanceof CrossTenantAccessError) {
+        sendError(res, 403, err.code, err.message);
+        return;
+      }
+      next(err);
+    }
+  });
+
+  router.post('/:id/restore', async (req, res, next) => {
+    try {
+      if (!req.user) {
+        sendError(res, 401, 'AUTH_REQUIRED', 'Authentication required');
+        return;
+      }
+      const photo = await photos.restore(req.params.id, callerTenant(req));
+      res.status(200).json({
+        id: photo.id,
+        trashedAt: photo.trashedAt ?? null,
+        trashedBy: photo.trashedBy ?? null,
+      });
+    } catch (err) {
+      if (err instanceof PhotoNotFoundError) {
+        sendError(res, 404, 'PHOTO_NOT_FOUND', err.message);
+        return;
+      }
+      if (err instanceof CrossTenantAccessError) {
+        sendError(res, 403, err.code, err.message);
+        return;
+      }
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -90,6 +90,9 @@ import { createComplianceV1Router } from './routes/complianceV1.js';
 import { createBrandingV1Router } from './routes/brandingV1.js';
 import { createTenantUsageRouter } from './routes/tenantUsage.js';
 import { createWebhookDeliveriesRouter } from './routes/webhookDeliveriesV1.js';
+import { createPhotosV1Router } from './routes/photosV1.js';
+import { PhotosService } from './domain/photos/PhotosService.js';
+import { resolveTenant } from './middleware/resolveTenant.js';
 import { InMemoryUsageMeteringBus } from './services/metering/UsageMeteringBus.js';
 import {
   getHostWebhookSink,
@@ -119,6 +122,27 @@ app.use('/api', apiVersionMiddleware);
 app.use('/api/albums', authMiddleware, createAlbumsRouter(domainModules.albums));
 app.use('/api/v1/albums', authMiddleware, createAlbumsV1Router(domainModules.albums));
 app.use('/api/v1/compliance', authMiddleware, createComplianceV1Router(dataAdapter));
+
+// Photos: soft-delete (Trash) + restore + trashed list (issue #152).
+// Mounted at both `/v1/photos` (spec) and `/api/v1/photos` (in-product) so
+// hosts can call the documented contract URL while clients keep the
+// `/api` prefix used elsewhere.
+const photosService = new PhotosService({
+  dataAdapter,
+  storageAdapter,
+});
+app.use(
+  '/v1/photos',
+  authMiddleware,
+  resolveTenant,
+  createPhotosV1Router(photosService)
+);
+app.use(
+  '/api/v1/photos',
+  authMiddleware,
+  resolveTenant,
+  createPhotosV1Router(photosService)
+);
 
 // --- Metering / usage rollups (issue #133) ---
 // In-memory wiring suitable for local mode; Firebase mode will swap in a

--- a/functions/src/services/metering/MeteringBus.ts
+++ b/functions/src/services/metering/MeteringBus.ts
@@ -13,7 +13,9 @@ export type MeteringEventType =
   | 'signed_url.issued'
   | 'edit.applied'
   | 'share.viewed'
-  | 'plugin.ran';
+  | 'plugin.ran'
+  | 'photo.trashed'
+  | 'photo.purged';
 // Future (placeholder; not emitted in this PR):
 //   | 'user.active'
 


### PR DESCRIPTION
## Summary

Adds a recoverable Trash for photos, matching Lightroom/Apple Photos/Google Photos UX. Deletes go to Trash first; a scheduled purge job hard-deletes after a configurable retention window (default 30 days). Two new metering events (`photo.trashed`, `photo.purged`) flow through the existing bus, with `storageBytesDelta` decrementing on purge.

## Changes

- **Model:** `Photo` gains `trashedAt` / `trashedBy` fields.
- **Service:** new `domain/photos/PhotosService` (`softDelete`, `restore`, `list`, `purgeExpired`), tenant-scoped via `assertSameTenant`.
- **Routes:** `DELETE /v1/photos/:id`, `POST /v1/photos/:id/restore`, `GET /v1/photos?trashed=true` (also mounted at `/api/v1/photos`).
- **Job:** `functions/src/jobs/purgeTrash.ts` — per-tenant iteration (no single tenant can starve others), `TRASH_RETENTION_DAYS` env override, reuses the existing `StorageAdapter` for cleanup.
- **Metering:** new `photo.trashed` / `photo.purged` types; `photo.purged` carries negative bytes and also publishes a `storageBytesDelta` event to the rollup bus (exactly once via `eventId=photo.purged:<id>`).
- **Docs:** new Trash section in `docs/features/library-and-organization.md`; event catalog rows in `docs/features/metering-events.md`.
- **Contract:** new `contracts/openapi/photos.openapi.json`; existing contract check still passes.

## Testing

- `npm --prefix functions test` → **193 passed** (15 new across `PhotosService.test.ts` and `purgeTrash.test.ts`).
- `npm run contract:check` → passes (validate + breaking-change check).
- Purge job unit-tested with a fake clock: only purges items older than retention, emits `photo.purged` exactly once, decrements `storageBytesDelta` rollup. Per-tenant fairness test confirms `perTenantLimit` does not block other tenants in the same run.
- Cross-tenant restore returns `CrossTenantAccessError` (HTTP 403).

## Caveats

- The scheduler that actually invokes `runPurgeTrashJob` on a cadence is out of scope here; the job is import-ready and unit-tested. Production wiring will mirror the existing storage snapshot job in a follow-up.
- `TRASH_RETENTION_DAYS` is a deployment-wide env default; per-tenant override is intentionally deferred (called out in the issue).
- Two pre-existing `tsc` errors remain in `routes/signing.ts` and `handlers/edits/applyEdits.conflict.test.ts` (verified by building `main` before changes); vitest still runs cleanly.

Fixes rwrife/AuraPix#152