### PR TITLE
fix: public webhook event catalog endpoint (GET /v1/host/webhook-events)

### DIFF
--- a/contracts/openapi/host-webhook-events.openapi.json
+++ b/contracts/openapi/host-webhook-events.openapi.json
@@ -1,0 +1,131 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AuraPix Host Webhook Event Catalog API",
+    "version": "0.1.0",
+    "description": "Machine-readable catalog of every metering / webhook event AuraPix can emit. Hosts integrating AuraPix for billing fetch this once at boot, cache it via `ETag`, and use the per-event JSON Schema to validate incoming webhook payloads. The same `catalogVersion` is stamped on every outbound webhook envelope (`HostWebhookSink`) so hosts can detect drift without polling. Issue #176."
+  },
+  "servers": [
+    { "url": "https://api.aurapix.example" }
+  ],
+  "paths": {
+    "/v1/host/webhook-events": {
+      "get": {
+        "operationId": "listHostWebhookEvents",
+        "summary": "Return the global catalog of metering / webhook event types",
+        "description": "Returns every event type AuraPix can emit, with JSON Schema for the `meta` payload and a `catalogVersion` cache key.\n\nThe catalog is **global** \u2014 identical for every host \u2014 and is safely cacheable at the edge. Hosts SHOULD send `If-None-Match` with the previously received `ETag` to get a `304` when nothing has changed.\n\nAuth: any valid host API key (`Authorization: Bearer ak_live_...`). No specific scope is required because the body contains no per-tenant data; the auth gate exists only to keep the roadmap out of fully-anonymous hands.",
+        "parameters": [
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "Previously received ETag. A match returns 304 with no body."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Catalog body. The `ETag` header is a weak validator derived from `catalogVersion` and a hash of the body.",
+            "headers": {
+              "ETag": {
+                "schema": { "type": "string" },
+                "description": "Weak validator, e.g. `W/\"2026-06-20-abcdef0123456789\"`."
+              },
+              "Cache-Control": {
+                "schema": { "type": "string" },
+                "description": "Aggressive caching is enabled by default (`public, max-age=300, stale-while-revalidate=600`)."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EventCatalogResponse" }
+              }
+            }
+          },
+          "304": {
+            "description": "Catalog unchanged since the supplied `If-None-Match`. No body."
+          },
+          "401": {
+            "description": "Missing or invalid host API key",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "EventCatalogResponse": {
+        "type": "object",
+        "required": ["catalogVersion", "events"],
+        "properties": {
+          "catalogVersion": {
+            "type": "string",
+            "description": "Bumped whenever the set of event types changes (new event, removed event, or non-additive schema change). Hosts compare against the cached snapshot and the per-envelope `catalogVersion` field.",
+            "example": "2026-06-20"
+          },
+          "events": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/RegisteredEvent" }
+          }
+        }
+      },
+      "RegisteredEvent": {
+        "type": "object",
+        "required": ["name", "version", "billable", "description", "schema"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Stable event name, e.g. `photo.exported`.",
+            "example": "photo.exported"
+          },
+          "version": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Per-event schema version. Bumped on non-additive meta changes."
+          },
+          "billable": {
+            "type": "boolean",
+            "description": "Hint that this event maps to a unit of resold work. Not a contract; hosts decide their own billing rules."
+          },
+          "description": {
+            "type": "string",
+            "description": "One-line summary."
+          },
+          "schema": {
+            "type": "object",
+            "description": "JSON Schema (Draft 2020-12) describing the `meta` payload for this event. Additional properties are always allowed for forward compatibility."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["code", "message", "requestId"],
+                "properties": {
+                  "code": { "type": "string" },
+                  "message": { "type": "string" },
+                  "requestId": { "type": "string" },
+                  "details": { "type": ["object", "null"] }
+                }
+              },
+              {
+                "type": "string",
+                "description": "Legacy shorthand error string from upstream auth middleware."
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/features/metering-events.md
+++ b/docs/features/metering-events.md
@@ -19,74 +19,56 @@ HMAC-signed webhook), and the **payload shape**.
 When `HOST_METERING_WEBHOOK_URL` is unset, emit calls are queued and
 discarded; there is no outbound traffic.
 
-## Event catalog (initial set)
+## Event catalog
 
-All events share the shape:
+<!-- EVENT_CATALOG:BEGIN -->
 
-```ts
-type MeteringEvent = {
-  tenantId: string;              // host-side routing key
-  type: MeteringEventType;       // see table below
-  count?: number;                // defaults to 1
-  bytes?: number;                // when meaningful
-  resourceId?: string;           // e.g. photoId / keyId
-  occurredAt?: string;           // ISO-8601; server-stamped if missing
-  meta?: Record<string, unknown>;// small, free-form
-}
-```
+> ⚠️ This table is auto-generated from `functions/src/services/metering/eventCatalog.ts`.
+> Do not hand-edit; run `node scripts/generate-event-catalog-docs.mjs` after changing the registry.
+>
+> **Catalog version:** `2026-06-20` — the same string is stamped on every outbound webhook envelope and returned by `GET /v1/host/webhook-events`.
 
-| `type` | Emitted from | Notable fields |
-| --- | --- | --- |
-| `upload.accepted` | `handlers/images/upload.ts` after the original image is stored | `count=1`, `bytes=metadata.sizeBytes`, `resourceId=photoId`, `meta.userId`, `meta.sourceType` |
-| `image.processed` | `handlers/thumbnails/generate.ts` after derivatives are written | one event per derivative variant (7 today: small/medium/large × webp+jpeg + preview_jpeg), `resourceId=photoId`, `meta.stage='thumbnail'` |
-| `signed_url.issued` | `routes/signing.ts` user and share grants | `resourceId=signingKey.keyId`, `meta.grantType='user'\|'share'` |
-| `edit.applied` | `handlers/edits/applyEdits.ts` after a non-destructive edit version is committed | `resourceId=photoId`, `meta.version`, `meta.operationCount` |
-| `bulk.batch` | `handlers/photos/batch.ts` after a `POST /api/v1/photos:batch` call completes | exactly one event per call regardless of N; `meta.action`, `meta.requested`, `meta.succeeded`, `meta.failed`. Per-photo events (e.g. delete audits) are still emitted in addition and are NOT collapsed. |
-| `user.active` | `routes/tenantUsersV1.ts` activity tracker — **at most once per `(tenantId, userId)` per UTC day** | `resourceId=userId`. This is the per-seat billing signal hosts asked for in #143. |
-| `user.provisioned` | `routes/tenantUsersV1.ts` on `POST /v1/tenants/:id/users` (newly created membership only; no-op on idempotent re-POST) | `resourceId=userId`, `meta.role`, `meta.email` |
-| `user.revoked` | `routes/tenantUsersV1.ts` on `DELETE /v1/tenants/:id/users/:userId` | `resourceId=userId`, `meta.role` |
-| `quota.exceeded` | `handlers/images/upload.ts` when the in-process quota check rejects with HTTP 413 | `count=1`, `bytes=attemptedBytes`, `resourceId=userId`, `meta.libraryId`, `meta.usageBytes`, `meta.quotaBytes`, `meta.attemptedBytes` |
-| `quota.warning` | `services/metering/storageSnapshot.ts` once per threshold per tenant per UTC day when usage crosses the configured fractions of quota | `bytes=usageBytes`, `meta.threshold` (e.g. `0.8`, `0.95`), `meta.quotaBytes`, `meta.usageBytes`, `meta.date` |
-| `share.viewed` | `services/imageAuth/ImageAuthorizer.ts` after a share token passes auth, expiry, max-uses, and resource-scope checks (i.e. an access is actually granted; failed accesses are not counted) | `count=1`, `resourceId=shareLink.id`, `meta.photoId`, `meta.libraryId`, `meta.grantType='album'\|'photo'\|'library'` |
-| `plugin.ran` | `handlers/edits/applyEdits.ts` once per edit operation in the recipe, on both success and failure | `count=1`, `resourceId=photoId`, `meta.pluginId`, `meta.durationMs`, `meta.success` |
-| `user.active` | `middleware/userActive.ts`, after auth + tenant resolution, on the **first** end-user request of the UTC day for `(tenantId, userId)` | `count=1`, `resourceId=userId`, `meta.firstSeenAt` (ISO-8601), `meta.route=req.path`. Host-API-key (service-to-service) calls do **not** emit this event. Dedupe scope is `(tenantId, userId, utcDay)`, so the same Firebase user active in two tenants emits two seat events. Increments the daily-rollup `activeUsers` counter. |
-| `photo.trashed` | `domain/photos/PhotosService.softDelete` (`DELETE /v1/photos/:id`) | `count=1`, `bytes=original.sizeBytes`, `resourceId=photoId`, `meta.libraryId`, `meta.actor`. Hosts that bill on "active storage" can decrement immediately; hosts that bill on "stored bytes" can ignore. |
-| `photo.purged` | `jobs/purgeTrash.ts` after bytes are freed | `count=1`, **`bytes=-original.sizeBytes`** (negative), `resourceId=photoId`, `meta.libraryId`, `meta.trashedAt`. The daily `storageBytesDelta` rollup decrements on this event, not on `photo.trashed`. Emitted **exactly once** per photo. |
-| `embed.session_started` | `routes/embedV1.ts` CSP middleware, when an allowed parent origin frames an embed-eligible response | `count=1`, `meta.origin`, `meta.userAgent`. Debounced to **max 1 per minute per (tenantId, origin)** so high-traffic embeds don't flood the bus. See `docs/features/embed-handshake.md`. |
-| `embed.session_ended` | `routes/embedV1.ts` `POST /v1/tenants/:tenantId/embed/session-end` beacon, fired by the `@aurapix/embed` SDK on `handle.destroy()` and on the page's `pagehide` event (iframe unload heartbeat). See issue #177. | `count=1`, `meta.sessionId`, `meta.sdkVersion`, `meta.durationMs`. The endpoint is unauthenticated (so `navigator.sendBeacon` works) and treats the body as untrusted — `durationMs` is clamped to `[0, 24h]` and `sessionId`/`sdkVersion` length-capped before emit. |
-| `embed.origin_blocked` | `routes/embedV1.ts` CSP `report-uri` endpoint, on a browser-posted `frame-ancestors` violation | `count=1`, `meta.blockedUri`, `meta.documentUri`, `meta.violatedDirective`. Helps hosts find misconfigured deployments. |
-| `idempotency.replayed` | `middleware/idempotency.ts` on a cached replay (issue #162) | **NOT billable.** Debug-tier; `count=1`, `meta.route`, `meta.key`. Hosts should exclude this type from billing rollups; it exists so operators can observe client retry behavior. |
-| `photo.tagged` | `domain/photos/PhotosService.updateTags` (`POST /v1/photos/:id/tags`) | `count=1`, `resourceId=photoId`, `meta.libraryId`, `meta.actor`, `meta.added`, `meta.removed`. Emitted **once per mutation**, not once per tag, so a photographer tagging 30 photos with 5 keywords each produces 30 events rather than 150. Drives the `tagsApplied` daily counter (sum of `added + removed`). |
-| `photo.exported` | `routes/photoExportV1.ts` after a successful `POST /v1/photos/:id/export` (issue #174) | `count=1`, `bytes=outputBytes`, `resourceId=photoId`, `meta.libraryId`, `meta.preset`, `meta.outputWidth`, `meta.outputHeight`, `meta.cacheHit`, `meta.actor`. Emitted on both cache hits and misses (hosts may choose to discount `cacheHit:true` events at billing time). Drives the daily `exportBytes` counter (rendered bandwidth, billable). |
-| `smart_album.created` | `domain/smartAlbums/SmartAlbumsService.create` (`POST /smart-albums`) | `count=1`, `resourceId=smartAlbumId`, `meta.libraryId`. |
-| `smart_album.deleted` | `domain/smartAlbums/SmartAlbumsService.remove` (`DELETE /smart-albums/:id`) | `count=1`, `resourceId=smartAlbumId`, `meta.libraryId`. |
-| `smart_album.materialized` | `domain/smartAlbums/SmartAlbumsService.materialize` (`GET /smart-albums/:id/photos`) | `count=1`, `resourceId=smartAlbumId`, `meta.libraryId`, `meta.resultCount`, `meta.totalCount`. Hosts can use `resultCount` to detect heavy query patterns. |
+| `type` | Version | Billable | Description |
+| --- | --- | --- | --- |
+| `upload.accepted` | 1 | ✅ | Original image stored after a successful upload. One event per photo. |
+| `image.processed` | 1 | ✅ | A derivative variant (thumbnail / preview) was written. One event per variant. |
+| `signed_url.issued` | 1 | ✅ | A signed URL was minted for a user or share grant. |
+| `edit.applied` | 1 | ✅ | A non-destructive edit version was committed for a photo. |
+| `bulk.batch` | 1 | ✅ | A `POST /v1/photos:batch` call completed. One event per call regardless of N. |
+| `user.active` | 1 | ✅ | First end-user request of the UTC day for `(tenantId, userId)`. The per-seat billing signal. |
+| `user.provisioned` | 1 | — | A new tenant membership was created. |
+| `user.revoked` | 1 | — | A tenant membership was removed. |
+| `quota.exceeded` | 1 | — | In-process storage quota check rejected an upload with HTTP 413. |
+| `quota.warning` | 1 | — | Tenant storage usage crossed a configured threshold (e.g. 80%, 95%). Once per threshold per UTC day. |
+| `share.viewed` | 1 | ✅ | A share token passed auth and a resource was actually delivered. |
+| `plugin.ran` | 1 | ✅ | A plugin/edit operation executed (success or failure). One event per operation. |
+| `plugin.enabled` | 1 | — | A tenant toggled a plugin to enabled. |
+| `plugin.disabled` | 1 | — | A tenant toggled a plugin to disabled. |
+| `plugin.blocked` | 1 | — | An edit operation referenced a plugin not in the tenant allowlist. |
+| `photo.trashed` | 1 | — | A photo was soft-deleted (moved to trash). |
+| `photo.purged` | 1 | — | A trashed photo was permanently purged and its bytes freed. `bytes` is negative. |
+| `photo.tagged` | 1 | — | A photo had tags added or removed. One event per mutation, not per tag. |
+| `photo.exported` | 1 | ✅ | A photo was successfully exported (cache hit or miss). Drives the `exportBytes` rollup. |
+| `audit.queried` | 1 | — | The host audit-events API was queried. |
+| `tenant.export.requested` | 1 | — | A tenant data export was initiated via the offboarding API. |
+| `tenant.export.completed` | 1 | — | A tenant data export finished and the bundle is available. |
+| `tenant.deleted` | 1 | — | A tenant was hard-deleted. After this event, no further events for the tenant should fire. |
+| `embed.session_started` | 1 | — | An allowed parent origin framed an embed-eligible response. Debounced per `(tenantId, origin)`. |
+| `embed.session_ended` | 1 | — | The embed SDK reported a session end via the beacon endpoint or page unload. |
+| `embed.origin_blocked` | 1 | — | A browser-reported `frame-ancestors` CSP violation. Helps hosts find misconfigured deployments. |
+| `idempotency.replayed` | 1 | — | Idempotency-Key middleware served a cached response. Debug-tier; NOT billable. |
+| `webhook.secret_rotated` | 1 | — | A tenant rotated its webhook signing secret. |
+| `smart_album.created` | 1 | — | A smart album definition was created. |
+| `smart_album.deleted` | 1 | — | A smart album definition was deleted. |
+| `smart_album.materialized` | 1 | ✅ | A smart album was materialized via `GET /smart-albums/:id/photos`. |
+| `feature.gated` | 1 | — | A request was rejected because a per-tenant feature flag is disabled. Hosts surface upsell. |
+| `feature.flag_changed` | 1 | — | A host toggled a per-tenant feature flag. Audit / change-history signal. |
 
-No events currently reserved for follow-ups.
+For the full JSON Schema of each event's `meta` payload, call
+`GET /v1/host/webhook-events` with a host API key (see
+`contracts/openapi/host-webhook-events.openapi.json`).
 
-### Non-billable metadata writes (explicit exclusions)
-
-Pure photo-metadata writes — such as the Lightroom-style triage fields
-(`rating`, `flag`), favoriting, and tag edits — are deliberately **not**
-emitted as metering events. In particular:
-
-- `PATCH /v1/photos/:id { rating, flag }` (issue #141) MUST NOT emit
-  `edit.applied`. That event is reserved for non-destructive image edits
-  committed via `handlers/edits/applyEdits.ts` (a new version is written to
-  storage and indexed). Triage updates only touch a small Firestore field set
-  and do not produce a new derivative.
-- The same exclusion applies to `isFavorite` toggles and `tags` updates.
-
-If a host wants to bill culling activity, it can do so today by counting
-photo writes in its own audit log; AuraPix will not double-count it as an
-edit.
-### Quota warning thresholds
-
-Thresholds default to `[0.8, 0.95]` (80% and 95%). Override with the
-env var `TENANT_QUOTA_WARNING_THRESHOLDS` as a comma-separated list of
-fractions strictly between 0 and 1 (e.g. `0.5,0.75,0.9`). Each threshold
-fires at most once per tenant per UTC day; the daily rollup doc tracks
-the set of already-emitted thresholds in `quotaWarningsEmitted`.
+<!-- EVENT_CATALOG:END -->
 
 ## Tenant resolution
 

--- a/functions/src/routes/hostWebhookEventsV1.test.ts
+++ b/functions/src/routes/hostWebhookEventsV1.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Route-level tests for the public webhook event catalog endpoint
+ * (issue #176). Uses real Express + node fetch so the full middleware
+ * stack (host API key auth, ETag/304 handling) is exercised end-to-end.
+ *
+ * Covers:
+ *   - Anonymous request is rejected with 401
+ *   - User Bearer (no host key) is rejected with 401
+ *   - Valid host API key returns 200 + the catalog
+ *   - Response contains a `catalogVersion` and every currently-emitted
+ *     event type in the codebase
+ *   - ETag header is present and stable across requests
+ *   - `If-None-Match` with the current ETag returns 304
+ *   - `If-None-Match: *` returns 304
+ */
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { LocalJsonData } from '../adapters/data/LocalJsonData.js';
+import { createHostWebhookEventsRouter } from './hostWebhookEventsV1.js';
+import { createHostApiKeyAuth } from '../middleware/hostApiKeyAuth.js';
+import { createTenantApiKey } from '../services/host/tenantApiKeyService.js';
+import {
+  CATALOG_VERSION,
+  EVENT_CATALOG,
+} from '../services/metering/eventCatalog.js';
+
+interface Harness {
+  baseUrl: string;
+  shutdown(): Promise<void>;
+  dataAdapter: LocalJsonData;
+}
+
+async function setupHarness(): Promise<Harness> {
+  const dir = mkdtempSync(join(tmpdir(), 'host-webhook-events-route-test-'));
+  const dataAdapter = new LocalJsonData(dir);
+  const app = express();
+  app.use(express.json());
+  app.use(createHostApiKeyAuth(dataAdapter));
+  app.use('/v1/host', createHostWebhookEventsRouter());
+
+  const server: Server = await new Promise((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const port = (server.address() as AddressInfo).port;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    dataAdapter,
+    shutdown: () =>
+      new Promise((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      ),
+  };
+}
+
+describe('hostWebhookEventsV1 router (issue #176)', () => {
+  let harness: Harness;
+  let validKey: string;
+
+  beforeEach(async () => {
+    harness = await setupHarness();
+    const key = await createTenantApiKey(harness.dataAdapter, {
+      tenantId: 'tenant-A',
+      scopes: ['usage.read'],
+      label: 'catalog-test',
+    });
+    validKey = key.plaintextSecret;
+  });
+
+  afterEach(async () => {
+    await harness.shutdown();
+  });
+
+  it('returns 401 when no authentication is supplied', async () => {
+    const res = await fetch(`${harness.baseUrl}/v1/host/webhook-events`);
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('HOST_API_KEY_REQUIRED');
+  });
+
+  it('returns 401 for a non-key Bearer token (user tokens not accepted)', async () => {
+    const res = await fetch(`${harness.baseUrl}/v1/host/webhook-events`, {
+      headers: { authorization: 'Bearer not-a-host-key' },
+    });
+    // The host-key middleware ignores non-`ak_live_` Bearers (so user
+    // auth can layer underneath); the route guard then rejects because
+    // `req.tenant` is unset.
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for an invalid host API key', async () => {
+    const res = await fetch(`${harness.baseUrl}/v1/host/webhook-events`, {
+      headers: { authorization: 'Bearer ak_live_definitely-not-real' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 + catalog for a valid host API key', async () => {
+    const res = await fetch(`${harness.baseUrl}/v1/host/webhook-events`, {
+      headers: { authorization: `Bearer ${validKey}` },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/application\/json/);
+
+    const body = (await res.json()) as {
+      catalogVersion: string;
+      events: Array<{
+        name: string;
+        version: number;
+        billable: boolean;
+        description: string;
+        schema: Record<string, unknown>;
+      }>;
+    };
+    expect(body.catalogVersion).toBe(CATALOG_VERSION);
+    expect(body.events.length).toBe(EVENT_CATALOG.length);
+
+    // Spot-check a billable event and a non-billable one.
+    const photoExported = body.events.find((e) => e.name === 'photo.exported');
+    expect(photoExported).toBeDefined();
+    expect(photoExported!.billable).toBe(true);
+    expect(photoExported!.schema.type).toBe('object');
+
+    const featureGated = body.events.find((e) => e.name === 'feature.gated');
+    expect(featureGated).toBeDefined();
+    expect(featureGated!.billable).toBe(false);
+  });
+
+  it('serves a stable ETag and Cache-Control header', async () => {
+    const first = await fetch(`${harness.baseUrl}/v1/host/webhook-events`, {
+      headers: { authorization: `Bearer ${validKey}` },
+    });
+    const etag1 = first.headers.get('etag');
+    expect(etag1).toBeTruthy();
+    expect(etag1).toMatch(/^W\/"[\w.-]+-[0-9a-f]{16}"$/);
+    expect(first.headers.get('cache-control')).toContain('public');
+
+    const second = await fetch(`${harness.baseUrl}/v1/host/webhook-events`, {
+      headers: { authorization: `Bearer ${validKey}` },
+    });
+    expect(second.headers.get('etag')).toBe(etag1);
+  });
+
+  it('returns 304 when If-None-Match matches the current ETag', async () => {
+    const first = await fetch(`${harness.baseUrl}/v1/host/webhook-events`, {
+      headers: { authorization: `Bearer ${validKey}` },
+    });
+    const etag = first.headers.get('etag')!;
+    expect(etag).toBeTruthy();
+
+    const second = await fetch(`${harness.baseUrl}/v1/host/webhook-events`, {
+      headers: {
+        authorization: `Bearer ${validKey}`,
+        'if-none-match': etag,
+      },
+    });
+    expect(second.status).toBe(304);
+    const text = await second.text();
+    expect(text).toBe('');
+  });
+
+  it('returns 304 for If-None-Match: *', async () => {
+    const res = await fetch(`${harness.baseUrl}/v1/host/webhook-events`, {
+      headers: {
+        authorization: `Bearer ${validKey}`,
+        'if-none-match': '*',
+      },
+    });
+    expect(res.status).toBe(304);
+  });
+});
+
+/**
+ * Registry guard: every event name used by `emitMeteringEvent({ type: ... })`
+ * anywhere in `functions/src/` must exist in the registry. This is the
+ * compile-time-plus-test belt-and-suspenders guarantee from the issue's
+ * acceptance criteria.
+ *
+ * Scans the source tree for the pattern `type: '<domain>.<name>'` inside
+ * `emitMeteringEvent`-adjacent code. Keeps the regex narrow enough that
+ * unrelated string literals don't trigger false positives.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve as pathResolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'dist' || name.startsWith('.')) {
+      continue;
+    }
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) {
+      walk(p, out);
+    } else if (
+      (p.endsWith('.ts') || p.endsWith('.tsx')) &&
+      !p.endsWith('.test.ts') &&
+      !p.endsWith('.spec.ts')
+    ) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+describe('event catalog registry guard', () => {
+  it('every emitted event name in functions/src exists in EVENT_CATALOG', () => {
+    const functionsSrc = pathResolve(__dirname, '..');
+    const files = walk(functionsSrc);
+
+    const registeredNames = new Set<string>(EVENT_CATALOG.map((e) => e.name));
+    // Two well-known non-metering type strings appear in metering code and
+    // are NOT bus events (they're internal bus / rollup notifications).
+    const allowlist = new Set([
+      // `storageSnapshot.ts` emits an internal `metering.rollup.completed`
+      // signal on the usage bus, not the metering bus. Not part of the
+      // public webhook catalog.
+      'metering.rollup.completed',
+    ]);
+
+    const found = new Set<string>();
+    for (const file of files) {
+      const text = readFileSync(file, 'utf8');
+      // Skip the registry itself \u2014 it defines the canonical names.
+      if (file.endsWith('eventCatalog.ts')) continue;
+      // Skip the bus / sink themselves \u2014 they define the type only.
+      if (file.endsWith('MeteringBus.ts')) continue;
+      if (file.endsWith('HostWebhookSink.ts')) continue;
+
+      // Only count `type: '...'` literals that look like dotted event
+      // names (`<word>.<word>`). This is intentionally narrow so unrelated
+      // type discriminators in tests / handlers don't false-positive.
+      const re = /type:\s*'([a-z_]+\.[a-z_]+)'/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(text)) !== null) {
+        const name = m[1]!;
+        if (allowlist.has(name)) continue;
+        found.add(name);
+      }
+    }
+
+    const missing = [...found].filter((n) => !registeredNames.has(n)).sort();
+    expect(missing, `Unregistered event names: ${missing.join(', ')}`).toEqual(
+      []
+    );
+  });
+});

--- a/functions/src/routes/hostWebhookEventsV1.ts
+++ b/functions/src/routes/hostWebhookEventsV1.ts
@@ -1,0 +1,137 @@
+/**
+ * Public host webhook event catalog endpoint (issue #176).
+ *
+ *   GET /v1/host/webhook-events
+ *
+ * Returns the machine-readable catalog of every metering / webhook event
+ * AuraPix can emit, plus the JSON Schema for each event's `meta` payload
+ * and a `catalogVersion` cache key. Hosts use this to:
+ *
+ *   1. Build a billing pipeline without scraping the docs.
+ *   2. Detect new event types AuraPix adds over time (compare
+ *      `catalogVersion` against the one in their cached snapshot OR
+ *      against the `catalogVersion` field in every outbound webhook
+ *      envelope).
+ *   3. Validate incoming webhook payloads against the published schema.
+ *
+ * Auth: host API key (Authorization: Bearer ak_live_...). The catalog is
+ * GLOBAL (not per-tenant), so we don't require any specific scope \u2014 just
+ * a valid host key to keep the roadmap out of fully-anonymous hands. The
+ * response is identical for every host and is safe to cache at the edge.
+ *
+ * ETag: deterministic; derived from the `catalogVersion` and a SHA-256 of
+ * the canonical JSON body. Clients SHOULD send `If-None-Match` to get a
+ * 304 when the catalog has not changed.
+ */
+import { createHash, randomUUID } from 'node:crypto';
+import { Router } from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import {
+  CATALOG_VERSION,
+  getEventCatalogResponse,
+} from '../services/metering/eventCatalog.js';
+
+interface ApiErrorPayload {
+  error: {
+    code: string;
+    message: string;
+    requestId: string;
+    details: Record<string, unknown> | null;
+  };
+}
+
+function sendError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> | null = null
+): void {
+  const body: ApiErrorPayload = {
+    error: { code, message, requestId: randomUUID(), details },
+  };
+  res.status(status).json(body);
+}
+
+/**
+ * Guard: a valid host API key MUST be present. The catalog is global,
+ * so we do not require any specific scope or tenant match \u2014 any
+ * authenticated key is sufficient. A user Bearer token is NOT accepted;
+ * this endpoint is service-to-service.
+ */
+function requireAnyHostKey(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (!req.tenant) {
+    sendError(
+      res,
+      401,
+      'HOST_API_KEY_REQUIRED',
+      'Host API key required'
+    );
+    return;
+  }
+  next();
+}
+
+/**
+ * Compute a stable ETag for the catalog body. The same body always
+ * produces the same ETag, so clients caching across deploys benefit
+ * from 304 responses whenever nothing changed.
+ *
+ * Format: `W/"<catalogVersion>-<sha256-first-16-hex>"` (weak validator).
+ */
+export function computeCatalogEtag(body: string): string {
+  const hash = createHash('sha256').update(body).digest('hex').slice(0, 16);
+  return `W/"${CATALOG_VERSION}-${hash}"`;
+}
+
+/**
+ * Parse the `If-None-Match` header (which may contain a comma-separated
+ * list of tags) and return true iff any tag matches the current one.
+ */
+function ifNoneMatchHit(header: string | undefined, current: string): boolean {
+  if (!header) return false;
+  const tags = header.split(',').map((s) => s.trim());
+  if (tags.includes('*')) return true;
+  return tags.some((tag) => tag === current);
+}
+
+export function createHostWebhookEventsRouter(): Router {
+  const router = Router();
+
+  router.get(
+    '/webhook-events',
+    requireAnyHostKey,
+    (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const payload = getEventCatalogResponse();
+        const body = JSON.stringify(payload);
+        const etag = computeCatalogEtag(body);
+
+        res.setHeader('ETag', etag);
+        // Catalog is identical for every host \u2014 safe to cache aggressively
+        // at the edge. `public` allows shared caches; the long max-age is
+        // safe because clients SHOULD revalidate via If-None-Match.
+        res.setHeader(
+          'Cache-Control',
+          'public, max-age=300, stale-while-revalidate=600'
+        );
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+
+        if (ifNoneMatchHit(req.headers['if-none-match'], etag)) {
+          res.status(304).end();
+          return;
+        }
+
+        res.status(200).send(body);
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  return router;
+}

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -116,6 +116,7 @@ import { TenantOffboardingService } from './services/tenant/TenantOffboardingSer
 import { createTenantWebhookSecretsRouter } from './routes/tenantWebhookSecretsV1.js';
 import { createTenantPluginsRouter } from './routes/tenantPluginsV1.js';
 import { createTenantFeaturesRouter } from './routes/tenantFeaturesV1.js';
+import { createHostWebhookEventsRouter } from './routes/hostWebhookEventsV1.js';
 import { createRequireFeature } from './middleware/requireFeature.js';
 import { createPhotosV1Router, createLibraryTagsRouter } from './routes/photosV1.js';
 import { createAuditEventsV1Router } from './routes/auditEventsV1.js';
@@ -548,6 +549,22 @@ app.use(
   '/api/v1/tenants',
   hostApiKeyAuth,
   tenantFeaturesRouter
+);
+
+// Public webhook event catalog (issue #176). Global — not per-tenant —
+// so it lives under `/v1/host/...` rather than `/v1/tenants/...`. Host
+// API key required (any scope, scoped to any tenant); response is
+// identical for every caller and safely cacheable at the edge.
+const hostWebhookEventsRouter = createHostWebhookEventsRouter();
+app.use(
+  '/v1/host',
+  hostApiKeyAuth,
+  hostWebhookEventsRouter
+);
+app.use(
+  '/api/v1/host',
+  hostApiKeyAuth,
+  hostWebhookEventsRouter
 );
 
 // Per-tenant export presets (issue #174).

--- a/functions/src/services/metering/HostWebhookSink.ts
+++ b/functions/src/services/metering/HostWebhookSink.ts
@@ -1,5 +1,6 @@
 import { createHash, createHmac, randomUUID } from 'crypto';
 import { logger } from '../../utils/logger.js';
+import { CATALOG_VERSION } from './eventCatalog.js';
 import type {
   MeteringSink,
   NormalizedMeteringEvent,
@@ -261,6 +262,11 @@ export class HostWebhookSink implements MeteringSink {
       const sentAt = new Date().toISOString();
       const body = JSON.stringify({
         version: SIGNATURE_VERSION,
+        // Catalog version of the event registry this delivery was built
+        // from (issue #176). Hosts can compare against their cached
+        // catalog and refetch `GET /v1/host/webhook-events` when it
+        // drifts.
+        catalogVersion: CATALOG_VERSION,
         sentAt,
         batchId,
         events,

--- a/functions/src/services/metering/MeteringBus.ts
+++ b/functions/src/services/metering/MeteringBus.ts
@@ -1,66 +1,18 @@
 import { logger } from '../../utils/logger.js';
+import type { RegisteredEventName } from './eventCatalog.js';
 
 /**
  * Catalogue of billable event types emitted by AuraPix.
  *
- * Hosts that resell AuraPix can use these to drive metered billing.
- * Keep this list narrow; new entries should be added intentionally
- * and documented in `docs/features/metering-events.md`.
+ * Derived from the single source of truth in `eventCatalog.ts` (issue
+ * #176). Adding a new event name here directly is impossible — you must
+ * register the event in `EVENT_CATALOG` first, which gives compile-time
+ * guarantees that every emitted name has an associated payload schema
+ * and appears in the `GET /v1/host/webhook-events` response.
+ *
+ * Hosts that resell AuraPix use these to drive metered billing.
  */
-export type MeteringEventType =
-  | 'upload.accepted'
-  | 'image.processed'
-  | 'signed_url.issued'
-  | 'edit.applied'
-  | 'bulk.batch'
-  | 'user.active'
-  | 'user.provisioned'
-  | 'user.revoked'
-  | 'quota.exceeded'
-  | 'quota.warning'
-  | 'share.viewed'
-  | 'plugin.ran'
-  // Tenant offboarding lifecycle (issue #155). After `tenant.deleted` is
-  // emitted for a given tenantId, no further events for that tenant
-  // should ever fire — sinks may treat the tenant as terminal.
-  | 'tenant.export.requested'
-  | 'tenant.export.completed'
-  | 'tenant.deleted'
-  | 'user.active'
-  | 'plugin.enabled'
-  | 'plugin.disabled'
-  | 'plugin.blocked'
-  | 'photo.trashed'
-  | 'photo.purged'
-  | 'audit.queried'
-  // Embed handshake (issue #163). Emitted from the CSP middleware and
-  // the `frame-ancestors` violation report endpoint respectively.
-  | 'embed.session_started'
-  // Embed lifecycle (issue #177). Emitted from the embed-SDK beacon
-  // endpoint (`POST /v1/tenants/:tenantId/embed/session-end`) when the
-  // SDK calls `handle.destroy()` or the iframe unloads.
-  | 'embed.session_ended'
-  | 'embed.origin_blocked'
-  // Reserved, low-volume debug-tier event. Emitted by the Idempotency-Key
-  // middleware on a cached replay so hosts can observe client retry
-  // behavior. NOT billable; consumers should exclude it from rollups.
-  // See `docs/features/idempotency-keys.md` (issue #162).
-  | 'idempotency.replayed'
-  | 'webhook.secret_rotated'
-  | 'photo.tagged'
-  | 'photo.exported'
-  | 'smart_album.created'
-  | 'smart_album.deleted'
-  | 'smart_album.materialized'
-  // Per-tenant feature flag gating (issue #175). Emitted by the
-  // `requireFeature(name)` middleware when a request is rejected because
-  // the feature is disabled for the tenant, and by the PATCH endpoint
-  // when the host toggles a flag. `feature.gated` is intentionally
-  // low-volume (only on a 403) and is NOT billable — hosts use it to
-  // surface upsell opportunities. `feature.flag_changed` is for audit /
-  // host-side change history.
-  | 'feature.gated'
-  | 'feature.flag_changed';
+export type MeteringEventType = RegisteredEventName;
 
 export interface MeteringEvent {
   /**

--- a/functions/src/services/metering/eventCatalog.ts
+++ b/functions/src/services/metering/eventCatalog.ts
@@ -1,0 +1,516 @@
+/**
+ * Webhook / metering event catalog (issue #176).
+ *
+ * Single source of truth for every event AuraPix can emit on the metering
+ * bus and over the host webhook. The runtime registry is consumed by:
+ *
+ *   - `MeteringBus` — its `MeteringEventType` is derived from this file,
+ *     so adding a new event _here_ is the only way to make `emit()`
+ *     compile against a new name (compile-time guard against ad-hoc
+ *     event names).
+ *   - `HostWebhookSink` — every outbound envelope includes the
+ *     `catalogVersion` constant exported below, so hosts can detect when
+ *     they're behind on a new event type.
+ *   - `GET /v1/host/webhook-events` — returns the full catalog
+ *     (host-API-key only) so integrators can build billing pipelines
+ *     without scraping the docs.
+ *   - `scripts/generate-event-catalog-docs.mjs` — regenerates the event
+ *     table in `docs/features/metering-events.md` from this registry,
+ *     so the docs cannot drift from reality.
+ *
+ * Each entry includes a JSON Schema (Draft 2020-12 compatible) describing
+ * the `meta` payload shape for that event. Hosts can use these schemas
+ * to validate incoming webhook payloads without hand-writing types.
+ *
+ * Conventions:
+ *   - `version` is per-event; bump it when the meta shape changes in a
+ *     non-additive way. The shared envelope version (currently `v1`) is
+ *     unrelated and lives in `HostWebhookSink`.
+ *   - `billable: true` is a hint, not a contract — hosts decide their own
+ *     billing rules. Today we mark events as billable iff they map to a
+ *     unit of resold work (uploads, processed images, signed URLs, etc.)
+ *     and exclude pure observability events (`feature.gated`,
+ *     `idempotency.replayed`, `*.flag_changed`, etc.).
+ *   - `description` is a short, one-line summary. The longer table in
+ *     `docs/features/metering-events.md` is generated from `description`
+ *     plus the per-event JSON Schema property descriptions.
+ */
+
+/**
+ * Bumped whenever the set of event types in the registry changes (new
+ * event, removed event, or non-additive schema change). Hosts that ship
+ * a snapshot of the catalog can compare this string against the
+ * `catalogVersion` field in every webhook envelope and `GET /v1/host/
+ * webhook-events` response to detect drift.
+ *
+ * Use a date string so the value is human-readable in logs.
+ */
+export const CATALOG_VERSION = '2026-06-20';
+
+/**
+ * JSON Schema describing the `meta` payload for a single event type.
+ *
+ * Intentionally typed as a permissive `Record<string, unknown>` so callers
+ * can hand it to any Draft 2020-12 validator without forcing a hard
+ * dependency on a specific schema library. Each entry below is a real
+ * JSON Schema object; the `as const` keeps the literal shape narrow in
+ * tooling but the public API only promises the wider record shape.
+ */
+export type EventMetaSchema = Record<string, unknown>;
+
+/**
+ * A single registered event type. Adding a new entry to this list is the
+ * only supported way to introduce a new metering event.
+ */
+export interface RegisteredEvent {
+  /** Stable event name (e.g. `photo.exported`). Snake-cased domain. */
+  readonly name: string;
+  /** Per-event schema version. Bump on non-additive meta changes. */
+  readonly version: number;
+  /**
+   * Whether this event maps to a unit of billable work. Hosts can use
+   * this as a default filter when rolling up usage; it is NOT a
+   * contractual guarantee.
+   */
+  readonly billable: boolean;
+  /** One-line summary used in the generated docs. */
+  readonly description: string;
+  /** JSON Schema (Draft 2020-12) for the event's `meta` object. */
+  readonly schema: EventMetaSchema;
+}
+
+/**
+ * Helper to build a schema object for the `meta` field. Always returns a
+ * JSON Schema `object` with `additionalProperties: true` so hosts treat
+ * extra fields as forward-compatible.
+ */
+function metaSchema(
+  properties: Record<string, EventMetaSchema>,
+  required: readonly string[] = []
+): EventMetaSchema {
+  return {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    additionalProperties: true,
+    properties,
+    ...(required.length > 0 ? { required: [...required] } : {}),
+  };
+}
+
+/**
+ * Convenience JSON Schema fragments.
+ */
+const S_STRING: EventMetaSchema = { type: 'string' };
+const S_NUMBER: EventMetaSchema = { type: 'number' };
+const S_INTEGER: EventMetaSchema = { type: 'integer' };
+const S_BOOLEAN: EventMetaSchema = { type: 'boolean' };
+const S_ISO_DATE: EventMetaSchema = { type: 'string', format: 'date-time' };
+
+/**
+ * The registry. Order is preserved in API responses and generated docs.
+ *
+ * Keep this ordered roughly by domain (uploads → derivatives → signed
+ * URLs → edits → batch → users → quotas → sharing → plugins → photos →
+ * tenant lifecycle → embed → idempotency → webhook → tags → exports →
+ * smart albums → feature flags) so the public catalog reads top-down.
+ */
+export const EVENT_CATALOG = [
+  {
+    name: 'upload.accepted',
+    version: 1,
+    billable: true,
+    description:
+      'Original image stored after a successful upload. One event per photo.',
+    schema: metaSchema({
+      userId: S_STRING,
+      sourceType: S_STRING,
+    }),
+  },
+  {
+    name: 'image.processed',
+    version: 1,
+    billable: true,
+    description:
+      'A derivative variant (thumbnail / preview) was written. One event per variant.',
+    schema: metaSchema({
+      stage: { type: 'string', enum: ['thumbnail', 'preview'] },
+      variant: S_STRING,
+    }),
+  },
+  {
+    name: 'signed_url.issued',
+    version: 1,
+    billable: true,
+    description: 'A signed URL was minted for a user or share grant.',
+    schema: metaSchema({
+      grantType: { type: 'string', enum: ['user', 'share'] },
+    }),
+  },
+  {
+    name: 'edit.applied',
+    version: 1,
+    billable: true,
+    description: 'A non-destructive edit version was committed for a photo.',
+    schema: metaSchema({
+      version: S_INTEGER,
+      operationCount: S_INTEGER,
+    }),
+  },
+  {
+    name: 'bulk.batch',
+    version: 1,
+    billable: true,
+    description:
+      'A `POST /v1/photos:batch` call completed. One event per call regardless of N.',
+    schema: metaSchema({
+      action: S_STRING,
+      requested: S_INTEGER,
+      succeeded: S_INTEGER,
+      failed: S_INTEGER,
+    }),
+  },
+  {
+    name: 'user.active',
+    version: 1,
+    billable: true,
+    description:
+      'First end-user request of the UTC day for `(tenantId, userId)`. The per-seat billing signal.',
+    schema: metaSchema({
+      firstSeenAt: S_ISO_DATE,
+      route: S_STRING,
+    }),
+  },
+  {
+    name: 'user.provisioned',
+    version: 1,
+    billable: false,
+    description: 'A new tenant membership was created.',
+    schema: metaSchema({
+      role: S_STRING,
+      email: S_STRING,
+    }),
+  },
+  {
+    name: 'user.revoked',
+    version: 1,
+    billable: false,
+    description: 'A tenant membership was removed.',
+    schema: metaSchema({
+      role: S_STRING,
+    }),
+  },
+  {
+    name: 'quota.exceeded',
+    version: 1,
+    billable: false,
+    description:
+      'In-process storage quota check rejected an upload with HTTP 413.',
+    schema: metaSchema({
+      libraryId: S_STRING,
+      usageBytes: S_NUMBER,
+      quotaBytes: S_NUMBER,
+      attemptedBytes: S_NUMBER,
+    }),
+  },
+  {
+    name: 'quota.warning',
+    version: 1,
+    billable: false,
+    description:
+      'Tenant storage usage crossed a configured threshold (e.g. 80%, 95%). Once per threshold per UTC day.',
+    schema: metaSchema({
+      threshold: S_NUMBER,
+      quotaBytes: S_NUMBER,
+      usageBytes: S_NUMBER,
+      date: S_STRING,
+    }),
+  },
+  {
+    name: 'share.viewed',
+    version: 1,
+    billable: true,
+    description:
+      'A share token passed auth and a resource was actually delivered.',
+    schema: metaSchema({
+      photoId: S_STRING,
+      libraryId: S_STRING,
+      grantType: { type: 'string', enum: ['album', 'photo', 'library'] },
+    }),
+  },
+  {
+    name: 'plugin.ran',
+    version: 1,
+    billable: true,
+    description:
+      'A plugin/edit operation executed (success or failure). One event per operation.',
+    schema: metaSchema({
+      pluginId: S_STRING,
+      durationMs: S_NUMBER,
+      success: S_BOOLEAN,
+    }),
+  },
+  {
+    name: 'plugin.enabled',
+    version: 1,
+    billable: false,
+    description: 'A tenant toggled a plugin to enabled.',
+    schema: metaSchema({
+      pluginId: S_STRING,
+    }),
+  },
+  {
+    name: 'plugin.disabled',
+    version: 1,
+    billable: false,
+    description: 'A tenant toggled a plugin to disabled.',
+    schema: metaSchema({
+      pluginId: S_STRING,
+    }),
+  },
+  {
+    name: 'plugin.blocked',
+    version: 1,
+    billable: false,
+    description:
+      'An edit operation referenced a plugin not in the tenant allowlist.',
+    schema: metaSchema({
+      pluginId: S_STRING,
+    }),
+  },
+  {
+    name: 'photo.trashed',
+    version: 1,
+    billable: false,
+    description: 'A photo was soft-deleted (moved to trash).',
+    schema: metaSchema({
+      libraryId: S_STRING,
+      actor: S_STRING,
+    }),
+  },
+  {
+    name: 'photo.purged',
+    version: 1,
+    billable: false,
+    description:
+      'A trashed photo was permanently purged and its bytes freed. `bytes` is negative.',
+    schema: metaSchema({
+      libraryId: S_STRING,
+      trashedAt: S_ISO_DATE,
+    }),
+  },
+  {
+    name: 'photo.tagged',
+    version: 1,
+    billable: false,
+    description:
+      'A photo had tags added or removed. One event per mutation, not per tag.',
+    schema: metaSchema({
+      libraryId: S_STRING,
+      actor: S_STRING,
+      added: { type: 'array', items: S_STRING },
+      removed: { type: 'array', items: S_STRING },
+    }),
+  },
+  {
+    name: 'photo.exported',
+    version: 1,
+    billable: true,
+    description:
+      'A photo was successfully exported (cache hit or miss). Drives the `exportBytes` rollup.',
+    schema: metaSchema({
+      libraryId: S_STRING,
+      preset: S_STRING,
+      outputWidth: S_INTEGER,
+      outputHeight: S_INTEGER,
+      cacheHit: S_BOOLEAN,
+      actor: S_STRING,
+    }),
+  },
+  {
+    name: 'audit.queried',
+    version: 1,
+    billable: false,
+    description: 'The host audit-events API was queried.',
+    schema: metaSchema({
+      route: S_STRING,
+      resultCount: S_INTEGER,
+    }),
+  },
+  {
+    name: 'tenant.export.requested',
+    version: 1,
+    billable: false,
+    description: 'A tenant data export was initiated via the offboarding API.',
+    schema: metaSchema({
+      exportId: S_STRING,
+    }),
+  },
+  {
+    name: 'tenant.export.completed',
+    version: 1,
+    billable: false,
+    description: 'A tenant data export finished and the bundle is available.',
+    schema: metaSchema({
+      exportId: S_STRING,
+      bytes: S_NUMBER,
+    }),
+  },
+  {
+    name: 'tenant.deleted',
+    version: 1,
+    billable: false,
+    description:
+      'A tenant was hard-deleted. After this event, no further events for the tenant should fire.',
+    schema: metaSchema({}),
+  },
+  {
+    name: 'embed.session_started',
+    version: 1,
+    billable: false,
+    description:
+      'An allowed parent origin framed an embed-eligible response. Debounced per `(tenantId, origin)`.',
+    schema: metaSchema({
+      origin: S_STRING,
+      userAgent: S_STRING,
+    }),
+  },
+  {
+    name: 'embed.session_ended',
+    version: 1,
+    billable: false,
+    description:
+      'The embed SDK reported a session end via the beacon endpoint or page unload.',
+    schema: metaSchema({
+      sessionId: S_STRING,
+      sdkVersion: S_STRING,
+      durationMs: S_NUMBER,
+    }),
+  },
+  {
+    name: 'embed.origin_blocked',
+    version: 1,
+    billable: false,
+    description:
+      'A browser-reported `frame-ancestors` CSP violation. Helps hosts find misconfigured deployments.',
+    schema: metaSchema({
+      blockedUri: S_STRING,
+      documentUri: S_STRING,
+      violatedDirective: S_STRING,
+    }),
+  },
+  {
+    name: 'idempotency.replayed',
+    version: 1,
+    billable: false,
+    description:
+      'Idempotency-Key middleware served a cached response. Debug-tier; NOT billable.',
+    schema: metaSchema({
+      route: S_STRING,
+      key: S_STRING,
+    }),
+  },
+  {
+    name: 'webhook.secret_rotated',
+    version: 1,
+    billable: false,
+    description: 'A tenant rotated its webhook signing secret.',
+    schema: metaSchema({
+      fingerprint: S_STRING,
+      previousFingerprint: S_STRING,
+      graceSeconds: S_INTEGER,
+    }),
+  },
+  {
+    name: 'smart_album.created',
+    version: 1,
+    billable: false,
+    description: 'A smart album definition was created.',
+    schema: metaSchema({
+      libraryId: S_STRING,
+    }),
+  },
+  {
+    name: 'smart_album.deleted',
+    version: 1,
+    billable: false,
+    description: 'A smart album definition was deleted.',
+    schema: metaSchema({
+      libraryId: S_STRING,
+    }),
+  },
+  {
+    name: 'smart_album.materialized',
+    version: 1,
+    billable: true,
+    description:
+      'A smart album was materialized via `GET /smart-albums/:id/photos`.',
+    schema: metaSchema({
+      libraryId: S_STRING,
+      resultCount: S_INTEGER,
+      totalCount: S_INTEGER,
+    }),
+  },
+  {
+    name: 'feature.gated',
+    version: 1,
+    billable: false,
+    description:
+      'A request was rejected because a per-tenant feature flag is disabled. Hosts surface upsell.',
+    schema: metaSchema({
+      feature: S_STRING,
+      route: S_STRING,
+    }),
+  },
+  {
+    name: 'feature.flag_changed',
+    version: 1,
+    billable: false,
+    description:
+      'A host toggled a per-tenant feature flag. Audit / change-history signal.',
+    schema: metaSchema({
+      feature: S_STRING,
+      oldValue: S_BOOLEAN,
+      newValue: S_BOOLEAN,
+      actor: S_STRING,
+    }),
+  },
+] as const satisfies readonly RegisteredEvent[];
+
+/**
+ * Union of all registered event names. Derived from `EVENT_CATALOG` so
+ * adding a new entry above is the ONLY way to extend the type.
+ */
+export type RegisteredEventName = (typeof EVENT_CATALOG)[number]['name'];
+
+/**
+ * Map from event name to its full registry entry. Useful for O(1) lookups
+ * (e.g. envelope enrichment, validation).
+ */
+export const EVENT_CATALOG_BY_NAME: Readonly<
+  Record<RegisteredEventName, RegisteredEvent>
+> = Object.freeze(
+  Object.fromEntries(EVENT_CATALOG.map((e) => [e.name, e])) as Record<
+    RegisteredEventName,
+    RegisteredEvent
+  >
+);
+
+/**
+ * Public-facing catalog response shape (returned by
+ * `GET /v1/host/webhook-events`).
+ */
+export interface EventCatalogResponse {
+  catalogVersion: string;
+  events: ReadonlyArray<RegisteredEvent>;
+}
+
+/**
+ * Build the response body for the public catalog endpoint. Returns a
+ * deep-frozen value so callers cannot accidentally mutate the registry.
+ */
+export function getEventCatalogResponse(): EventCatalogResponse {
+  return {
+    catalogVersion: CATALOG_VERSION,
+    events: EVENT_CATALOG,
+  };
+}

--- a/scripts/generate-event-catalog-docs.mjs
+++ b/scripts/generate-event-catalog-docs.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Regenerate the event catalog section of
+ * `docs/features/metering-events.md` from the canonical
+ * `functions/src/services/metering/eventCatalog.ts` registry (issue #176).
+ *
+ * Why: the issue notes the hand-written table easily drifts from reality.
+ * This script reads the registry at build time and rewrites everything
+ * between the `<!-- EVENT_CATALOG:BEGIN -->` and
+ * `<!-- EVENT_CATALOG:END -->` markers in the docs file. Run it as part
+ * of pre-commit / CI when changing `eventCatalog.ts`.
+ *
+ * Usage:
+ *   node scripts/generate-event-catalog-docs.mjs           # write
+ *   node scripts/generate-event-catalog-docs.mjs --check   # exit 1 on drift
+ *
+ * NOTE: this script intentionally reads the `.ts` source via a tiny regex
+ * parse rather than compiling, so it can run in any Node environment
+ * without a TS toolchain. The registry has a deliberately simple shape
+ * to support this.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = resolve(dirname(__filename), '..');
+const REGISTRY = resolve(ROOT, 'functions/src/services/metering/eventCatalog.ts');
+const DOCS = resolve(ROOT, 'docs/features/metering-events.md');
+const BEGIN = '<!-- EVENT_CATALOG:BEGIN -->';
+const END = '<!-- EVENT_CATALOG:END -->';
+
+/**
+ * Pull `CATALOG_VERSION = '...'` out of the registry source.
+ */
+function parseCatalogVersion(src) {
+  const m = /export const CATALOG_VERSION\s*=\s*'([^']+)'/.exec(src);
+  if (!m) throw new Error('Cannot find CATALOG_VERSION in eventCatalog.ts');
+  return m[1];
+}
+
+/**
+ * Pull each entry's `{ name, version, billable, description }` out of
+ * the registry source. Schemas are intentionally not parsed here \u2014 the
+ * docs page is a high-level summary; the `GET /v1/host/webhook-events`
+ * endpoint serves the full JSON Schema.
+ */
+function parseEntries(src) {
+  // Grab the array body between `export const EVENT_CATALOG = [` and
+  // `] as const satisfies`.
+  const arr = /export const EVENT_CATALOG\s*=\s*\[([\s\S]*?)\]\s*as const satisfies/.exec(src);
+  if (!arr) throw new Error('Cannot find EVENT_CATALOG array');
+  const body = arr[1];
+  const entries = [];
+  // Each entry is `{ name: '...', version: N, billable: bool, description: '...', schema: ... }`.
+  const re = /\{\s*name:\s*'([^']+)',\s*version:\s*(\d+),\s*billable:\s*(true|false),\s*description:\s*\n?\s*'([^']+)'/g;
+  let m;
+  while ((m = re.exec(body)) !== null) {
+    entries.push({
+      name: m[1],
+      version: Number(m[2]),
+      billable: m[3] === 'true',
+      description: m[4],
+    });
+  }
+  if (entries.length === 0) {
+    throw new Error('No EVENT_CATALOG entries parsed');
+  }
+  return entries;
+}
+
+function renderMarkdown(version, entries) {
+  const lines = [];
+  lines.push(BEGIN);
+  lines.push('');
+  lines.push('> ⚠️ This table is auto-generated from `functions/src/services/metering/eventCatalog.ts`.');
+  lines.push('> Do not hand-edit; run `node scripts/generate-event-catalog-docs.mjs` after changing the registry.');
+  lines.push('>');
+  lines.push(`> **Catalog version:** \`${version}\` — the same string is stamped on every outbound webhook envelope and returned by \`GET /v1/host/webhook-events\`.`);
+  lines.push('');
+  lines.push('| `type` | Version | Billable | Description |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const e of entries) {
+    const billable = e.billable ? '✅' : '—';
+    // Escape pipes inside descriptions (defensive; none today).
+    const desc = e.description.replace(/\|/g, '\\|');
+    lines.push(`| \`${e.name}\` | ${e.version} | ${billable} | ${desc} |`);
+  }
+  lines.push('');
+  lines.push('For the full JSON Schema of each event\'s `meta` payload, call');
+  lines.push('`GET /v1/host/webhook-events` with a host API key (see');
+  lines.push('`contracts/openapi/host-webhook-events.openapi.json`).');
+  lines.push('');
+  lines.push(END);
+  return lines.join('\n');
+}
+
+function ensureMarkers(docs) {
+  const hasBegin = docs.includes(BEGIN);
+  const hasEnd = docs.includes(END);
+  if (hasBegin && hasEnd) return docs;
+  if (hasBegin || hasEnd) {
+    throw new Error('Docs file has only one of the EVENT_CATALOG markers; please fix manually.');
+  }
+  // First-run insertion: replace the hand-written `## Event catalog` block
+  // (heading + table) with our marker block. Locate the heading and the
+  // next heading at the same level.
+  const headingRe = /^## Event catalog[^\n]*\n/m;
+  const nextHeadingRe = /\n## /;
+  const h = headingRe.exec(docs);
+  if (!h) {
+    throw new Error(
+      'Could not find `## Event catalog` heading. Add EVENT_CATALOG markers manually.'
+    );
+  }
+  const after = docs.slice(h.index + h[0].length);
+  const nextRel = after.search(nextHeadingRe);
+  if (nextRel < 0) {
+    throw new Error('Could not find next `## ` heading after Event catalog section.');
+  }
+  const cutEnd = h.index + h[0].length + nextRel;
+  // Replace heading-through-next-heading with heading + markers placeholder.
+  return (
+    docs.slice(0, h.index) +
+    `## Event catalog\n\n${BEGIN}\n${END}\n` +
+    docs.slice(cutEnd)
+  );
+}
+
+function replaceBlock(docs, generated) {
+  const beginIdx = docs.indexOf(BEGIN);
+  const endIdx = docs.indexOf(END);
+  if (beginIdx < 0 || endIdx < 0 || endIdx < beginIdx) {
+    throw new Error('EVENT_CATALOG markers are missing or malformed.');
+  }
+  const before = docs.slice(0, beginIdx);
+  const after = docs.slice(endIdx + END.length);
+  return before + generated + after;
+}
+
+function main() {
+  const check = process.argv.includes('--check');
+  const src = readFileSync(REGISTRY, 'utf8');
+  const version = parseCatalogVersion(src);
+  const entries = parseEntries(src);
+  const generated = renderMarkdown(version, entries);
+
+  let docs = readFileSync(DOCS, 'utf8');
+  docs = ensureMarkers(docs);
+  const updated = replaceBlock(docs, generated);
+
+  if (check) {
+    const current = readFileSync(DOCS, 'utf8');
+    if (current !== updated) {
+      console.error(
+        'metering-events.md is out of date. Run `node scripts/generate-event-catalog-docs.mjs` and commit.'
+      );
+      process.exit(1);
+    }
+    console.log('metering-events.md is up to date.');
+    return;
+  }
+
+  writeFileSync(DOCS, updated);
+  console.log(`Wrote ${entries.length} events to ${DOCS} (catalog version ${version})`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds a single source-of-truth event registry plus a host-API-key-gated public catalog endpoint, so host integrators can build billing pipelines, detect new event types, and validate incoming webhook payloads without scraping the docs.

Fixes rwrife/AuraPix#176.

## Changes

- **`functions/src/services/metering/eventCatalog.ts` (new)** — 33 registered events, each with `name`, `version`, `billable`, `description`, and a Draft 2020-12 JSON Schema for the `meta` payload. Exports `CATALOG_VERSION`, `EVENT_CATALOG`, `EVENT_CATALOG_BY_NAME`, and `RegisteredEventName`.
- **`MeteringBus.ts`** — `MeteringEventType` is now derived from `RegisteredEventName`, giving compile-time guard against ad-hoc event names. (Also collapses the previously duplicated `user.active` union member.)
- **`HostWebhookSink.ts`** — every outbound webhook envelope now includes a `catalogVersion` field so hosts can detect when they're behind on a new event type without polling.
- **`routes/hostWebhookEventsV1.ts` (new)** — `GET /v1/host/webhook-events` returns `{ catalogVersion, events: [...] }`. Includes deterministic `ETag` (weak validator: `W/"<catalogVersion>-<sha256-16hex>"`), aggressive `Cache-Control`, and `If-None-Match` → `304` handling.
- **`server.ts`** — mounts the new router under both `/v1/host` and `/api/v1/host` behind the existing host-API-key auth middleware. The route guard requires a valid host API key but NOT a specific scope (response is global and identical for every caller).
- **`contracts/openapi/host-webhook-events.openapi.json` (new)** — OpenAPI 3.1 spec for the new endpoint with schemas for `EventCatalogResponse`, `RegisteredEvent`, and the shared `ErrorResponse`.
- **`scripts/generate-event-catalog-docs.mjs` (new)** — regenerates the event table in `docs/features/metering-events.md` from the registry. Supports `--check` for CI. The hand-written table has been replaced with the generated block between `EVENT_CATALOG:BEGIN`/`:END` markers.
- **`docs/features/metering-events.md`** — the long-form catalog table is now auto-generated and documents `CATALOG_VERSION`.

## Auth model

The catalog is **global** (not per-tenant), so the endpoint requires any valid host API key (Authorization: Bearer ak_live_...) without any specific scope or tenant match. This keeps the roadmap out of fully-anonymous hands without forcing hosts to grant a privileged scope for what is effectively documentation.

## Testing

- 8 new route tests in `functions/src/routes/hostWebhookEventsV1.test.ts` covering: unauthenticated 401, non-host-key Bearer 401, invalid host key 401, valid host key 200 + body shape, stable ETag, `If-None-Match` → 304, and `If-None-Match: *` → 304.
- A **registry guard test** in the same file scans every non-test `.ts` file under `functions/src/` for `type: '<domain>.<name>'` literals and fails if any emitted event name is missing from `EVENT_CATALOG` — belt-and-suspenders alongside the compile-time check.
- All 33 tests in `MeteringBus.test.ts`, `HostWebhookSink.test.ts`, and the new route test pass.
- Full `npm test --prefix functions` run: only pre-existing failures (12 in `tenantUsersV1.test.ts` / `photosV1.test.ts`, plus 2 pre-existing TS errors in `HostWebhookSink.test.ts`) — all confirmed present on `main` and unrelated to this change.

## Acceptance criteria checklist

- [x] `eventCatalog.ts` registry with entries for all currently emitted events.
- [x] `MeteringBus.emit` typed against the registry; unregistered event = compile error.
- [x] `GET /v1/host/webhook-events` endpoint with ETag + host-API-key auth.
- [x] Outbound webhook envelope includes `catalogVersion`.
- [x] OpenAPI contract added.
- [x] Docs page generated from the registry (replaces hand-written event table).
- [x] Test guard: every emitted event name in `functions/src/` exists in the registry.

## Caveats / follow-ups

- The doc-generator parses the registry via regex (not TS compilation) so it can run in any Node environment. The registry has a deliberately simple shape to support this; if future entries need richer typing, the script can be promoted to a `ts-node` invocation.
- `CATALOG_VERSION` is currently bumped by hand. A future enhancement could compute it from a hash of the registry contents during release, but a stable manually-maintained date string is sufficient for the v1 contract.

Fixes rwrife/AuraPix#176