### PR TITLE
fix: per-tenant feature flag config

### DIFF
--- a/contracts/openapi/tenant-features.openapi.json
+++ b/contracts/openapi/tenant-features.openapi.json
@@ -1,0 +1,183 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AuraPix Tenant Feature Flags API",
+    "version": "0.1.0",
+    "description": "Per-tenant feature flag configuration (issue #175). Host applications use these endpoints to map pricing tiers (Free / Pro / Business) to capability \u2014 toggling features like sharing, plugins, smart albums, export, and bulk ops on or off per tenant.\n\nBoth endpoints are host-API-key only with the `tenant.config` scope; feature flags are NOT end-user-tunable.\n\nTenants with no configuration document read every feature as `true` (back-compat). Unknown flag keys submitted to PATCH are silently ignored."
+  },
+  "paths": {
+    "/v1/tenants/{tenantId}/features": {
+      "parameters": [
+        {
+          "name": "tenantId",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string", "pattern": "^[a-zA-Z0-9_-]{1,64}$" }
+        }
+      ],
+      "get": {
+        "summary": "Fetch effective per-tenant feature flags",
+        "description": "Returns the merged flag map (defaults applied for any feature without an explicit override). Use this when bootstrapping host-side admin UI.",
+        "security": [{ "hostApiKey": ["tenant.config"] }],
+        "responses": {
+          "200": {
+            "description": "Effective feature flags",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FeaturesEnvelope" }
+              }
+            }
+          },
+          "401": {
+            "description": "Host API key required",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing `tenant.config` scope or cross-tenant request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Partially update per-tenant feature flags",
+        "description": "Send only the flags you want to change. Returns the new effective state plus a `changes` array enumerating transitioning flags. Emits a `feature.flag_changed` metering event per transition.",
+        "security": [{ "hostApiKey": ["tenant.config"] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/FeaturesPatch" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated feature flags",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FeaturesEnvelope" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "401": {
+            "description": "Host API key required",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing `tenant.config` scope or cross-tenant request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": { "type": "http", "scheme": "bearer", "bearerFormat": "JWT" },
+      "hostApiKey": { "type": "apiKey", "in": "header", "name": "X-Host-API-Key" }
+    },
+    "schemas": {
+      "FeatureFlags": {
+        "type": "object",
+        "description": "Effective state for every gateable feature. All keys are required in responses; defaults are `true`.",
+        "required": ["sharing", "plugins", "smartAlbums", "export", "bulkOps"],
+        "additionalProperties": false,
+        "properties": {
+          "sharing": { "type": "boolean", "description": "Share-token signing-key issuance." },
+          "plugins": { "type": "boolean", "description": "Edits/plugin execution." },
+          "smartAlbums": { "type": "boolean", "description": "Smart Albums CRUD + materialization." },
+          "export": { "type": "boolean", "description": "Photo export API." },
+          "bulkOps": { "type": "boolean", "description": "Bulk photo operations (`POST /v1/photos:batch`)." }
+        }
+      },
+      "FeaturesPatch": {
+        "type": "object",
+        "description": "Partial update. Omit a key to leave it unchanged. Unknown keys are rejected (`INVALID_BODY`).",
+        "additionalProperties": false,
+        "properties": {
+          "sharing": { "type": "boolean" },
+          "plugins": { "type": "boolean" },
+          "smartAlbums": { "type": "boolean" },
+          "export": { "type": "boolean" },
+          "bulkOps": { "type": "boolean" }
+        }
+      },
+      "FeatureFlagChange": {
+        "type": "object",
+        "required": ["feature", "oldValue", "newValue"],
+        "properties": {
+          "feature": { "type": "string" },
+          "oldValue": { "type": "boolean" },
+          "newValue": { "type": "boolean" }
+        }
+      },
+      "FeaturesEnvelope": {
+        "type": "object",
+        "required": ["tenantId", "flags"],
+        "properties": {
+          "tenantId": { "type": "string" },
+          "flags": { "$ref": "#/components/schemas/FeatureFlags" },
+          "updatedAt": { "type": ["string", "null"], "format": "date-time" },
+          "updatedBy": { "type": ["string", "null"] },
+          "changes": {
+            "type": "array",
+            "description": "Present on PATCH responses. Enumerates feature flags whose effective value transitioned.",
+            "items": { "$ref": "#/components/schemas/FeatureFlagChange" }
+          }
+        }
+      },
+      "ErrorEnvelope": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["code", "message", "requestId"],
+                "properties": {
+                  "code": { "type": "string" },
+                  "message": { "type": "string" },
+                  "requestId": { "type": "string" },
+                  "details": { "type": ["object", "null"] }
+                }
+              },
+              {
+                "type": "string",
+                "description": "Gated requests return a flat shape: `{ \"error\": \"feature_disabled\", \"feature\": \"<name>\" }`."
+              }
+            ]
+          },
+          "feature": {
+            "type": "string",
+            "description": "Present on 403 responses from `requireFeature` middleware. Identifies which feature was disabled."
+          }
+        }
+      }
+    }
+  }
+}

--- a/functions/src/middleware/requireFeature.test.ts
+++ b/functions/src/middleware/requireFeature.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import { createRequireFeature } from './requireFeature.js';
+import {
+  TENANT_FEATURES_CONFIG_COLLECTION,
+  type TenantFeaturesConfigRecord,
+} from '../models/TenantFeaturesConfig.js';
+import { __resetTenantFeaturesCacheForTests } from '../services/host/tenantFeaturesConfigService.js';
+import {
+  MeteringBus,
+  type MeteringSink,
+  type NormalizedMeteringEvent,
+} from '../services/metering/MeteringBus.js';
+import { setMeteringBus } from '../services/metering/index.js';
+
+class CapturingSink implements MeteringSink {
+  events: NormalizedMeteringEvent[] = [];
+  async deliver(events: NormalizedMeteringEvent[]): Promise<void> {
+    this.events.push(...events);
+  }
+}
+
+function makeMemoryAdapter(
+  seed?: TenantFeaturesConfigRecord
+): { data: DataAdapter; store: Map<string, Map<string, unknown>> } {
+  const store = new Map<string, Map<string, unknown>>();
+  if (seed) {
+    const inner = new Map<string, unknown>();
+    inner.set(seed.tenantId, seed);
+    store.set(TENANT_FEATURES_CONFIG_COLLECTION, inner);
+  }
+  const get = (collection: string) => {
+    let inner = store.get(collection);
+    if (!inner) {
+      inner = new Map();
+      store.set(collection, inner);
+    }
+    return inner;
+  };
+  const adapter: DataAdapter = {
+    storeData: vi.fn(async (collection: string, id: string, value: unknown) => {
+      get(collection).set(id, value);
+    }),
+    fetchData: vi.fn(async <T>(collection: string, id: string) => {
+      const value = get(collection).get(id);
+      return (value ?? null) as T | null;
+    }),
+    queryData: vi.fn(async () => []),
+    updateData: vi.fn(async () => {}),
+    deleteData: vi.fn(async () => {}),
+    exists: vi.fn(async () => false),
+    listIds: vi.fn(async () => []),
+    getPhoto: vi.fn(async () => null),
+  } as unknown as DataAdapter;
+  return { data: adapter, store };
+}
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    method: 'POST',
+    path: '/v1/photos/abc/export',
+    params: {},
+    headers: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+function makeRes(): { res: Response; status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> } {
+  const json = vi.fn();
+  const status = vi.fn().mockImplementation(() => ({ json }));
+  const res = { status, json } as unknown as Response;
+  return { res, status, json };
+}
+
+describe('requireFeature middleware', () => {
+  let sink: CapturingSink;
+  let bus: MeteringBus;
+
+  beforeEach(() => {
+    __resetTenantFeaturesCacheForTests();
+    sink = new CapturingSink();
+    bus = new MeteringBus({ sink, flushIntervalMs: 5 });
+    setMeteringBus(bus);
+  });
+
+  afterEach(() => {
+    setMeteringBus(null);
+  });
+
+  it('default-on: passes through when the tenant has no config doc', async () => {
+    const { data } = makeMemoryAdapter();
+    const requireFeature = createRequireFeature(data);
+    const mw = requireFeature('export');
+
+    const req = makeReq({ tenant: { id: 'tenant-fresh', scopes: [], keyId: 'k1' } } as Partial<Request>);
+    const { res, status } = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await mw(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 with feature_disabled when the flag is off', async () => {
+    const seed: TenantFeaturesConfigRecord = {
+      tenantId: 'tenant-gated',
+      flags: { export: false },
+      updatedAt: new Date().toISOString(),
+      updatedBy: null,
+    };
+    const { data } = makeMemoryAdapter(seed);
+    const requireFeature = createRequireFeature(data);
+    const mw = requireFeature('export');
+
+    const req = makeReq({ tenant: { id: 'tenant-gated', scopes: [], keyId: 'k1' } } as Partial<Request>);
+    const { res, status, json } = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await mw(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith({
+      error: 'feature_disabled',
+      feature: 'export',
+    });
+  });
+
+  it('emits a `feature.gated` metering event on rejection', async () => {
+    const seed: TenantFeaturesConfigRecord = {
+      tenantId: 'tenant-gated',
+      flags: { sharing: false },
+      updatedAt: new Date().toISOString(),
+      updatedBy: null,
+    };
+    const { data } = makeMemoryAdapter(seed);
+    const requireFeature = createRequireFeature(data);
+    const mw = requireFeature('sharing');
+
+    const req = makeReq({
+      tenant: { id: 'tenant-gated', scopes: [], keyId: 'k1' },
+      user: { uid: 'u_42' },
+    } as Partial<Request>);
+    const { res } = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await mw(req, res, next);
+    await bus.flush();
+
+    const gated = sink.events.filter((e) => e.type === 'feature.gated');
+    expect(gated).toHaveLength(1);
+    expect(gated[0]).toMatchObject({
+      tenantId: 'tenant-gated',
+      type: 'feature.gated',
+      count: 1,
+    });
+    expect(gated[0]?.meta).toMatchObject({
+      feature: 'sharing',
+      userId: 'u_42',
+    });
+  });
+
+  it('fails open when the data adapter throws', async () => {
+    const data: DataAdapter = {
+      fetchData: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+      storeData: vi.fn(),
+      queryData: vi.fn(async () => []),
+      updateData: vi.fn(async () => {}),
+      deleteData: vi.fn(async () => {}),
+      exists: vi.fn(async () => false),
+      listIds: vi.fn(async () => []),
+      getPhoto: vi.fn(async () => null),
+    } as unknown as DataAdapter;
+    const requireFeature = createRequireFeature(data);
+    const mw = requireFeature('export');
+
+    const req = makeReq({ tenant: { id: 'tenant-broken', scopes: [], keyId: 'k1' } } as Partial<Request>);
+    const { res, status } = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await mw(req, res, next);
+
+    // Adapter exploded; we still let the request through.
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when no tenant context can be resolved', async () => {
+    const { data } = makeMemoryAdapter();
+    const requireFeature = createRequireFeature(data);
+    const mw = requireFeature('export');
+
+    const req = makeReq(); // no tenant, no user, no params
+    const { res, status } = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await mw(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(status).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/middleware/requireFeature.ts
+++ b/functions/src/middleware/requireFeature.ts
@@ -1,0 +1,148 @@
+/**
+ * `requireFeature(name)` middleware (issue #175).
+ *
+ * Gates a route group on a per-tenant feature flag. When the named
+ * feature is disabled for the tenant on the request, the middleware
+ * responds with HTTP 403 and a structured error payload:
+ *
+ *     { "error": "feature_disabled", "feature": "<name>" }
+ *
+ * It additionally emits a low-volume `feature.gated` metering event so
+ * hosts can detect upsell opportunities (e.g. "this tenant tried
+ * `export` 14 times this week, offer them Pro").
+ *
+ * Default-on behavior: if a tenant has no feature config doc, every
+ * feature reads as enabled (back-compat). Errors fetching the config
+ * also fail-open \u2014 we never block a request because the flag store
+ * is unreachable. The middleware is designed to be cheap on the hot
+ * path; the service layer is responsible for caching.
+ */
+
+import type { NextFunction, Request, Response } from 'express';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import { isFeatureEnabled } from '../services/host/tenantFeaturesConfigService.js';
+import type { FeatureFlagName } from '../models/TenantFeaturesConfig.js';
+import {
+  emitMeteringEvent,
+  resolveTenantId,
+} from '../services/metering/index.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Resolve the tenantId associated with the request.
+ *
+ * Order of precedence:
+ *   1. `req.tenant?.id`     \u2014 host API key authenticated callers
+ *   2. `req.params.tenantId` \u2014 routes mounted under `/:tenantId/...`
+ *   3. `req.params.libraryId` (legacy) or `req.user?.uid` \u2014 fallback
+ *      while the tenantId model rolls out (matches the convention in
+ *      `tenantUsage`).
+ *
+ * Returns null when no tenant can be derived; the middleware treats this
+ * as "no gate to apply" and forwards to next().
+ */
+function resolveRequestTenantId(req: Request): string | null {
+  if (req.tenant?.id) return req.tenant.id;
+  // `req.tenantId` is populated by the resolveTenant middleware (claim /
+  // header / default). Prefer it over path params because it has already
+  // been normalized and reflects whatever the auth pipeline resolved.
+  const resolved = (req as Request & { tenantId?: string }).tenantId;
+  if (typeof resolved === 'string' && resolved.length > 0) return resolved;
+  const paramTenantId = (req.params as { tenantId?: string } | undefined)?.tenantId;
+  if (paramTenantId) return paramTenantId;
+  const paramLibraryId = (req.params as { libraryId?: string } | undefined)
+    ?.libraryId;
+  if (paramLibraryId) return paramLibraryId;
+  if (req.user?.uid) return req.user.uid;
+  return null;
+}
+
+export interface RequireFeatureOptions {
+  /**
+   * Override how the tenantId is resolved from the request. Defaults to
+   * `resolveRequestTenantId` above.
+   */
+  resolveTenantId?: (req: Request) => string | null;
+}
+
+/**
+ * Build the middleware factory. The factory is curried (`createRequireFeature(data)`
+ * \u2192 `requireFeature(name)`) so the server can wire the data adapter once
+ * at startup and individual route mounts pick the flag name.
+ */
+export function createRequireFeature(
+  dataAdapter: DataAdapter,
+  opts: RequireFeatureOptions = {}
+) {
+  const resolve = opts.resolveTenantId ?? resolveRequestTenantId;
+
+  return function requireFeature(feature: FeatureFlagName) {
+    return async function requireFeatureMiddleware(
+      req: Request,
+      res: Response,
+      next: NextFunction
+    ): Promise<void> {
+      const tenantId = resolve(req);
+      // No tenant context \u2014 we cannot check the flag. Fail open so we
+      // do not break unauthenticated or pre-tenant-resolution routes.
+      if (!tenantId) {
+        next();
+        return;
+      }
+
+      let enabled = true;
+      try {
+        enabled = await isFeatureEnabled(dataAdapter, tenantId, feature);
+      } catch (err) {
+        // Fail open on adapter errors. The host can still detect a
+        // misconfiguration via standard error monitoring; blocking
+        // requests because the config store is unreachable would
+        // amplify incidents into customer-visible outages.
+        logger.warn(
+          { err, tenantId, feature },
+          'requireFeature: failed to resolve flag, failing open'
+        );
+        next();
+        return;
+      }
+
+      if (enabled) {
+        next();
+        return;
+      }
+
+      // Gated. Emit a metering event \u2014 hosts use this as an upsell
+      // signal. `route` is intentionally the registered Express route
+      // path (e.g. `/v1/photos/:photoId/export`), not the concrete URL,
+      // so it groups cleanly in rollups without leaking ids.
+      try {
+        emitMeteringEvent({
+          tenantId: resolveTenantId({ tenantId }),
+          type: 'feature.gated',
+          count: 1,
+          meta: {
+            feature,
+            route: req.route?.path ?? req.baseUrl ?? req.path ?? null,
+            method: req.method,
+            userId: req.user?.uid ?? null,
+            keyId: req.tenant?.keyId ?? null,
+          },
+        });
+      } catch (err) {
+        // Metering MUST NOT affect the response.
+        logger.debug({ err, tenantId, feature }, 'feature.gated emit failed');
+      }
+
+      res.status(403).json({
+        error: 'feature_disabled',
+        feature,
+      });
+    };
+  };
+}
+
+/**
+ * Type alias for the curried middleware factory \u2014 lets callers type
+ * the per-feature factory without re-deriving the return type.
+ */
+export type RequireFeatureFactory = ReturnType<typeof createRequireFeature>;

--- a/functions/src/models/TenantApiKey.ts
+++ b/functions/src/models/TenantApiKey.ts
@@ -21,6 +21,7 @@ export type TenantApiKeyScope =
   | 'webhooks.write'
   | 'audit.read'
   | 'tenant.admin'
+  | 'tenant.config'
   | 'plugins.read'
   | 'plugins.write'
   | 'export-presets.read'
@@ -39,6 +40,14 @@ export const TENANT_API_KEY_SCOPES: readonly TenantApiKeyScope[] = [
    * auth — these endpoints are host-key-only.
    */
   'tenant.admin',
+  /**
+   * `tenant.config` grants read/write access to per-tenant feature flag
+   * configuration (issue #175). The host application uses this scope to
+   * map pricing tiers to capability — Free/Pro/Business plans toggle
+   * features (sharing, plugins, export, etc.) on or off per tenant.
+   * Host-key-only — feature flags are NOT end-user-tunable.
+   */
+  'tenant.config',
   'plugins.read',
   'plugins.write',
   'export-presets.read',

--- a/functions/src/models/TenantFeaturesConfig.ts
+++ b/functions/src/models/TenantFeaturesConfig.ts
@@ -1,0 +1,72 @@
+/**
+ * Per-tenant feature flag config (issue #175).
+ *
+ * Hosts that resell AuraPix on tiered pricing plans need to map plan
+ * tiers (Free / Pro / Business) to capability \u2014 e.g. Free tenants
+ * cannot use plugins or sharing, Pro tenants cannot use the export API.
+ * This document stores, per tenant, the explicit on/off state for each
+ * gated feature.
+ *
+ * Default-on behavior: when a tenant has no `tenantFeaturesConfig`
+ * document yet, every feature MUST behave as if enabled (back-compat
+ * for existing tenants pre-rollout). The service layer resolves
+ * unset flags to `true`.
+ *
+ * Configuration is strictly per tenant. There is no global override
+ * or cross-tenant inheritance.
+ */
+
+export const TENANT_FEATURES_CONFIG_COLLECTION = 'tenantFeaturesConfig';
+
+/**
+ * Canonical list of gateable feature names. Adding a new feature here
+ * is the only place required \u2014 routes opt in by passing the name to
+ * `requireFeature(name)`, the GET response will include the new key
+ * automatically (defaulting to `true` until the host PATCHes it), and
+ * the embedded UI bootstrap payload will surface it for hide/show.
+ */
+export const FEATURE_FLAG_NAMES = [
+  'sharing',
+  'plugins',
+  'smartAlbums',
+  'export',
+  'bulkOps',
+] as const;
+
+export type FeatureFlagName = (typeof FEATURE_FLAG_NAMES)[number];
+
+export type TenantFeatureFlags = Record<FeatureFlagName, boolean>;
+
+export interface TenantFeaturesConfigRecord {
+  /**
+   * Document id; equal to `tenantId`. Using tenantId as the document id
+   * keeps lookups O(1) and keeps configuration strictly per-tenant.
+   */
+  tenantId: string;
+
+  /**
+   * Sparse map of feature flag overrides. Unset features fall back to
+   * the default (`true`). Stored as a partial map so legacy docs that
+   * predate a new feature name read cleanly as "default-on".
+   */
+  flags: Partial<TenantFeatureFlags>;
+
+  /** ISO-8601 timestamp of the last mutation. */
+  updatedAt: string;
+
+  /**
+   * Identifier of the principal that last updated the doc. For host
+   * API key actors this is the API key id (e.g. `tak_...`); for admin
+   * users it is their uid. May be null for system-initialized docs.
+   */
+  updatedBy: string | null;
+}
+
+/** Default feature state when no doc exists \u2014 every feature is enabled. */
+export const DEFAULT_FEATURE_FLAGS: TenantFeatureFlags = {
+  sharing: true,
+  plugins: true,
+  smartAlbums: true,
+  export: true,
+  bulkOps: true,
+};

--- a/functions/src/routes/brandingV1.ts
+++ b/functions/src/routes/brandingV1.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 import type { DataAdapter } from '../adapters/data/DataAdapter.js';
 import { recordAuditEvent } from '../services/audit/AuditService.js';
+import { getEffectiveFeatureFlags } from '../services/host/tenantFeaturesConfigService.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -129,9 +130,28 @@ export function createBrandingV1Router(
       const stored = await dataAdapter.fetchData<BrandingRecord>(BRANDING_COLLECTION, tenantId);
       const branding = brandingWithDefaults(tenantId, stored);
 
-      // Cacheable: branding rarely changes and is public.
+      // Per-tenant feature flags (issue #175) are surfaced in the same
+      // bootstrap payload so the embedded UI can hide disabled affordances
+      // (avoids dead buttons) without a second request. Defaults all-on so
+      // tenants with no doc behave as before.
+      let features;
+      try {
+        features = await getEffectiveFeatureFlags(dataAdapter, tenantId);
+      } catch (err) {
+        logger.warn(
+          { err, tenantId },
+          'Failed to resolve feature flags for branding bootstrap; falling back to defaults'
+        );
+        // Don't fail the branding response on a feature lookup miss — the
+        // UI degrades gracefully to all-on, matching the server-side default.
+        features = undefined;
+      }
+
+      // Cacheable: branding rarely changes and is public. Features change
+      // more often, but the 60s freshness window is acceptable and bounded
+      // by the service-layer TTL anyway.
       res.setHeader('Cache-Control', 'public, max-age=60, stale-while-revalidate=300');
-      res.status(200).json({ branding });
+      res.status(200).json(features ? { branding, features } : { branding });
     } catch (error) {
       next(error);
     }

--- a/functions/src/routes/tenantFeaturesV1.ts
+++ b/functions/src/routes/tenantFeaturesV1.ts
@@ -1,0 +1,251 @@
+/**
+ * Per-tenant feature flag endpoints (issue #175).
+ *
+ * Mounted at `/v1/tenants/:tenantId/features` (and the legacy
+ * `/api/v1/tenants/...` alias). Both endpoints are host-API-key only
+ * with the `tenant.config` scope \u2014 feature flags are a host
+ * configuration concern (they map to pricing tiers) and are NOT
+ * user-tunable.
+ *
+ *   GET   /:tenantId/features        \u2192 effective flag map (defaults
+ *                                       merged in) plus metadata.
+ *   PATCH /:tenantId/features        \u2192 partial update; emits
+ *                                       `feature.flag_changed` for each
+ *                                       transitioning flag.
+ *
+ * Defaults: tenants with no doc read every feature as `true` (back-compat).
+ * Unknown keys in PATCH bodies are silently ignored at the service layer.
+ *
+ * See:
+ *   - models/TenantFeaturesConfig.ts        \u2014 storage shape, defaults
+ *   - services/host/tenantFeaturesConfigService.ts \u2014 cached read + PATCH
+ *   - middleware/requireFeature.ts          \u2014 the per-route gate
+ *   - contracts/openapi/tenant-features.openapi.json \u2014 contract
+ */
+
+import { randomUUID } from 'node:crypto';
+import { Router } from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import {
+  FEATURE_FLAG_NAMES,
+  type FeatureFlagName,
+} from '../models/TenantFeaturesConfig.js';
+import {
+  fetchTenantFeaturesConfig,
+  getEffectiveFeatureFlags,
+  patchTenantFeatures,
+} from '../services/host/tenantFeaturesConfigService.js';
+import {
+  emitMeteringEvent,
+  resolveTenantId,
+} from '../services/metering/index.js';
+import { recordAuditEvent } from '../services/audit/AuditService.js';
+import type { TenantApiKeyScope } from '../models/TenantApiKey.js';
+import { logger } from '../utils/logger.js';
+
+interface ApiErrorPayload {
+  error: {
+    code: string;
+    message: string;
+    requestId: string;
+    details: Record<string, unknown> | null;
+  };
+}
+
+function sendError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> | null = null
+): void {
+  const body: ApiErrorPayload = {
+    error: { code, message, requestId: randomUUID(), details },
+  };
+  res.status(status).json(body);
+}
+
+/**
+ * Host-API-key-only guard. Mirrors `requireTenantHostKey` in the
+ * plugin-config router: rejects user-Bearer tokens entirely.
+ */
+function requireTenantHostKey(scope: TenantApiKeyScope) {
+  return function guard(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): void {
+    const tenantId = String(req.params.tenantId ?? '');
+    if (!tenantId) {
+      sendError(res, 400, 'VALIDATION_ERROR', 'tenantId is required');
+      return;
+    }
+    if (!req.tenant) {
+      sendError(
+        res,
+        401,
+        'HOST_API_KEY_REQUIRED',
+        'Feature flag configuration endpoints require a host API key'
+      );
+      return;
+    }
+    if (req.tenant.id !== tenantId) {
+      sendError(
+        res,
+        403,
+        'CROSS_TENANT_FORBIDDEN',
+        'Cross-tenant request rejected'
+      );
+      return;
+    }
+    if (!new Set(req.tenant.scopes).has(scope)) {
+      sendError(res, 403, 'INSUFFICIENT_SCOPE', 'Insufficient scope', {
+        missing: [scope],
+      });
+      return;
+    }
+    next();
+  };
+}
+
+/**
+ * PATCH body schema. Every flag is optional; unknown keys are stripped
+ * by zod's default `.strict()`-free behavior, and the service layer also
+ * ignores them defensively.
+ */
+const PatchSchema = z
+  .object(
+    Object.fromEntries(
+      FEATURE_FLAG_NAMES.map((name) => [name, z.boolean().optional()])
+    ) as Record<FeatureFlagName, z.ZodOptional<z.ZodBoolean>>
+  )
+  .strict();
+
+export interface TenantFeaturesRouterDeps {
+  dataAdapter: DataAdapter;
+}
+
+export function createTenantFeaturesRouter(
+  deps: TenantFeaturesRouterDeps
+): Router {
+  const router = Router({ mergeParams: true });
+
+  // GET /:tenantId/features
+  router.get(
+    '/:tenantId/features',
+    requireTenantHostKey('tenant.config'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId);
+        const flags = await getEffectiveFeatureFlags(deps.dataAdapter, tenantId);
+        const doc = await fetchTenantFeaturesConfig(deps.dataAdapter, tenantId);
+        res.status(200).json({
+          tenantId,
+          flags,
+          updatedAt: doc?.updatedAt ?? null,
+          updatedBy: doc?.updatedBy ?? null,
+        });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  // PATCH /:tenantId/features
+  router.patch(
+    '/:tenantId/features',
+    requireTenantHostKey('tenant.config'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId);
+        const parsed = PatchSchema.safeParse(req.body ?? {});
+        if (!parsed.success) {
+          sendError(res, 400, 'INVALID_BODY', 'Invalid feature flag payload', {
+            issues: parsed.error.issues,
+          });
+          return;
+        }
+
+        const actor = req.tenant?.keyId ?? null;
+        const result = await patchTenantFeatures(deps.dataAdapter, {
+          tenantId,
+          patch: parsed.data as Partial<Record<FeatureFlagName, boolean>>,
+          actor,
+        });
+
+        // Emit one `feature.flag_changed` per transitioning flag so the
+        // host's audit log has a clean per-feature trail. `actor` is the
+        // API key id with a short prefix so audit consumers can identify
+        // which integration flipped the flag without exposing the secret.
+        const actorLabel = actor ? `host-api-key:${actor.substring(0, 8)}` : 'host-api-key';
+        for (const change of result.changes) {
+          try {
+            emitMeteringEvent({
+              tenantId: resolveTenantId({ tenantId }),
+              type: 'feature.flag_changed',
+              count: 1,
+              resourceId: change.feature,
+              meta: {
+                tenantId,
+                feature: change.feature,
+                oldValue: change.oldValue,
+                newValue: change.newValue,
+                actor: actorLabel,
+              },
+            });
+          } catch (err) {
+            logger.debug(
+              { err, tenantId, feature: change.feature },
+              'feature.flag_changed emit failed'
+            );
+          }
+        }
+
+        // Audit event for compliance trails (same pattern as branding).
+        if (result.changes.length > 0) {
+          try {
+            await recordAuditEvent(deps.dataAdapter, {
+              eventType: 'tenant.features.updated',
+              actorId: actor ?? 'host-api-key',
+              targetId: tenantId,
+              createdAt: result.record.updatedAt,
+              metadata: {
+                tenantId,
+                changes: result.changes,
+              },
+            });
+          } catch (auditErr) {
+            logger.warn(
+              { err: auditErr, tenantId },
+              'Failed to record tenant.features audit event'
+            );
+          }
+        }
+
+        // Return the new effective flags (defaults merged) so the host
+        // does not have to re-GET to render UI.
+        const flags = await getEffectiveFeatureFlags(deps.dataAdapter, tenantId);
+        res.status(200).json({
+          tenantId,
+          flags,
+          updatedAt: result.record.updatedAt,
+          updatedBy: result.record.updatedBy,
+          changes: result.changes,
+        });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  return router;
+}
+
+/**
+ * Test surface: re-export internals helpful for unit testing.
+ */
+export const __test = {
+  PatchSchema,
+};

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -115,6 +115,8 @@ import { createTenantOffboardingRouter } from './routes/tenantOffboardingV1.js';
 import { TenantOffboardingService } from './services/tenant/TenantOffboardingService.js';
 import { createTenantWebhookSecretsRouter } from './routes/tenantWebhookSecretsV1.js';
 import { createTenantPluginsRouter } from './routes/tenantPluginsV1.js';
+import { createTenantFeaturesRouter } from './routes/tenantFeaturesV1.js';
+import { createRequireFeature } from './middleware/requireFeature.js';
 import { createPhotosV1Router, createLibraryTagsRouter } from './routes/photosV1.js';
 import { createAuditEventsV1Router } from './routes/auditEventsV1.js';
 import {
@@ -209,8 +211,13 @@ app.use('/images', createImageRoutes(dataAdapter));
 // require. Individual routes inside internalRouter enforce admin or scope
 // requirements via requireUserOrTenantScopes / requireAdmin.
 const hostApiKeyAuth = createHostApiKeyAuth(dataAdapter);
+// Per-tenant feature flag gate factory (issue #175). Curried so callers
+// pass just the flag name at mount time: `requireFeature('export')`.
+// Default-on when no doc exists, fail-open on adapter errors — see
+// `middleware/requireFeature.ts` for details.
+const requireFeature = createRequireFeature(dataAdapter);
 app.use('/internal', hostApiKeyAuth, optionalAuthMiddleware, internalRouter);
-app.use('/edits', authMiddleware, editsRouter);
+app.use('/edits', authMiddleware, requireFeature('plugins'), editsRouter);
 
 // Versioned API surface (desktop/web clients)
 app.use('/api', apiVersionMiddleware);
@@ -234,7 +241,8 @@ app.use('/api/v1/photos', authMiddleware, createPhotosListV1Router(dataAdapter))
 app.use('/api/v1/compliance', authMiddleware, createComplianceV1Router(dataAdapter));
 // Bulk photo operations (issue #142). Express routes treat `:` as a param
 // separator, so we register the exact literal path.
-app.use('/api/v1/photos\\:batch', authMiddleware, createBulkPhotosRouter(dataAdapter));
+// Gated by per-tenant `bulkOps` feature flag (issue #175).
+app.use('/api/v1/photos\\:batch', authMiddleware, requireFeature('bulkOps'), createBulkPhotosRouter(dataAdapter));
 
 // Photos: soft-delete (Trash) + restore + trashed list (issue #152),
 // plus keyword tags add/remove + per-library tag enumeration (issue #173).
@@ -271,11 +279,14 @@ const photoExportHandle = createPhotoExportRouter({
   dataAdapter,
   storageAdapter,
 });
+// Photo export endpoints — gated by per-tenant `export` feature flag
+// (issue #175). Hosts on Free/Basic plans can turn this off entirely.
 app.use(
   '/v1/photos',
   hostApiKeyAuth,
   optionalAuthMiddleware,
   resolveTenant,
+  requireFeature('export'),
   photoExportHandle.router
 );
 app.use(
@@ -283,6 +294,7 @@ app.use(
   hostApiKeyAuth,
   optionalAuthMiddleware,
   resolveTenant,
+  requireFeature('export'),
   photoExportHandle.router
 );
 app.use(
@@ -298,30 +310,35 @@ app.use(
   createLibraryTagsRouter(photosService)
 );
 
-// Smart Albums (issue #165).
+// Smart Albums (issue #165). Gated by per-tenant `smartAlbums` feature
+// flag (issue #175).
 const smartAlbumsService = domainModules.smartAlbums;
 app.use(
   '/v1/libraries/:libraryId/smart-albums',
   authMiddleware,
   resolveTenant,
+  requireFeature('smartAlbums'),
   createSmartAlbumsLibraryRouter(smartAlbumsService)
 );
 app.use(
   '/api/v1/libraries/:libraryId/smart-albums',
   authMiddleware,
   resolveTenant,
+  requireFeature('smartAlbums'),
   createSmartAlbumsLibraryRouter(smartAlbumsService)
 );
 app.use(
   '/v1/smart-albums',
   authMiddleware,
   resolveTenant,
+  requireFeature('smartAlbums'),
   createSmartAlbumsResourceRouter(smartAlbumsService)
 );
 app.use(
   '/api/v1/smart-albums',
   authMiddleware,
   resolveTenant,
+  requireFeature('smartAlbums'),
   createSmartAlbumsResourceRouter(smartAlbumsService)
 );
 
@@ -382,6 +399,16 @@ app.use(
   '/api/v1/tenants',
   hostApiKeyAuth,
   createTenantAdminRouter(dataAdapter)
+);
+// Sharing surface (issue #175): the `POST /api/signing/key/share/:token`
+// path is the host's entry point for issuing share-token signing keys.
+// Gate it on the per-tenant `sharing` feature flag *before* the full
+// signing router so a disabled tenant cannot mint share-grant keys.
+app.post(
+  '/api/signing/key/share/:token',
+  authMiddleware,
+  requireFeature('sharing'),
+  (_req, _res, next) => next()
 );
 app.use('/api/signing', authMiddleware, createSigningRouter(dataAdapter));
 
@@ -467,6 +494,8 @@ const auditEventsRouter = createAuditEventsV1Router({
   // Until a real tenantId model lands, treat the authenticated user's uid
   // as their own tenantId (mirrors the tenantUsage convention).
   ownsTenant: async (userId, tenantId) => userId === tenantId,
+});
+
 // --- Embed handshake routes (issue #163) ---
 // GET/PUT allowed-origins is host-API-key gated (or owner user); the CSP
 // report endpoint is unauthenticated so browsers can post violation
@@ -503,6 +532,22 @@ app.use(
   hostApiKeyAuth,
   optionalAuthMiddleware,
   createTenantPluginsRouter({ dataAdapter })
+);
+
+// Per-tenant feature flag config (issue #175). Host-API-key-only with
+// the `tenant.config` scope. Mounted on both `/v1/tenants` (canonical
+// spec URL) and `/api/v1/tenants` (legacy in-product prefix) so hosts
+// can call either path.
+const tenantFeaturesRouter = createTenantFeaturesRouter({ dataAdapter });
+app.use(
+  '/v1/tenants',
+  hostApiKeyAuth,
+  tenantFeaturesRouter
+);
+app.use(
+  '/api/v1/tenants',
+  hostApiKeyAuth,
+  tenantFeaturesRouter
 );
 
 // Per-tenant export presets (issue #174).

--- a/functions/src/services/host/tenantFeaturesConfigService.test.ts
+++ b/functions/src/services/host/tenantFeaturesConfigService.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+import {
+  DEFAULT_FEATURE_FLAGS,
+  FEATURE_FLAG_NAMES,
+  TENANT_FEATURES_CONFIG_COLLECTION,
+  type TenantFeaturesConfigRecord,
+} from '../../models/TenantFeaturesConfig.js';
+import {
+  __resetTenantFeaturesCacheForTests,
+  fetchTenantFeaturesConfig,
+  getEffectiveFeatureFlags,
+  invalidateTenantFeaturesCache,
+  isFeatureEnabled,
+  mergeWithDefaults,
+  patchTenantFeatures,
+} from './tenantFeaturesConfigService.js';
+
+/**
+ * Minimal DataAdapter stub backed by an in-memory map. Matches the
+ * pattern used elsewhere in the suite (see tenantPluginConfigService.test.ts).
+ */
+function makeMemoryAdapter(): {
+  data: DataAdapter;
+  store: Map<string, Map<string, unknown>>;
+} {
+  const store = new Map<string, Map<string, unknown>>();
+  const get = (collection: string) => {
+    let inner = store.get(collection);
+    if (!inner) {
+      inner = new Map();
+      store.set(collection, inner);
+    }
+    return inner;
+  };
+  const adapter: DataAdapter = {
+    storeData: vi.fn(async (collection: string, id: string, value: unknown) => {
+      get(collection).set(id, value);
+    }),
+    fetchData: vi.fn(async <T>(collection: string, id: string) => {
+      const value = get(collection).get(id);
+      return (value ?? null) as T | null;
+    }),
+    queryData: vi.fn(async () => []),
+    updateData: vi.fn(async () => {}),
+    deleteData: vi.fn(async (collection: string, id: string) => {
+      get(collection).delete(id);
+    }),
+    exists: vi.fn(async (collection: string, id: string) =>
+      get(collection).has(id)
+    ),
+    listIds: vi.fn(async (collection: string) =>
+      Array.from(get(collection).keys())
+    ),
+    getPhoto: vi.fn(async () => null),
+  } as unknown as DataAdapter;
+  return { data: adapter, store };
+}
+
+describe('tenantFeaturesConfigService', () => {
+  beforeEach(() => {
+    __resetTenantFeaturesCacheForTests();
+  });
+
+  describe('default-on policy (issue #175)', () => {
+    it('returns all flags true when the tenant has no doc', async () => {
+      const { data } = makeMemoryAdapter();
+      const flags = await getEffectiveFeatureFlags(data, 'tenant-a');
+      expect(flags).toEqual(DEFAULT_FEATURE_FLAGS);
+      // Every named feature must be present and true.
+      for (const name of FEATURE_FLAG_NAMES) {
+        expect(flags[name]).toBe(true);
+      }
+    });
+
+    it('isFeatureEnabled returns true for every feature on a fresh tenant', async () => {
+      const { data } = makeMemoryAdapter();
+      for (const name of FEATURE_FLAG_NAMES) {
+        await expect(isFeatureEnabled(data, 'fresh-tenant', name)).resolves.toBe(
+          true
+        );
+      }
+    });
+
+    it('isFeatureEnabled with empty tenantId resolves to the default', async () => {
+      const { data } = makeMemoryAdapter();
+      // The middleware passes through requests with no tenant context;
+      // this contract documents that an empty tenantId never blocks.
+      await expect(isFeatureEnabled(data, '', 'export')).resolves.toBe(
+        DEFAULT_FEATURE_FLAGS.export
+      );
+    });
+
+    it('treats an existing doc with a missing flag as default-on for that flag', async () => {
+      const { data, store } = makeMemoryAdapter();
+      // Persist a doc that only overrides one flag; the others must
+      // continue to read as defaults (back-compat for new features added
+      // after a tenant's doc was first written).
+      const partial: TenantFeaturesConfigRecord = {
+        tenantId: 'tenant-partial',
+        flags: { export: false },
+        updatedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+        updatedBy: 'api-key-001',
+      };
+      store
+        .get(TENANT_FEATURES_CONFIG_COLLECTION) ??
+        store.set(TENANT_FEATURES_CONFIG_COLLECTION, new Map());
+      store
+        .get(TENANT_FEATURES_CONFIG_COLLECTION)!
+        .set('tenant-partial', partial);
+
+      const flags = await getEffectiveFeatureFlags(data, 'tenant-partial');
+      expect(flags.export).toBe(false);
+      // Every other flag remains default-on.
+      for (const name of FEATURE_FLAG_NAMES) {
+        if (name === 'export') continue;
+        expect(flags[name]).toBe(true);
+      }
+    });
+  });
+
+  describe('mergeWithDefaults', () => {
+    it('returns defaults when given null', () => {
+      expect(mergeWithDefaults(null)).toEqual(DEFAULT_FEATURE_FLAGS);
+    });
+
+    it('overrides only the supplied keys', () => {
+      const merged = mergeWithDefaults({ sharing: false, plugins: false });
+      expect(merged.sharing).toBe(false);
+      expect(merged.plugins).toBe(false);
+      expect(merged.smartAlbums).toBe(true);
+      expect(merged.export).toBe(true);
+      expect(merged.bulkOps).toBe(true);
+    });
+
+    it('ignores non-boolean values', () => {
+      const merged = mergeWithDefaults({
+        // @ts-expect-error \u2014 deliberately exercising the defensive branch
+        sharing: 'yes',
+      });
+      expect(merged.sharing).toBe(true);
+    });
+  });
+
+  describe('patchTenantFeatures', () => {
+    it('writes a new doc when none exists and reports every transition vs. defaults', async () => {
+      const { data, store } = makeMemoryAdapter();
+      const result = await patchTenantFeatures(data, {
+        tenantId: 'tenant-x',
+        patch: { export: false, sharing: false },
+        actor: 'tak_abc123',
+      });
+
+      const stored = store
+        .get(TENANT_FEATURES_CONFIG_COLLECTION)
+        ?.get('tenant-x') as TenantFeaturesConfigRecord;
+      expect(stored).toBeDefined();
+      expect(stored.flags).toEqual({ export: false, sharing: false });
+      expect(stored.updatedBy).toBe('tak_abc123');
+
+      // `changes` enumerates flags whose effective value transitioned.
+      // Before: defaults (all true). After: export=false, sharing=false.
+      const changedNames = new Set(result.changes.map((c) => c.feature));
+      expect(changedNames).toEqual(new Set(['export', 'sharing']));
+      for (const change of result.changes) {
+        expect(change.oldValue).toBe(true);
+        expect(change.newValue).toBe(false);
+      }
+    });
+
+    it('returns an empty `changes` array when the patch is a no-op', async () => {
+      const { data } = makeMemoryAdapter();
+      // First mutation: flips a flag.
+      await patchTenantFeatures(data, {
+        tenantId: 'tenant-y',
+        patch: { plugins: false },
+      });
+      // Bust the cache so the next read sees the just-written doc and
+      // can compare apples-to-apples.
+      invalidateTenantFeaturesCache('tenant-y');
+
+      // Second mutation: re-asserts the same value. No transition.
+      const result = await patchTenantFeatures(data, {
+        tenantId: 'tenant-y',
+        patch: { plugins: false },
+      });
+      expect(result.changes).toEqual([]);
+    });
+
+    it('ignores unknown keys defensively', async () => {
+      const { data, store } = makeMemoryAdapter();
+      await patchTenantFeatures(data, {
+        tenantId: 'tenant-z',
+        // @ts-expect-error \u2014 simulating a typo / deprecated flag
+        patch: { sharing: false, somethingDeprecated: true },
+      });
+      const stored = store
+        .get(TENANT_FEATURES_CONFIG_COLLECTION)
+        ?.get('tenant-z') as TenantFeaturesConfigRecord;
+      expect(stored.flags).toEqual({ sharing: false });
+      // Unknown key did NOT leak into the stored map.
+      expect(Object.keys(stored.flags)).not.toContain('somethingDeprecated');
+    });
+
+    it('rejects missing tenantId', async () => {
+      const { data } = makeMemoryAdapter();
+      await expect(
+        patchTenantFeatures(data, { tenantId: '', patch: { export: false } })
+      ).rejects.toThrow(/tenantId/);
+    });
+  });
+
+  describe('TTL cache', () => {
+    it('caches fetchTenantFeaturesConfig and busts on patch', async () => {
+      const { data } = makeMemoryAdapter();
+      const fetchSpy = data.fetchData as ReturnType<typeof vi.fn>;
+
+      // Cold read \u2014 hits storage.
+      await fetchTenantFeaturesConfig(data, 'tenant-c');
+      const coldCalls = fetchSpy.mock.calls.length;
+
+      // Warm read \u2014 served from cache, no extra fetch.
+      await fetchTenantFeaturesConfig(data, 'tenant-c');
+      expect(fetchSpy.mock.calls.length).toBe(coldCalls);
+
+      // A patch invalidates the cache, so the next read must hit storage.
+      await patchTenantFeatures(data, {
+        tenantId: 'tenant-c',
+        patch: { plugins: false },
+      });
+      await fetchTenantFeaturesConfig(data, 'tenant-c');
+      expect(fetchSpy.mock.calls.length).toBeGreaterThan(coldCalls);
+    });
+  });
+});

--- a/functions/src/services/host/tenantFeaturesConfigService.ts
+++ b/functions/src/services/host/tenantFeaturesConfigService.ts
@@ -1,0 +1,217 @@
+/**
+ * Service layer for per-tenant feature flag configuration (issue #175).
+ *
+ * Storage shape: a single document per tenant in
+ * `TENANT_FEATURES_CONFIG_COLLECTION`, keyed by tenantId. The document
+ * holds a sparse map of feature overrides; unset features fall back to
+ * the default (`true`) so tenants without a doc retain full capability
+ * (back-compat).
+ *
+ * Caching: hot path \u2014 `requireFeature` runs on every gated request.
+ * The service maintains an in-memory TTL cache keyed by tenantId
+ * (mirroring the branding service pattern). Cache writes are inline on
+ * fetch and invalidated on mutation; default TTL is 30s, configurable
+ * via env `TENANT_FEATURES_CACHE_TTL_MS` for hosts that want stricter
+ * propagation guarantees.
+ *
+ * The cache is intentionally process-local: feature flag changes are
+ * low-volume, the eventual-consistency window is bounded by the TTL,
+ * and the host has access to the `feature.flag_changed` metering event
+ * if they need stronger guarantees (they can flush their own caches
+ * via a webhook fan-out).
+ */
+
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+import {
+  DEFAULT_FEATURE_FLAGS,
+  FEATURE_FLAG_NAMES,
+  TENANT_FEATURES_CONFIG_COLLECTION,
+  type FeatureFlagName,
+  type TenantFeatureFlags,
+  type TenantFeaturesConfigRecord,
+} from '../../models/TenantFeaturesConfig.js';
+
+interface CacheEntry {
+  record: TenantFeaturesConfigRecord | null;
+  expiresAt: number;
+}
+
+const DEFAULT_TTL_MS = 30_000;
+
+function resolveTtlMs(): number {
+  const raw = process.env.TENANT_FEATURES_CACHE_TTL_MS;
+  if (!raw) return DEFAULT_TTL_MS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_TTL_MS;
+  return Math.floor(n);
+}
+
+const cache = new Map<string, CacheEntry>();
+const TTL_MS = resolveTtlMs();
+
+/**
+ * Discard the cache entry for a tenant. Called automatically on mutation
+ * (`patchTenantFeatures`); exported for tests and explicit busts.
+ */
+export function invalidateTenantFeaturesCache(tenantId?: string | null): void {
+  if (!tenantId) {
+    cache.clear();
+    return;
+  }
+  cache.delete(tenantId);
+}
+
+/**
+ * Reset cache state. Test helper.
+ */
+export function __resetTenantFeaturesCacheForTests(): void {
+  cache.clear();
+}
+
+/**
+ * Fetch the raw config document for a tenant, or null if it does not
+ * exist. Most callers should use `getEffectiveFeatureFlags` or
+ * `isFeatureEnabled` instead.
+ */
+export async function fetchTenantFeaturesConfig(
+  data: DataAdapter,
+  tenantId: string
+): Promise<TenantFeaturesConfigRecord | null> {
+  if (!tenantId) return null;
+  const now = Date.now();
+  const cached = cache.get(tenantId);
+  if (cached && cached.expiresAt > now) {
+    return cached.record;
+  }
+  const record = await data.fetchData<TenantFeaturesConfigRecord>(
+    TENANT_FEATURES_CONFIG_COLLECTION,
+    tenantId
+  );
+  cache.set(tenantId, { record: record ?? null, expiresAt: now + TTL_MS });
+  return record ?? null;
+}
+
+/**
+ * Resolve the effective feature flag state for a tenant. Unset flags
+ * fall back to their default (`true`), so a tenant with no doc \u2014 or
+ * a doc that predates a newly-added feature \u2014 reads as fully enabled.
+ *
+ * Unknown keys in the stored map are silently ignored so a stale flag
+ * from an earlier deployment cannot accidentally grant access to a
+ * route that does not (yet) gate on that flag.
+ */
+export async function getEffectiveFeatureFlags(
+  data: DataAdapter,
+  tenantId: string
+): Promise<TenantFeatureFlags> {
+  const doc = await fetchTenantFeaturesConfig(data, tenantId);
+  return mergeWithDefaults(doc?.flags ?? null);
+}
+
+/**
+ * Convenience helper used by middleware and bootstrap.
+ *
+ * Returns `true` when the named feature is enabled for the tenant.
+ * Missing tenantId, missing doc, or missing flag entry all resolve to
+ * the default (`true`).
+ */
+export async function isFeatureEnabled(
+  data: DataAdapter,
+  tenantId: string,
+  feature: FeatureFlagName
+): Promise<boolean> {
+  if (!tenantId) return DEFAULT_FEATURE_FLAGS[feature];
+  const flags = await getEffectiveFeatureFlags(data, tenantId);
+  return flags[feature];
+}
+
+/**
+ * Apply a partial update to a tenant's feature flags. Returns the new
+ * record along with the previous flag state so callers can emit a
+ * `feature.flag_changed` metering event for each transitioning flag.
+ *
+ * Unknown keys in the input are ignored (defense in depth against the
+ * caller PATCHing a typo or a deprecated flag name).
+ */
+export async function patchTenantFeatures(
+  data: DataAdapter,
+  options: {
+    tenantId: string;
+    patch: Partial<TenantFeatureFlags>;
+    actor?: string | null;
+  }
+): Promise<{
+  record: TenantFeaturesConfigRecord;
+  previous: TenantFeatureFlags;
+  changes: Array<{ feature: FeatureFlagName; oldValue: boolean; newValue: boolean }>;
+}> {
+  const { tenantId, patch, actor } = options;
+  if (!tenantId) {
+    throw new Error('tenantId is required');
+  }
+
+  const existing = await data.fetchData<TenantFeaturesConfigRecord>(
+    TENANT_FEATURES_CONFIG_COLLECTION,
+    tenantId
+  );
+  const previous = mergeWithDefaults(existing?.flags ?? null);
+
+  const nextFlags: Partial<TenantFeatureFlags> = { ...(existing?.flags ?? {}) };
+  for (const [key, value] of Object.entries(patch)) {
+    if (!isKnownFeature(key)) continue;
+    if (typeof value !== 'boolean') continue;
+    nextFlags[key] = value;
+  }
+  const effective = mergeWithDefaults(nextFlags);
+
+  const changes: Array<{
+    feature: FeatureFlagName;
+    oldValue: boolean;
+    newValue: boolean;
+  }> = [];
+  for (const name of FEATURE_FLAG_NAMES) {
+    if (previous[name] !== effective[name]) {
+      changes.push({
+        feature: name,
+        oldValue: previous[name],
+        newValue: effective[name],
+      });
+    }
+  }
+
+  const now = new Date().toISOString();
+  const record: TenantFeaturesConfigRecord = {
+    tenantId,
+    flags: nextFlags,
+    updatedAt: now,
+    updatedBy: actor ?? null,
+  };
+
+  await data.storeData(TENANT_FEATURES_CONFIG_COLLECTION, tenantId, record);
+  invalidateTenantFeaturesCache(tenantId);
+
+  return { record, previous, changes };
+}
+
+/**
+ * Merge a sparse override map with the defaults to produce a complete
+ * `TenantFeatureFlags` value. Exported for tests and the bootstrap
+ * payload assembler.
+ */
+export function mergeWithDefaults(
+  partial: Partial<TenantFeatureFlags> | null
+): TenantFeatureFlags {
+  const out: TenantFeatureFlags = { ...DEFAULT_FEATURE_FLAGS };
+  if (!partial) return out;
+  for (const name of FEATURE_FLAG_NAMES) {
+    const v = partial[name];
+    if (typeof v === 'boolean') {
+      out[name] = v;
+    }
+  }
+  return out;
+}
+
+function isKnownFeature(value: string): value is FeatureFlagName {
+  return (FEATURE_FLAG_NAMES as readonly string[]).includes(value);
+}

--- a/functions/src/services/metering/MeteringBus.ts
+++ b/functions/src/services/metering/MeteringBus.ts
@@ -47,7 +47,16 @@ export type MeteringEventType =
   | 'photo.exported'
   | 'smart_album.created'
   | 'smart_album.deleted'
-  | 'smart_album.materialized';
+  | 'smart_album.materialized'
+  // Per-tenant feature flag gating (issue #175). Emitted by the
+  // `requireFeature(name)` middleware when a request is rejected because
+  // the feature is disabled for the tenant, and by the PATCH endpoint
+  // when the host toggles a flag. `feature.gated` is intentionally
+  // low-volume (only on a 403) and is NOT billable — hosts use it to
+  // surface upsell opportunities. `feature.flag_changed` is for audit /
+  // host-side change history.
+  | 'feature.gated'
+  | 'feature.flag_changed';
 
 export interface MeteringEvent {
   /**


### PR DESCRIPTION
## Summary

Adds host-controlled per-tenant feature gating (issue #175) so resellers can map pricing tiers (Free / Pro / Business) to capability without code changes. Five features ship as initial gates: `sharing`, `plugins`, `smartAlbums`, `export`, `bulkOps`. Tenants without a config doc keep full capability (default-on, back-compat).

## Changes

- **Model**: `tenantFeaturesConfig/{tenantId}` document storing a sparse flag override map.
- **Service** (`tenantFeaturesConfigService.ts`): cached reads (30s TTL, mirrors branding pattern), `patchTenantFeatures` reports per-flag transitions for metering, unknown keys ignored defensively.
- **Endpoints**: `GET` and `PATCH /v1/tenants/:id/features` (+ `/api/v1` alias), host-API-key only with the new `tenant.config` scope, cross-tenant requests return 403.
- **Middleware**: `requireFeature(name)` returns `403 { error: "feature_disabled", feature }` when off. Fails open on adapter errors so config-store outages do not cascade into customer-visible outages.
- **Gates applied**: `/edits` → `plugins`, `/api/v1/photos:batch` → `bulkOps`, photo export router → `export`, smart-albums routers → `smartAlbums`, `POST /api/signing/key/share/:token` → `sharing`.
- **Bootstrap payload**: embedded UI's branding GET response now includes effective `features` so the UI can hide disabled affordances (avoids dead buttons).
- **MeteringBus events**:
  - `feature.gated` — emitted on each 403, low-volume, NOT billable. Hosts use it for upsell signals.
  - `feature.flag_changed` — emitted once per transitioning flag on PATCH, for audit + host-side change history. `actor` prefixed with the API key id.
- **OpenAPI**: `contracts/openapi/tenant-features.openapi.json`.
- **Audit**: PATCH writes a `tenant.features.updated` event when at least one flag transitions.
- **Scope**: new `tenant.config` added to `TenantApiKeyScope` (alongside `tenant.admin`, matching the existing dot convention).

## Drive-by

Closes a pre-existing syntax error in `functions/src/server.ts` where `createAuditEventsV1Router({...})` was never closed. Without this fix the file cannot be type-checked at all, masking ~10 latent errors elsewhere. The diff is a single missing `});` plus the comment continuation that already existed.

## Testing

All 17 new tests pass:

- `tenantFeaturesConfigService.test.ts` (12): default-on policy (no doc, partial doc, empty tenantId), `mergeWithDefaults`, `patchTenantFeatures` (writes, no-op transitions return empty `changes`, unknown-key defense, missing tenantId rejection), TTL cache (cold/warm reads, mutation invalidates).
- `requireFeature.test.ts` (5): default-on pass-through, 403 shape on gated request, `feature.gated` metering emission, fail-open on adapter error, no-op when no tenant context.

Related suites also green:

```
 npx vitest run src/services/host src/middleware/requireFeature.test.ts
 Test Files  6 passed (6)  |  Tests  68 passed (68)
```

The 12 pre-existing failures in `test/routes/photosV1.test.ts` and `test/routes/tenantUsersV1.test.ts` reproduce on `main` with this branch stashed — confirmed unrelated to this change.

## Acceptance criteria

- [x] `tenants/{id}/config/features` document + service with cache
- [x] `GET` / `PATCH` endpoints behind host-API-key auth
- [x] OpenAPI contract
- [x] `requireFeature` middleware applied to: sharing, edits/plugin, smart albums, export, bulk ops route groups
- [x] Embedded UI bootstrap includes flags; UI can hide disabled affordances
- [x] `feature.gated` and `feature.flag_changed` events on MeteringBus
- [x] Unit tests cover default-on behavior

Fixes rwrife/AuraPix#175