### PR TITLE
fix: Per-tenant Trash retention override (#183)

### DIFF
--- a/contracts/openapi/tenant-trash-config.openapi.json
+++ b/contracts/openapi/tenant-trash-config.openapi.json
@@ -1,0 +1,178 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AuraPix Tenant Trash Retention API",
+    "version": "0.1.0",
+    "description": "Per-tenant Trash retention override (issue #183). Host applications use these endpoints to map pricing tiers (Free / Pro / Business) to Trash retention windows \u2014 e.g. Free=7d, Pro=30d, Business=90d. When no override is set, the deployment-wide `TRASH_RETENTION_DAYS` env default applies.\n\nBoth endpoints are host-API-key only with the `tenant.config` scope; trash retention is NOT end-user-tunable. Cross-tenant requests return `403`.\n\nValid range is `[1, 365]` days inclusive; `null` clears the override and reverts to the deployment default."
+  },
+  "paths": {
+    "/v1/tenants/{tenantId}/config/trash": {
+      "parameters": [
+        {
+          "name": "tenantId",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string", "pattern": "^[a-zA-Z0-9_-]{1,64}$" }
+        }
+      ],
+      "get": {
+        "summary": "Fetch the effective Trash retention window for a tenant",
+        "description": "Returns the effective retention (in days) plus metadata indicating whether the value comes from a per-tenant override or the deployment default.",
+        "security": [{ "hostApiKey": ["tenant.config"] }],
+        "responses": {
+          "200": {
+            "description": "Effective Trash retention",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TrashRetentionEnvelope" }
+              }
+            }
+          },
+          "401": {
+            "description": "Host API key required",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing `tenant.config` scope or cross-tenant request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Set or clear the per-tenant Trash retention override",
+        "description": "Pass an integer in `[1, 365]` to override the deployment default, or `null` to clear the override. Emits a `feature.flag_changed` metering event with `flag=\"trash.retentionDays\"` when the value transitions, and records an audit event.",
+        "security": [{ "hostApiKey": ["tenant.config"] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/TrashRetentionPatch" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated effective retention",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TrashRetentionEnvelope" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body (out of range, non-integer, or unknown keys)",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "401": {
+            "description": "Host API key required",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing `tenant.config` scope or cross-tenant request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": { "type": "http", "scheme": "bearer", "bearerFormat": "JWT" },
+      "hostApiKey": { "type": "apiKey", "in": "header", "name": "X-Host-API-Key" }
+    },
+    "schemas": {
+      "TrashRetentionPatch": {
+        "type": "object",
+        "required": ["retentionDays"],
+        "additionalProperties": false,
+        "properties": {
+          "retentionDays": {
+            "description": "Integer in [1, 365] to set a per-tenant override, or `null` to clear the override and revert to the deployment default.",
+            "oneOf": [
+              { "type": "integer", "minimum": 1, "maximum": 365 },
+              { "type": "null" }
+            ]
+          }
+        }
+      },
+      "TrashRetentionEnvelope": {
+        "type": "object",
+        "required": ["tenantId", "retentionDays", "override", "deploymentDefault", "source"],
+        "properties": {
+          "tenantId": { "type": "string" },
+          "retentionDays": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Effective retention window in days (override if set, otherwise the deployment default)."
+          },
+          "override": {
+            "oneOf": [
+              { "type": "integer", "minimum": 1, "maximum": 365 },
+              { "type": "null" }
+            ],
+            "description": "Per-tenant override value, or `null` when none is set."
+          },
+          "deploymentDefault": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Deployment-wide default in days (env `TRASH_RETENTION_DAYS`, default 30)."
+          },
+          "source": {
+            "type": "string",
+            "enum": ["tenant", "deployment"],
+            "description": "Where the effective value came from."
+          },
+          "updatedAt": { "type": ["string", "null"], "format": "date-time" },
+          "updatedBy": { "type": ["string", "null"] },
+          "changed": {
+            "type": "boolean",
+            "description": "Present on PATCH responses. `true` when the override value transitioned."
+          },
+          "previous": {
+            "oneOf": [
+              { "type": "integer" },
+              { "type": "null" }
+            ],
+            "description": "Present on PATCH responses. The override value prior to this request."
+          }
+        }
+      },
+      "ErrorEnvelope": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "message", "requestId"],
+            "properties": {
+              "code": { "type": "string" },
+              "message": { "type": "string" },
+              "requestId": { "type": "string" },
+              "details": { "type": ["object", "null"] }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/features/library-and-organization.md
+++ b/docs/features/library-and-organization.md
@@ -50,21 +50,67 @@ middleware and enforce `assertSameTenant` in the service layer.
 ### TTL purge job
 
 A scheduled job (`functions/src/jobs/purgeTrash.ts`) hard-deletes photos
-whose `trashedAt` is older than `TRASH_RETENTION_DAYS` (default **30**,
-env-configurable per deployment). The job:
+whose `trashedAt` is older than the effective retention window
+(deployment default **30** days, set via `TRASH_RETENTION_DAYS` env var,
+optionally overridden per tenant — see [Per-tenant Trash retention](#per-tenant-trash-retention-issue-183) below). The job:
 
 - Iterates **per-tenant** so one noisy tenant cannot starve others.
+- Resolves retention per tenant (override > deployment default) so
+  tiered plans can offer different retention windows.
 - Reuses the storage-cleanup path on the existing `StorageAdapter`
   (no new storage code).
 - Caps work per tenant per run via `perTenantLimit` (default 1000).
 - Emits `photo.purged` exactly once per photo (see
   [Metering Events](./metering-events.md)).
 
+### Per-tenant Trash retention (issue #183)
+
+Hosts that resell AuraPix on tiered plans (e.g. Free / Pro / Business)
+can override Trash retention per tenant. The override lives on the
+shared per-tenant config doc (`tenantFeaturesConfig`, the same
+collection used by feature flags from #175):
+
+```ts
+interface TenantFeaturesConfigRecord {
+  tenantId: string;
+  flags: Partial<TenantFeatureFlags>;
+  /** Issue #183: per-tenant Trash retention, integer in [1, 365] days. */
+  trashRetentionDays?: number | null;
+  updatedAt: string;
+  updatedBy: string | null;
+}
+```
+
+Resolution order on the purge hot path:
+
+1. `trashRetentionDays` on the tenant config doc, when set and within
+   `[1, 365]`. Out-of-range / non-integer values log a warning and are
+   ignored.
+2. Deployment default (`TRASH_RETENTION_DAYS` env, or `30`).
+
+#### Endpoints
+
+Both endpoints require a host API key with the `tenant.config` scope.
+Cross-tenant requests return `403`.
+
+| Method | Path | Behavior |
+| --- | --- | --- |
+| `GET` | `/v1/tenants/:tenantId/config/trash` | Returns the effective retention window, the override (or `null`), the deployment default, and the source (`"tenant"` or `"deployment"`). |
+| `PATCH` | `/v1/tenants/:tenantId/config/trash` | Body: `{ "retentionDays": <int 1..365> | null }`. Sets the per-tenant override, or pass `null` to clear and revert to the deployment default. |
+
+`PATCH` emits a `feature.flag_changed` metering event with
+`flag="trash.retentionDays"` and the old / new values when the override
+transitions, and writes a `tenant.config.trash.updated` audit event for
+compliance trails. The `photo.purged` event keeps firing on the actual
+purge — longer retention naturally lengthens the storage-GB billable
+window via the existing `usageDaily` rollups, so no new event types are
+required.
+
 ### Multi-tenant considerations
 
-- `TRASH_RETENTION_DAYS` is a deployment-wide default; a follow-up may
-  move it onto the tenant config doc when a host requests per-tenant
-  retention.
+- Trash retention is strictly per-tenant; cross-tenant reads return
+  `403`. The deployment-wide `TRASH_RETENTION_DAYS` env value is the
+  fallback when no override is set.
 - The purge job's per-tenant iteration is a soft fairness guarantee
   driven by `perTenantLimit`; production wiring should run the job on a
   cadence short enough that the limit drains backlogs within SLA.

--- a/functions/src/domain/photos/PhotosService.ts
+++ b/functions/src/domain/photos/PhotosService.ts
@@ -309,45 +309,80 @@ export class PhotosService {
    * `retentionDays`. Iterates per-tenant so one noisy tenant cannot
    * starve others. Emits exactly one `photo.purged` event per photo.
    *
+   * `retentionDays` is the deployment default. Callers can pass
+   * `resolveRetentionDays(tenantId)` to support per-tenant overrides
+   * (issue #183); when omitted, every tenant uses the global default.
+   *
    * Returns the list of purged photo ids (per tenant) for observability.
    */
   async purgeExpired(opts: {
     retentionDays: number;
     /** Limit work per tenant per run; default 1000. */
     perTenantLimit?: number;
+    /**
+     * Optional per-tenant override resolver. Called once per tenant
+     * that has trashed photos this run; the returned value is clamped
+     * to a sane positive finite number, otherwise the global
+     * `retentionDays` default is used.
+     */
+    resolveRetentionDays?: (tenantId: TenantId) => Promise<number> | number;
   }): Promise<{ tenantId: TenantId; photoIds: string[] }[]> {
     const { retentionDays } = opts;
     if (!Number.isFinite(retentionDays) || retentionDays < 0) {
       throw new Error('retentionDays must be a non-negative finite number');
     }
     const perTenantLimit = opts.perTenantLimit ?? 1000;
-    const cutoff = new Date(this.now().getTime() - retentionDays * 24 * 60 * 60 * 1000);
 
-    // Pull every trashed photo once, then bucket by tenant so we can iterate
-    // tenant-by-tenant. This keeps the operation fair across tenants while
-    // remaining usable on top of the existing queryData filter surface.
+    // Pull every trashed photo once, then bucket by tenant. Cutoff is
+    // computed per-tenant below so a tenant override can take effect.
     const all = await this.data.queryData<Photo>(PHOTOS_COLLECTION, []);
     const byTenant = new Map<TenantId, Photo[]>();
     for (const photo of all) {
       if (!photo.trashedAt) continue;
       const trashedAt = new Date(photo.trashedAt);
       if (Number.isNaN(trashedAt.getTime())) continue;
-      if (trashedAt >= cutoff) continue;
       const tenantId = (photo.tenantId ?? DEFAULT_TENANT_ID) as TenantId;
       const bucket = byTenant.get(tenantId) ?? [];
       bucket.push(photo);
       byTenant.set(tenantId, bucket);
     }
 
+    const nowMs = this.now().getTime();
+    const dayMs = 24 * 60 * 60 * 1000;
     const results: { tenantId: TenantId; photoIds: string[] }[] = [];
     for (const [tenantId, bucket] of byTenant) {
+      // Per-tenant retention (issue #183): resolver wins when it returns
+      // a sane finite non-negative number; otherwise fall back to the
+      // global deployment default. We intentionally swallow resolver
+      // errors so one bad tenant config cannot starve the whole job.
+      let tenantRetentionDays = retentionDays;
+      if (opts.resolveRetentionDays) {
+        try {
+          const resolved = await opts.resolveRetentionDays(tenantId);
+          if (Number.isFinite(resolved) && resolved >= 0) {
+            tenantRetentionDays = resolved;
+          }
+        } catch (err) {
+          logger.warn(
+            { err, tenantId },
+            'purgeTrash: resolveRetentionDays threw; using deployment default'
+          );
+        }
+      }
+      const tenantCutoff = new Date(nowMs - tenantRetentionDays * dayMs);
+
+      const eligible = bucket.filter((photo) => {
+        const trashedAt = new Date(photo.trashedAt as string);
+        return trashedAt < tenantCutoff;
+      });
+
       const purged: string[] = [];
       // Process up to perTenantLimit; oldest-trashedAt first so retention
       // pressure releases evenly.
-      bucket.sort((a, b) =>
+      eligible.sort((a, b) =>
         String(a.trashedAt).localeCompare(String(b.trashedAt))
       );
-      const slice = bucket.slice(0, perTenantLimit);
+      const slice = eligible.slice(0, perTenantLimit);
 
       for (const photo of slice) {
         try {

--- a/functions/src/jobs/purgeTrash.test.ts
+++ b/functions/src/jobs/purgeTrash.test.ts
@@ -11,6 +11,11 @@ import {
   type NormalizedMeteringEvent,
 } from '../services/metering/MeteringBus.js';
 import { InMemoryUsageMeteringBus } from '../services/metering/UsageMeteringBus.js';
+import { __resetTenantFeaturesCacheForTests } from '../services/host/tenantFeaturesConfigService.js';
+import {
+  TENANT_FEATURES_CONFIG_COLLECTION,
+  type TenantFeaturesConfigRecord,
+} from '../models/TenantFeaturesConfig.js';
 import type { Photo } from '../models/Photo.js';
 
 class InMemoryData implements DataAdapter {
@@ -84,6 +89,7 @@ describe('purgeTrash job', () => {
     sink = new CapturingSink();
     setWebhookDeliveryStore(null);
     setMeteringBus(new MeteringBus({ sink, flushIntervalMs: 10, maxBatchSize: 50 }));
+    __resetTenantFeaturesCacheForTests();
   });
 
   afterEach(() => {
@@ -126,5 +132,184 @@ describe('purgeTrash job', () => {
     expect(resolveTrashRetentionDays({ TRASH_RETENTION_DAYS: 'banana' })).toBe(
       DEFAULT_TRASH_RETENTION_DAYS
     );
+  });
+
+  describe('per-tenant Trash retention override (issue #183)', () => {
+    const now = new Date('2025-06-01T00:00:00Z');
+    const day = 86_400_000;
+
+    function storeTenantOverride(
+      tenantId: string,
+      retentionDays: number | null | undefined,
+      extra: Partial<TenantFeaturesConfigRecord> = {}
+    ) {
+      const record: TenantFeaturesConfigRecord = {
+        tenantId,
+        flags: {},
+        updatedAt: '2025-01-01T00:00:00Z',
+        updatedBy: 'test',
+        ...(retentionDays === undefined
+          ? {}
+          : { trashRetentionDays: retentionDays }),
+        ...extra,
+      };
+      return data.storeData(
+        TENANT_FEATURES_CONFIG_COLLECTION,
+        tenantId,
+        record
+      );
+    }
+
+    it('uses the deployment default when the tenant has no config doc', async () => {
+      // Photo is 20 days old; default is 30 → must NOT purge.
+      await data.storeData('photos', 'p1', makePhoto({
+        id: 'p1',
+        tenantId: 'no-override',
+        trashedAt: new Date(now.getTime() - 20 * day).toISOString(),
+      }));
+      const result = await runPurgeTrashJob({
+        dataAdapter: data,
+        usageBus: new InMemoryUsageMeteringBus(),
+        retentionDays: 30,
+        now: () => now,
+      });
+      expect(result.totalPurged).toBe(0);
+      expect(await data.fetchData('photos', 'p1')).not.toBeNull();
+    });
+
+    it('honors a valid per-tenant override (Pro=7) and ignores the default', async () => {
+      // Photo is 10 days old. Tenant override is 7 → must purge.
+      await storeTenantOverride('pro-tenant', 7);
+      await data.storeData('photos', 'pro-old', makePhoto({
+        id: 'pro-old',
+        tenantId: 'pro-tenant',
+        trashedAt: new Date(now.getTime() - 10 * day).toISOString(),
+      }));
+      // Different tenant on default 30 with same age → must NOT purge.
+      await data.storeData('photos', 'free-keep', makePhoto({
+        id: 'free-keep',
+        tenantId: 'free-tenant',
+        trashedAt: new Date(now.getTime() - 10 * day).toISOString(),
+      }));
+
+      const result = await runPurgeTrashJob({
+        dataAdapter: data,
+        usageBus: new InMemoryUsageMeteringBus(),
+        retentionDays: 30,
+        now: () => now,
+      });
+      const purgedIds = result.tenants.flatMap((t) => t.purgedPhotoIds);
+      expect(purgedIds).toContain('pro-old');
+      expect(purgedIds).not.toContain('free-keep');
+      expect(await data.fetchData('photos', 'pro-old')).toBeNull();
+      expect(await data.fetchData('photos', 'free-keep')).not.toBeNull();
+    });
+
+    it('honors a higher per-tenant override (Business=90) and retains photos the deployment default would purge', async () => {
+      // Photo is 60 days old. Default is 30 → would purge. Override=90 → keep.
+      await storeTenantOverride('biz', 90);
+      await data.storeData('photos', 'biz-keep', makePhoto({
+        id: 'biz-keep',
+        tenantId: 'biz',
+        trashedAt: new Date(now.getTime() - 60 * day).toISOString(),
+      }));
+      // 100 day-old photo — even the override should purge this one.
+      await data.storeData('photos', 'biz-purge', makePhoto({
+        id: 'biz-purge',
+        tenantId: 'biz',
+        trashedAt: new Date(now.getTime() - 100 * day).toISOString(),
+      }));
+
+      const result = await runPurgeTrashJob({
+        dataAdapter: data,
+        usageBus: new InMemoryUsageMeteringBus(),
+        retentionDays: 30,
+        now: () => now,
+      });
+      expect(result.totalPurged).toBe(1);
+      const purgedIds = result.tenants.flatMap((t) => t.purgedPhotoIds);
+      expect(purgedIds).toEqual(['biz-purge']);
+      expect(await data.fetchData('photos', 'biz-keep')).not.toBeNull();
+      expect(await data.fetchData('photos', 'biz-purge')).toBeNull();
+    });
+
+    it('falls back to the deployment default on an invalid (out-of-range) override', async () => {
+      // Store an invalid override (negative). Photo is 20 days old.
+      // Override invalid → default 30 applies → must NOT purge.
+      await storeTenantOverride('bad', -5);
+      await data.storeData('photos', 'bad-photo', makePhoto({
+        id: 'bad-photo',
+        tenantId: 'bad',
+        trashedAt: new Date(now.getTime() - 20 * day).toISOString(),
+      }));
+
+      const result = await runPurgeTrashJob({
+        dataAdapter: data,
+        usageBus: new InMemoryUsageMeteringBus(),
+        retentionDays: 30,
+        now: () => now,
+      });
+      expect(result.totalPurged).toBe(0);
+      expect(await data.fetchData('photos', 'bad-photo')).not.toBeNull();
+    });
+
+    it('falls back to the deployment default on a non-integer override', async () => {
+      // 3.7 days is not an integer → invalid → default applies.
+      await storeTenantOverride('frac', 3.7);
+      await data.storeData('photos', 'frac-keep', makePhoto({
+        id: 'frac-keep',
+        tenantId: 'frac',
+        trashedAt: new Date(now.getTime() - 10 * day).toISOString(),
+      }));
+
+      const result = await runPurgeTrashJob({
+        dataAdapter: data,
+        usageBus: new InMemoryUsageMeteringBus(),
+        retentionDays: 30,
+        now: () => now,
+      });
+      expect(result.totalPurged).toBe(0);
+      expect(await data.fetchData('photos', 'frac-keep')).not.toBeNull();
+    });
+
+    it('treats null trashRetentionDays as "no override" and uses the deployment default', async () => {
+      await storeTenantOverride('nullish', null);
+      await data.storeData('photos', 'nullish-old', makePhoto({
+        id: 'nullish-old',
+        tenantId: 'nullish',
+        trashedAt: new Date(now.getTime() - 40 * day).toISOString(),
+      }));
+
+      const result = await runPurgeTrashJob({
+        dataAdapter: data,
+        usageBus: new InMemoryUsageMeteringBus(),
+        retentionDays: 30,
+        now: () => now,
+      });
+      // 40 days old — default 30 purges it.
+      expect(result.totalPurged).toBe(1);
+      expect(await data.fetchData('photos', 'nullish-old')).toBeNull();
+    });
+
+    it('disablePerTenantOverride forces the deployment default for every tenant', async () => {
+      // Override would keep this photo (override=90) but the diagnostic
+      // flag disables that resolution — default 30 must apply.
+      await storeTenantOverride('biz', 90);
+      await data.storeData('photos', 'biz-photo', makePhoto({
+        id: 'biz-photo',
+        tenantId: 'biz',
+        trashedAt: new Date(now.getTime() - 60 * day).toISOString(),
+      }));
+
+      const result = await runPurgeTrashJob({
+        dataAdapter: data,
+        usageBus: new InMemoryUsageMeteringBus(),
+        retentionDays: 30,
+        now: () => now,
+        disablePerTenantOverride: true,
+      });
+      expect(result.totalPurged).toBe(1);
+      expect(await data.fetchData('photos', 'biz-photo')).toBeNull();
+    });
   });
 });

--- a/functions/src/jobs/purgeTrash.ts
+++ b/functions/src/jobs/purgeTrash.ts
@@ -1,9 +1,16 @@
 /**
  * purgeTrash — scheduled job that hard-deletes photos whose `trashedAt`
- * timestamp is older than `TRASH_RETENTION_DAYS` (default 30).
+ * timestamp is older than the effective retention window.
  *
  * Wired via the scheduler in production; runnable on demand in tests by
  * calling {@link runPurgeTrashJob} with a fake clock.
+ *
+ * Retention resolution (issue #183):
+ *   - Per-tenant override on the features-config doc wins when present
+ *     and within `[1, 365]`.
+ *   - Otherwise the deployment-wide default from
+ *     `TRASH_RETENTION_DAYS` (or `DEFAULT_TRASH_RETENTION_DAYS`) is used.
+ *   - Invalid per-tenant values log WARN and fall back to the default.
  *
  * Behavior (issue #152):
  *   - Iterates per-tenant so one noisy tenant cannot starve others.
@@ -16,6 +23,7 @@ import type { DataAdapter } from '../adapters/data/DataAdapter.js';
 import type { StorageAdapter } from '../adapters/storage/StorageAdapter.js';
 import { PhotosService } from '../domain/photos/PhotosService.js';
 import type { UsageMeteringBus } from '../services/metering/UsageMeteringBus.js';
+import { resolveTenantTrashRetentionDays } from '../services/host/tenantFeaturesConfigService.js';
 import { logger } from '../utils/logger.js';
 
 export const DEFAULT_TRASH_RETENTION_DAYS = 30;
@@ -40,11 +48,21 @@ export interface PurgeTrashJobOptions {
   dataAdapter: DataAdapter;
   storageAdapter?: StorageAdapter;
   usageBus?: UsageMeteringBus;
+  /**
+   * Deployment-wide default retention. Per-tenant overrides on the
+   * features-config doc take precedence; pass this when you want to
+   * pin the default instead of reading `TRASH_RETENTION_DAYS` from env.
+   */
   retentionDays?: number;
   /** Cap per-tenant work per run (default 1000). */
   perTenantLimit?: number;
   /** Test hook. */
   now?: () => Date;
+  /**
+   * Disable per-tenant resolution (test/diagnostic hook). When `true`,
+   * every tenant uses the deployment default. Defaults to `false`.
+   */
+  disablePerTenantOverride?: boolean;
 }
 
 export interface PurgeTrashJobResult {
@@ -69,6 +87,17 @@ export async function runPurgeTrashJob(
   const results = await service.purgeExpired({
     retentionDays,
     perTenantLimit: opts.perTenantLimit,
+    // Resolve per-tenant Trash retention from the features-config doc
+    // (issue #183). The resolver is closure-captured so the data adapter
+    // does not have to leak into PhotosService.
+    resolveRetentionDays: opts.disablePerTenantOverride
+      ? undefined
+      : (tenantId) =>
+          resolveTenantTrashRetentionDays(
+            opts.dataAdapter,
+            String(tenantId),
+            retentionDays
+          ),
   });
 
   const totalPurged = results.reduce((acc, r) => acc + r.photoIds.length, 0);

--- a/functions/src/models/TenantFeaturesConfig.ts
+++ b/functions/src/models/TenantFeaturesConfig.ts
@@ -51,6 +51,20 @@ export interface TenantFeaturesConfigRecord {
    */
   flags: Partial<TenantFeatureFlags>;
 
+  /**
+   * Optional per-tenant Trash retention window in days (issue #183).
+   * When set (and within `TRASH_RETENTION_MIN_DAYS..TRASH_RETENTION_MAX_DAYS`),
+   * the `purgeTrash` job uses this value instead of the deployment-wide
+   * `TRASH_RETENTION_DAYS` env default. Hosts use this to map plan tiers
+   * (e.g. Free=7, Pro=30, Business=90) to retention windows.
+   *
+   * Unset / null / invalid → deployment default. Storing this on the
+   * same per-tenant config doc as `flags` keeps a single source of
+   * truth for host configuration and avoids a second Firestore read on
+   * the purge hot path.
+   */
+  trashRetentionDays?: number | null;
+
   /** ISO-8601 timestamp of the last mutation. */
   updatedAt: string;
 
@@ -61,6 +75,24 @@ export interface TenantFeaturesConfigRecord {
    */
   updatedBy: string | null;
 }
+
+/**
+ * Inclusive lower bound on per-tenant Trash retention (issue #183).
+ *
+ * A value below `1` makes no operational sense (the next purge run
+ * would always reap the photo) and is rejected by validation so hosts
+ * cannot accidentally configure "instant purge" via a misplaced zero.
+ */
+export const TRASH_RETENTION_MIN_DAYS = 1;
+
+/**
+ * Inclusive upper bound on per-tenant Trash retention (issue #183).
+ *
+ * 365 days is a year of cold-storage exposure — a sensible cap that
+ * keeps billable storage windows bounded and matches the limit called
+ * out in the issue.
+ */
+export const TRASH_RETENTION_MAX_DAYS = 365;
 
 /** Default feature state when no doc exists \u2014 every feature is enabled. */
 export const DEFAULT_FEATURE_FLAGS: TenantFeatureFlags = {

--- a/functions/src/routes/tenantTrashConfigV1.ts
+++ b/functions/src/routes/tenantTrashConfigV1.ts
@@ -1,0 +1,301 @@
+/**
+ * Per-tenant Trash retention config endpoints (issue #183).
+ *
+ * Mounted at `/v1/tenants/:tenantId/config/trash` (and the legacy
+ * `/api/v1/tenants/...` alias). Both endpoints are host-API-key only
+ * with the `tenant.config` scope (shared with the feature-flag config
+ * router; trash retention is also a host configuration concern that
+ * maps to pricing tiers, not a user-tunable preference).
+ *
+ *   GET   /:tenantId/config/trash   → { tenantId, retentionDays, source,
+ *                                       updatedAt, updatedBy }
+ *   PATCH /:tenantId/config/trash   → { retentionDays: number | null }
+ *                                       emits `feature.flag_changed` with
+ *                                       `flag="trash.retentionDays"`.
+ *
+ * Validation: `retentionDays` MUST be an integer in `[1, 365]`.
+ * `null` clears the override and reverts to the deployment default.
+ *
+ * See:
+ *   - models/TenantFeaturesConfig.ts        — storage shape, min/max
+ *   - services/host/tenantFeaturesConfigService.ts — read + PATCH helpers
+ *   - jobs/purgeTrash.ts                    — purge job honors the override
+ *   - contracts/openapi/tenant-trash-config.openapi.json — contract
+ */
+
+import { randomUUID } from 'node:crypto';
+import { Router } from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import {
+  TRASH_RETENTION_MAX_DAYS,
+  TRASH_RETENTION_MIN_DAYS,
+} from '../models/TenantFeaturesConfig.js';
+import {
+  clampTrashRetentionDays,
+  fetchTenantFeaturesConfig,
+  patchTrashRetention,
+} from '../services/host/tenantFeaturesConfigService.js';
+import {
+  emitMeteringEvent,
+  resolveTenantId,
+} from '../services/metering/index.js';
+import { recordAuditEvent } from '../services/audit/AuditService.js';
+import {
+  DEFAULT_TRASH_RETENTION_DAYS,
+  resolveTrashRetentionDays,
+} from '../jobs/purgeTrash.js';
+import type { TenantApiKeyScope } from '../models/TenantApiKey.js';
+import { logger } from '../utils/logger.js';
+
+interface ApiErrorPayload {
+  error: {
+    code: string;
+    message: string;
+    requestId: string;
+    details: Record<string, unknown> | null;
+  };
+}
+
+function sendError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> | null = null
+): void {
+  const body: ApiErrorPayload = {
+    error: { code, message, requestId: randomUUID(), details },
+  };
+  res.status(status).json(body);
+}
+
+/**
+ * Host-API-key-only guard. Mirrors the pattern in `tenantFeaturesV1.ts`.
+ */
+function requireTenantHostKey(scope: TenantApiKeyScope) {
+  return function guard(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): void {
+    const tenantId = String(req.params.tenantId ?? '');
+    if (!tenantId) {
+      sendError(res, 400, 'VALIDATION_ERROR', 'tenantId is required');
+      return;
+    }
+    if (!req.tenant) {
+      sendError(
+        res,
+        401,
+        'HOST_API_KEY_REQUIRED',
+        'Trash retention configuration endpoints require a host API key'
+      );
+      return;
+    }
+    if (req.tenant.id !== tenantId) {
+      sendError(
+        res,
+        403,
+        'CROSS_TENANT_FORBIDDEN',
+        'Cross-tenant request rejected'
+      );
+      return;
+    }
+    if (!new Set(req.tenant.scopes).has(scope)) {
+      sendError(res, 403, 'INSUFFICIENT_SCOPE', 'Insufficient scope', {
+        missing: [scope],
+      });
+      return;
+    }
+    next();
+  };
+}
+
+/**
+ * PATCH body schema. `retentionDays` may be a positive integer in range
+ * or `null` to clear the override and revert to the deployment default.
+ */
+const PatchSchema = z
+  .object({
+    retentionDays: z
+      .union([
+        z
+          .number()
+          .int()
+          .min(TRASH_RETENTION_MIN_DAYS)
+          .max(TRASH_RETENTION_MAX_DAYS),
+        z.null(),
+      ])
+      .describe(
+        `Integer in [${TRASH_RETENTION_MIN_DAYS}, ${TRASH_RETENTION_MAX_DAYS}], or null to clear.`
+      ),
+  })
+  .strict();
+
+export interface TenantTrashConfigRouterDeps {
+  dataAdapter: DataAdapter;
+  /**
+   * Test hook: override the deployment-default resolver. Defaults to
+   * reading `TRASH_RETENTION_DAYS` from `process.env`.
+   */
+  resolveDeploymentDefault?: () => number;
+}
+
+export function createTenantTrashConfigRouter(
+  deps: TenantTrashConfigRouterDeps
+): Router {
+  const router = Router({ mergeParams: true });
+  const deploymentDefault = () =>
+    deps.resolveDeploymentDefault
+      ? deps.resolveDeploymentDefault()
+      : resolveTrashRetentionDays();
+
+  // GET /:tenantId/config/trash
+  router.get(
+    '/:tenantId/config/trash',
+    requireTenantHostKey('tenant.config'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId);
+        const doc = await fetchTenantFeaturesConfig(deps.dataAdapter, tenantId);
+        const override = clampTrashRetentionDays(doc?.trashRetentionDays);
+        const fallback = deploymentDefault();
+        const effective = override ?? fallback;
+        res.status(200).json({
+          tenantId,
+          retentionDays: effective,
+          override,
+          deploymentDefault: fallback,
+          source: override !== null ? 'tenant' : 'deployment',
+          updatedAt: doc?.updatedAt ?? null,
+          updatedBy: doc?.updatedBy ?? null,
+        });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  // PATCH /:tenantId/config/trash
+  router.patch(
+    '/:tenantId/config/trash',
+    requireTenantHostKey('tenant.config'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId);
+        const parsed = PatchSchema.safeParse(req.body ?? {});
+        if (!parsed.success) {
+          sendError(
+            res,
+            400,
+            'INVALID_BODY',
+            'Invalid trash retention payload',
+            { issues: parsed.error.issues }
+          );
+          return;
+        }
+
+        const actor = req.tenant?.keyId ?? null;
+        const fallback = deploymentDefault();
+        let result;
+        try {
+          result = await patchTrashRetention(deps.dataAdapter, {
+            tenantId,
+            retentionDays: parsed.data.retentionDays,
+            actor,
+          });
+        } catch (err) {
+          if (err instanceof RangeError) {
+            // Defensive: zod already rejects out-of-range values, but
+            // surfacing the service-layer error keeps both layers honest.
+            sendError(res, 400, 'INVALID_BODY', err.message);
+            return;
+          }
+          throw err;
+        }
+
+        // Emit `feature.flag_changed` with `flag="trash.retentionDays"`
+        // so hosts can correlate plan changes with bill deltas (the
+        // event already exists in the catalog).
+        if (result.changed) {
+          const actorLabel = actor
+            ? `host-api-key:${actor.substring(0, 8)}`
+            : 'host-api-key';
+          try {
+            emitMeteringEvent({
+              tenantId: resolveTenantId({ tenantId }),
+              type: 'feature.flag_changed',
+              count: 1,
+              resourceId: 'trash.retentionDays',
+              meta: {
+                tenantId,
+                feature: 'trash.retentionDays',
+                // The existing schema is { oldValue: boolean, newValue: boolean }
+                // and uses `additionalProperties: true`, so we also publish the
+                // numeric values for hosts that want to inspect them.
+                oldValue: result.previous,
+                newValue: result.next,
+                actor: actorLabel,
+              },
+            });
+          } catch (err) {
+            logger.debug(
+              { err, tenantId },
+              'feature.flag_changed emit failed for trash.retentionDays'
+            );
+          }
+
+          // Audit event for compliance trails (same pattern as
+          // tenant.features and branding routes).
+          try {
+            await recordAuditEvent(deps.dataAdapter, {
+              eventType: 'tenant.config.trash.updated',
+              actorId: actor ?? 'host-api-key',
+              targetId: tenantId,
+              tenantId,
+              resourceType: 'tenant-config',
+              createdAt: result.record.updatedAt,
+              metadata: {
+                tenantId,
+                previous: result.previous,
+                next: result.next,
+              },
+            });
+          } catch (auditErr) {
+            logger.warn(
+              { err: auditErr, tenantId },
+              'Failed to record tenant.config.trash audit event'
+            );
+          }
+        }
+
+        const effective = result.next ?? fallback;
+        res.status(200).json({
+          tenantId,
+          retentionDays: effective,
+          override: result.next,
+          deploymentDefault: fallback,
+          source: result.next !== null ? 'tenant' : 'deployment',
+          updatedAt: result.record.updatedAt,
+          updatedBy: result.record.updatedBy,
+          changed: result.changed,
+          previous: result.previous,
+        });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  return router;
+}
+
+/**
+ * Test surface.
+ */
+export const __test = {
+  PatchSchema,
+  DEFAULT_TRASH_RETENTION_DAYS,
+};

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -116,6 +116,7 @@ import { TenantOffboardingService } from './services/tenant/TenantOffboardingSer
 import { createTenantWebhookSecretsRouter } from './routes/tenantWebhookSecretsV1.js';
 import { createTenantPluginsRouter } from './routes/tenantPluginsV1.js';
 import { createTenantFeaturesRouter } from './routes/tenantFeaturesV1.js';
+import { createTenantTrashConfigRouter } from './routes/tenantTrashConfigV1.js';
 import { createHostWebhookEventsRouter } from './routes/hostWebhookEventsV1.js';
 import { createRequireFeature } from './middleware/requireFeature.js';
 import { createPhotosV1Router, createLibraryTagsRouter } from './routes/photosV1.js';
@@ -549,6 +550,21 @@ app.use(
   '/api/v1/tenants',
   hostApiKeyAuth,
   tenantFeaturesRouter
+);
+
+// Per-tenant Trash retention config (issue #183). Host-API-key-only
+// with the `tenant.config` scope, mounted next to the feature flag
+// router so hosts can manage both knobs through the same key/scope.
+const tenantTrashConfigRouter = createTenantTrashConfigRouter({ dataAdapter });
+app.use(
+  '/v1/tenants',
+  hostApiKeyAuth,
+  tenantTrashConfigRouter
+);
+app.use(
+  '/api/v1/tenants',
+  hostApiKeyAuth,
+  tenantTrashConfigRouter
 );
 
 // Public webhook event catalog (issue #176). Global — not per-tenant —

--- a/functions/src/services/host/tenantFeaturesConfigService.test.ts
+++ b/functions/src/services/host/tenantFeaturesConfigService.test.ts
@@ -4,16 +4,21 @@ import {
   DEFAULT_FEATURE_FLAGS,
   FEATURE_FLAG_NAMES,
   TENANT_FEATURES_CONFIG_COLLECTION,
+  TRASH_RETENTION_MAX_DAYS,
+  TRASH_RETENTION_MIN_DAYS,
   type TenantFeaturesConfigRecord,
 } from '../../models/TenantFeaturesConfig.js';
 import {
   __resetTenantFeaturesCacheForTests,
+  clampTrashRetentionDays,
   fetchTenantFeaturesConfig,
   getEffectiveFeatureFlags,
   invalidateTenantFeaturesCache,
   isFeatureEnabled,
   mergeWithDefaults,
   patchTenantFeatures,
+  patchTrashRetention,
+  resolveTenantTrashRetentionDays,
 } from './tenantFeaturesConfigService.js';
 
 /**
@@ -230,6 +235,205 @@ describe('tenantFeaturesConfigService', () => {
       });
       await fetchTenantFeaturesConfig(data, 'tenant-c');
       expect(fetchSpy.mock.calls.length).toBeGreaterThan(coldCalls);
+    });
+  });
+
+  describe('Trash retention override (issue #183)', () => {
+    describe('clampTrashRetentionDays', () => {
+      it('accepts integers within [MIN, MAX]', () => {
+        expect(clampTrashRetentionDays(TRASH_RETENTION_MIN_DAYS)).toBe(
+          TRASH_RETENTION_MIN_DAYS
+        );
+        expect(clampTrashRetentionDays(30)).toBe(30);
+        expect(clampTrashRetentionDays(TRASH_RETENTION_MAX_DAYS)).toBe(
+          TRASH_RETENTION_MAX_DAYS
+        );
+      });
+
+      it('rejects out-of-range, non-integer, and non-number values', () => {
+        expect(clampTrashRetentionDays(0)).toBeNull();
+        expect(clampTrashRetentionDays(-1)).toBeNull();
+        expect(clampTrashRetentionDays(TRASH_RETENTION_MAX_DAYS + 1)).toBeNull();
+        expect(clampTrashRetentionDays(3.5)).toBeNull();
+        expect(clampTrashRetentionDays(NaN)).toBeNull();
+        expect(clampTrashRetentionDays(Infinity)).toBeNull();
+        expect(clampTrashRetentionDays('30' as unknown)).toBeNull();
+        expect(clampTrashRetentionDays(null)).toBeNull();
+        expect(clampTrashRetentionDays(undefined)).toBeNull();
+      });
+    });
+
+    describe('resolveTenantTrashRetentionDays', () => {
+      it('returns the deployment default when no doc exists', async () => {
+        const { data } = makeMemoryAdapter();
+        await expect(
+          resolveTenantTrashRetentionDays(data, 'tenant-a', 30)
+        ).resolves.toBe(30);
+      });
+
+      it('returns the deployment default when tenantId is empty', async () => {
+        const { data } = makeMemoryAdapter();
+        await expect(
+          resolveTenantTrashRetentionDays(data, '', 14)
+        ).resolves.toBe(14);
+      });
+
+      it('returns the override when present and valid', async () => {
+        const { data, store } = makeMemoryAdapter();
+        const rec: TenantFeaturesConfigRecord = {
+          tenantId: 'tenant-b',
+          flags: {},
+          trashRetentionDays: 7,
+          updatedAt: '2024-01-01T00:00:00Z',
+          updatedBy: null,
+        };
+        store
+          .get(TENANT_FEATURES_CONFIG_COLLECTION) ??
+          store.set(TENANT_FEATURES_CONFIG_COLLECTION, new Map());
+        store
+          .get(TENANT_FEATURES_CONFIG_COLLECTION)!
+          .set('tenant-b', rec);
+        await expect(
+          resolveTenantTrashRetentionDays(data, 'tenant-b', 30)
+        ).resolves.toBe(7);
+      });
+
+      it('falls back to deployment default on invalid override', async () => {
+        const { data, store } = makeMemoryAdapter();
+        const rec: TenantFeaturesConfigRecord = {
+          tenantId: 'tenant-c',
+          flags: {},
+          trashRetentionDays: 9999,
+          updatedAt: '2024-01-01T00:00:00Z',
+          updatedBy: null,
+        };
+        store
+          .get(TENANT_FEATURES_CONFIG_COLLECTION) ??
+          store.set(TENANT_FEATURES_CONFIG_COLLECTION, new Map());
+        store
+          .get(TENANT_FEATURES_CONFIG_COLLECTION)!
+          .set('tenant-c', rec);
+        await expect(
+          resolveTenantTrashRetentionDays(data, 'tenant-c', 30)
+        ).resolves.toBe(30);
+      });
+
+      it('treats undefined / null override as no override', async () => {
+        const { data, store } = makeMemoryAdapter();
+        const rec: TenantFeaturesConfigRecord = {
+          tenantId: 'tenant-d',
+          flags: { plugins: false },
+          updatedAt: '2024-01-01T00:00:00Z',
+          updatedBy: null,
+        };
+        store
+          .get(TENANT_FEATURES_CONFIG_COLLECTION) ??
+          store.set(TENANT_FEATURES_CONFIG_COLLECTION, new Map());
+        store
+          .get(TENANT_FEATURES_CONFIG_COLLECTION)!
+          .set('tenant-d', rec);
+        await expect(
+          resolveTenantTrashRetentionDays(data, 'tenant-d', 30)
+        ).resolves.toBe(30);
+      });
+    });
+
+    describe('patchTrashRetention', () => {
+      it('writes a new doc and reports the transition from null to 7', async () => {
+        const { data, store } = makeMemoryAdapter();
+        const result = await patchTrashRetention(data, {
+          tenantId: 'pro',
+          retentionDays: 7,
+          actor: 'tak_pro123',
+        });
+        expect(result.previous).toBeNull();
+        expect(result.next).toBe(7);
+        expect(result.changed).toBe(true);
+
+        const stored = store
+          .get(TENANT_FEATURES_CONFIG_COLLECTION)
+          ?.get('pro') as TenantFeaturesConfigRecord;
+        expect(stored.trashRetentionDays).toBe(7);
+        expect(stored.updatedBy).toBe('tak_pro123');
+      });
+
+      it('reports changed=false when the value is unchanged', async () => {
+        const { data } = makeMemoryAdapter();
+        await patchTrashRetention(data, { tenantId: 't', retentionDays: 14 });
+        invalidateTenantFeaturesCache('t');
+        const result = await patchTrashRetention(data, {
+          tenantId: 't',
+          retentionDays: 14,
+        });
+        expect(result.changed).toBe(false);
+        expect(result.previous).toBe(14);
+        expect(result.next).toBe(14);
+      });
+
+      it('clears the override on null and reports the transition', async () => {
+        const { data, store } = makeMemoryAdapter();
+        await patchTrashRetention(data, { tenantId: 't', retentionDays: 60 });
+        const result = await patchTrashRetention(data, {
+          tenantId: 't',
+          retentionDays: null,
+        });
+        expect(result.previous).toBe(60);
+        expect(result.next).toBeNull();
+        expect(result.changed).toBe(true);
+        const stored = store
+          .get(TENANT_FEATURES_CONFIG_COLLECTION)
+          ?.get('t') as TenantFeaturesConfigRecord;
+        expect(stored.trashRetentionDays).toBeNull();
+      });
+
+      it('rejects out-of-range values with RangeError', async () => {
+        const { data } = makeMemoryAdapter();
+        await expect(
+          patchTrashRetention(data, { tenantId: 't', retentionDays: 0 })
+        ).rejects.toBeInstanceOf(RangeError);
+        await expect(
+          patchTrashRetention(data, { tenantId: 't', retentionDays: 999 })
+        ).rejects.toBeInstanceOf(RangeError);
+        await expect(
+          patchTrashRetention(data, { tenantId: 't', retentionDays: 1.5 })
+        ).rejects.toBeInstanceOf(RangeError);
+      });
+
+      it('rejects missing tenantId', async () => {
+        const { data } = makeMemoryAdapter();
+        await expect(
+          patchTrashRetention(data, { tenantId: '', retentionDays: 7 })
+        ).rejects.toThrow(/tenantId/);
+      });
+
+      it('preserves existing flags when patching retention only', async () => {
+        const { data, store } = makeMemoryAdapter();
+        await patchTenantFeatures(data, {
+          tenantId: 't',
+          patch: { sharing: false },
+        });
+        await patchTrashRetention(data, { tenantId: 't', retentionDays: 14 });
+        const stored = store
+          .get(TENANT_FEATURES_CONFIG_COLLECTION)
+          ?.get('t') as TenantFeaturesConfigRecord;
+        expect(stored.flags.sharing).toBe(false);
+        expect(stored.trashRetentionDays).toBe(14);
+      });
+
+      it('preserves the retention override when patching flags only', async () => {
+        const { data, store } = makeMemoryAdapter();
+        await patchTrashRetention(data, { tenantId: 't', retentionDays: 21 });
+        await patchTenantFeatures(data, {
+          tenantId: 't',
+          patch: { plugins: false },
+        });
+        const stored = store
+          .get(TENANT_FEATURES_CONFIG_COLLECTION)
+          ?.get('t') as TenantFeaturesConfigRecord;
+        // Critical: a flag PATCH must NOT silently drop the retention value.
+        expect(stored.trashRetentionDays).toBe(21);
+        expect(stored.flags.plugins).toBe(false);
+      });
     });
   });
 });

--- a/functions/src/services/host/tenantFeaturesConfigService.ts
+++ b/functions/src/services/host/tenantFeaturesConfigService.ts
@@ -26,10 +26,13 @@ import {
   DEFAULT_FEATURE_FLAGS,
   FEATURE_FLAG_NAMES,
   TENANT_FEATURES_CONFIG_COLLECTION,
+  TRASH_RETENTION_MAX_DAYS,
+  TRASH_RETENTION_MIN_DAYS,
   type FeatureFlagName,
   type TenantFeatureFlags,
   type TenantFeaturesConfigRecord,
 } from '../../models/TenantFeaturesConfig.js';
+import { logger } from '../../utils/logger.js';
 
 interface CacheEntry {
   record: TenantFeaturesConfigRecord | null;
@@ -183,6 +186,13 @@ export async function patchTenantFeatures(
   const record: TenantFeaturesConfigRecord = {
     tenantId,
     flags: nextFlags,
+    // Preserve any existing per-tenant Trash retention override
+    // (issue #183). `patchTenantFeatures` and `patchTrashRetention`
+    // share the same underlying doc; flag mutations must NOT clobber a
+    // separately-set retention value.
+    ...(existing && 'trashRetentionDays' in existing
+      ? { trashRetentionDays: existing.trashRetentionDays ?? null }
+      : {}),
     updatedAt: now,
     updatedBy: actor ?? null,
   };
@@ -214,4 +224,128 @@ export function mergeWithDefaults(
 
 function isKnownFeature(value: string): value is FeatureFlagName {
   return (FEATURE_FLAG_NAMES as readonly string[]).includes(value);
+}
+
+/**
+ * Validate + clamp a candidate Trash retention value (issue #183).
+ *
+ * Returns the integer in `[TRASH_RETENTION_MIN_DAYS, TRASH_RETENTION_MAX_DAYS]`
+ * when the input is a finite integer in range, otherwise `null`. Hosts
+ * call `patchTrashRetention` which rejects invalid values; this helper
+ * is also used on the read path so an out-of-band corrupt value falls
+ * back to the deployment default rather than crashing the purge job.
+ */
+export function clampTrashRetentionDays(value: unknown): number | null {
+  if (typeof value !== 'number') return null;
+  if (!Number.isFinite(value)) return null;
+  if (!Number.isInteger(value)) return null;
+  if (value < TRASH_RETENTION_MIN_DAYS) return null;
+  if (value > TRASH_RETENTION_MAX_DAYS) return null;
+  return value;
+}
+
+/**
+ * Resolve the effective Trash retention window for a tenant
+ * (issue #183).
+ *
+ * Lookup order:
+ *   1. Per-tenant override on the features-config doc (when present
+ *      and valid).
+ *   2. The supplied deployment default (the caller passes the result
+ *      of `resolveTrashRetentionDays(env)` from `purgeTrash.ts`).
+ *
+ * Invalid override values are logged at WARN and ignored — the job
+ * MUST keep running on a sensible default rather than skipping the
+ * tenant entirely (acceptance criteria for issue #183).
+ */
+export async function resolveTenantTrashRetentionDays(
+  data: DataAdapter,
+  tenantId: string,
+  deploymentDefault: number
+): Promise<number> {
+  if (!tenantId) return deploymentDefault;
+  const doc = await fetchTenantFeaturesConfig(data, tenantId);
+  if (!doc) return deploymentDefault;
+  const raw = doc.trashRetentionDays;
+  if (raw === undefined || raw === null) return deploymentDefault;
+  const clamped = clampTrashRetentionDays(raw);
+  if (clamped === null) {
+    logger.warn(
+      { tenantId, raw },
+      'tenantFeaturesConfig.trashRetentionDays is invalid; falling back to deployment default'
+    );
+    return deploymentDefault;
+  }
+  return clamped;
+}
+
+/**
+ * Apply a Trash retention update to a tenant's features-config doc
+ * (issue #183).
+ *
+ * `retentionDays` MUST be a finite integer in
+ * `[TRASH_RETENTION_MIN_DAYS, TRASH_RETENTION_MAX_DAYS]`; out-of-range
+ * inputs throw `RangeError` so the route layer can surface `400`.
+ *
+ * Pass `retentionDays: null` to clear the override and fall back to
+ * the deployment default.
+ *
+ * Returns the new record plus `previous`/`next` retention values so
+ * the caller can emit `feature.flag_changed` and audit events only
+ * when the value actually transitioned.
+ */
+export async function patchTrashRetention(
+  data: DataAdapter,
+  options: {
+    tenantId: string;
+    retentionDays: number | null;
+    actor?: string | null;
+  }
+): Promise<{
+  record: TenantFeaturesConfigRecord;
+  previous: number | null;
+  next: number | null;
+  changed: boolean;
+}> {
+  const { tenantId, retentionDays, actor } = options;
+  if (!tenantId) {
+    throw new Error('tenantId is required');
+  }
+
+  let nextValue: number | null;
+  if (retentionDays === null) {
+    nextValue = null;
+  } else {
+    const clamped = clampTrashRetentionDays(retentionDays);
+    if (clamped === null) {
+      throw new RangeError(
+        `retentionDays must be an integer between ${TRASH_RETENTION_MIN_DAYS} and ${TRASH_RETENTION_MAX_DAYS}`
+      );
+    }
+    nextValue = clamped;
+  }
+
+  const existing = await data.fetchData<TenantFeaturesConfigRecord>(
+    TENANT_FEATURES_CONFIG_COLLECTION,
+    tenantId
+  );
+  const previous = clampTrashRetentionDays(existing?.trashRetentionDays);
+  const changed = previous !== nextValue;
+
+  const now = new Date().toISOString();
+  const record: TenantFeaturesConfigRecord = {
+    tenantId,
+    flags: existing?.flags ?? {},
+    // Omit the key entirely when clearing so the doc shape stays clean.
+    ...(nextValue === null
+      ? { trashRetentionDays: null }
+      : { trashRetentionDays: nextValue }),
+    updatedAt: now,
+    updatedBy: actor ?? null,
+  };
+
+  await data.storeData(TENANT_FEATURES_CONFIG_COLLECTION, tenantId, record);
+  invalidateTenantFeaturesCache(tenantId);
+
+  return { record, previous, next: nextValue, changed };
 }

--- a/functions/test/routes/tenantTrashConfigV1.test.ts
+++ b/functions/test/routes/tenantTrashConfigV1.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import { createTenantTrashConfigRouter } from '../../src/routes/tenantTrashConfigV1.js';
+import type { DataAdapter, QueryFilter } from '../../src/adapters/data/DataAdapter.js';
+import {
+  setMeteringBus,
+  setWebhookDeliveryStore,
+} from '../../src/services/metering/index.js';
+import {
+  MeteringBus,
+  type MeteringSink,
+  type NormalizedMeteringEvent,
+} from '../../src/services/metering/MeteringBus.js';
+import { __resetTenantFeaturesCacheForTests } from '../../src/services/host/tenantFeaturesConfigService.js';
+import {
+  TENANT_FEATURES_CONFIG_COLLECTION,
+  type TenantFeaturesConfigRecord,
+} from '../../src/models/TenantFeaturesConfig.js';
+import { AUDIT_EVENTS_COLLECTION } from '../../src/services/audit/AuditService.js';
+import type { TenantApiKeyScope } from '../../src/models/TenantApiKey.js';
+
+/**
+ * Route tests for `/v1/tenants/:tenantId/config/trash` (issue #183).
+ *
+ * Mirrors the auth-shim pattern used in `tenantOffboardingV1.test.ts`:
+ * an in-process express app installs a fake `req.tenant` based on
+ * `x-test-tenant` / `x-test-scopes` headers, then mounts the real
+ * router so we exercise the actual guards and handlers.
+ */
+
+class MemData implements DataAdapter {
+  public docs = new Map<string, Map<string, any>>();
+  private col(c: string) {
+    let m = this.docs.get(c);
+    if (!m) { m = new Map(); this.docs.set(c, m); }
+    return m;
+  }
+  async storeData(c: string, id: string, d: any) { this.col(c).set(id, d); }
+  async fetchData(c: string, id: string) { return this.col(c).get(id) ?? null; }
+  async queryData(c: string, filters: QueryFilter[]) {
+    return Array.from(this.col(c).values()).filter((d) =>
+      filters.every((f) => (d as any)[f.field] === f.value)
+    );
+  }
+  async updateData(c: string, id: string, u: any) {
+    const cur = this.col(c).get(id);
+    this.col(c).set(id, { ...cur, ...u });
+  }
+  async deleteData(c: string, id: string) { this.col(c).delete(id); }
+  async exists(c: string, id: string) { return this.col(c).has(id); }
+  async listIds(c: string) { return Array.from(this.col(c).keys()); }
+  async getPhoto() { return null; }
+}
+
+class CapturingSink implements MeteringSink {
+  batches: NormalizedMeteringEvent[][] = [];
+  async deliver(events: NormalizedMeteringEvent[]) { this.batches.push(events); }
+  all() { return this.batches.flat(); }
+}
+
+function makeApp(data: DataAdapter, deploymentDefault = 30): express.Express {
+  const app = express();
+  app.use(express.json());
+  // Fake auth shim — synth req.tenant from headers.
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    const id = req.header('x-test-tenant');
+    const scopes = req.header('x-test-scopes');
+    if (id) {
+      req.tenant = {
+        id,
+        scopes: ((scopes ?? '').split(',').filter(Boolean) as TenantApiKeyScope[]),
+        keyId: 'tak_test001',
+      };
+    }
+    next();
+  });
+  app.use(
+    '/v1/tenants',
+    createTenantTrashConfigRouter({
+      dataAdapter: data,
+      resolveDeploymentDefault: () => deploymentDefault,
+    })
+  );
+  return app;
+}
+
+async function request(
+  app: express.Express,
+  method: 'GET' | 'PATCH',
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {}
+): Promise<{ status: number; body: any }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const port = (server.address() as any).port;
+      const init: RequestInit = {
+        method,
+        headers: { 'content-type': 'application/json', ...(opts.headers ?? {}) },
+      };
+      if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+      fetch(`http://127.0.0.1:${port}${path}`, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: any = null;
+          try { parsed = text ? JSON.parse(text) : null; } catch { parsed = text; }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => { server.close(); reject(err); });
+    });
+  });
+}
+
+describe('tenant trash retention config routes (issue #183)', () => {
+  let data: MemData;
+  let app: express.Express;
+  let sink: CapturingSink;
+
+  beforeEach(() => {
+    data = new MemData();
+    app = makeApp(data);
+    sink = new CapturingSink();
+    setWebhookDeliveryStore(null);
+    setMeteringBus(new MeteringBus({ sink, flushIntervalMs: 5, maxBatchSize: 50 }));
+    __resetTenantFeaturesCacheForTests();
+  });
+
+  afterEach(() => {
+    setMeteringBus(null);
+  });
+
+  describe('auth + scope guard', () => {
+    it('401 without host API key', async () => {
+      const res = await request(app, 'GET', '/v1/tenants/t1/config/trash');
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe('HOST_API_KEY_REQUIRED');
+    });
+
+    it('403 on cross-tenant request', async () => {
+      const res = await request(app, 'GET', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't2', 'x-test-scopes': 'tenant.config' },
+      });
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('CROSS_TENANT_FORBIDDEN');
+    });
+
+    it('403 without tenant.config scope', async () => {
+      const res = await request(app, 'GET', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'usage.read' },
+      });
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('INSUFFICIENT_SCOPE');
+    });
+
+    it('401 on PATCH without host API key', async () => {
+      const res = await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+        body: { retentionDays: 7 },
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET', () => {
+    it('returns the deployment default when no override is set', async () => {
+      const res = await request(app, 'GET', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+      });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        tenantId: 't1',
+        retentionDays: 30,
+        override: null,
+        deploymentDefault: 30,
+        source: 'deployment',
+      });
+    });
+
+    it('returns the override when set', async () => {
+      const rec: TenantFeaturesConfigRecord = {
+        tenantId: 't1',
+        flags: {},
+        trashRetentionDays: 7,
+        updatedAt: '2024-01-01T00:00:00Z',
+        updatedBy: 'tak_abc',
+      };
+      await data.storeData(TENANT_FEATURES_CONFIG_COLLECTION, 't1', rec);
+      const res = await request(app, 'GET', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.retentionDays).toBe(7);
+      expect(res.body.override).toBe(7);
+      expect(res.body.source).toBe('tenant');
+      expect(res.body.updatedBy).toBe('tak_abc');
+    });
+  });
+
+  describe('PATCH', () => {
+    it('sets a per-tenant override and returns the new effective value', async () => {
+      const res = await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+        body: { retentionDays: 7 },
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.retentionDays).toBe(7);
+      expect(res.body.override).toBe(7);
+      expect(res.body.source).toBe('tenant');
+      expect(res.body.changed).toBe(true);
+      expect(res.body.previous).toBeNull();
+
+      // Persisted.
+      const stored = (await data.fetchData(
+        TENANT_FEATURES_CONFIG_COLLECTION,
+        't1'
+      )) as TenantFeaturesConfigRecord;
+      expect(stored.trashRetentionDays).toBe(7);
+    });
+
+    it('clears the override on null', async () => {
+      await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+        body: { retentionDays: 21 },
+      });
+      const res = await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+        body: { retentionDays: null },
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.override).toBeNull();
+      expect(res.body.retentionDays).toBe(30);
+      expect(res.body.source).toBe('deployment');
+      expect(res.body.previous).toBe(21);
+    });
+
+    it('rejects out-of-range values (0, negative, >365)', async () => {
+      for (const v of [0, -1, 366, 1000]) {
+        const res = await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+          headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+          body: { retentionDays: v },
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error.code).toBe('INVALID_BODY');
+      }
+    });
+
+    it('rejects non-integer values', async () => {
+      const res = await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+        body: { retentionDays: 3.5 },
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('INVALID_BODY');
+    });
+
+    it('rejects unknown body keys (strict)', async () => {
+      const res = await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+        body: { retentionDays: 7, somethingElse: true },
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('INVALID_BODY');
+    });
+
+    it('emits feature.flag_changed with flag="trash.retentionDays" on transition', async () => {
+      const res = await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+        body: { retentionDays: 90 },
+      });
+      expect(res.status).toBe(200);
+
+      // Allow MeteringBus flushInterval (5ms) to drain.
+      await new Promise((r) => setTimeout(r, 30));
+      const events = sink.all();
+      const flagEvent = events.find(
+        (e) =>
+          e.type === 'feature.flag_changed' &&
+          (e.meta as any)?.feature === 'trash.retentionDays'
+      );
+      expect(flagEvent).toBeDefined();
+      expect((flagEvent!.meta as any).oldValue).toBeNull();
+      expect((flagEvent!.meta as any).newValue).toBe(90);
+    });
+
+    it('does NOT emit feature.flag_changed when the value is unchanged', async () => {
+      // First PATCH sets the value.
+      await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+        body: { retentionDays: 60 },
+      });
+      await new Promise((r) => setTimeout(r, 30));
+      const before = sink
+        .all()
+        .filter(
+          (e) =>
+            e.type === 'feature.flag_changed' &&
+            (e.meta as any)?.feature === 'trash.retentionDays'
+        ).length;
+
+      // Second PATCH with the same value — no transition.
+      const res = await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+        body: { retentionDays: 60 },
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.changed).toBe(false);
+
+      await new Promise((r) => setTimeout(r, 30));
+      const after = sink
+        .all()
+        .filter(
+          (e) =>
+            e.type === 'feature.flag_changed' &&
+            (e.meta as any)?.feature === 'trash.retentionDays'
+        ).length;
+      expect(after).toBe(before);
+    });
+
+    it('records an audit event on transition', async () => {
+      await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+        body: { retentionDays: 14 },
+      });
+      const auditRecords = Array.from(
+        data.docs.get(AUDIT_EVENTS_COLLECTION)?.values() ?? []
+      );
+      const trashAudit = auditRecords.find(
+        (r: any) => r.eventType === 'tenant.config.trash.updated'
+      );
+      expect(trashAudit).toBeDefined();
+      expect((trashAudit as any).tenantId).toBe('t1');
+      expect((trashAudit as any).metadata.next).toBe(14);
+      expect((trashAudit as any).metadata.previous).toBeNull();
+    });
+
+    it('does NOT record an audit event on a no-op PATCH', async () => {
+      await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+        body: { retentionDays: 14 },
+      });
+      const before = Array.from(
+        data.docs.get(AUDIT_EVENTS_COLLECTION)?.values() ?? []
+      ).length;
+
+      await request(app, 'PATCH', '/v1/tenants/t1/config/trash', {
+        headers: { 'x-test-tenant': 't1', 'x-test-scopes': 'tenant.config' },
+        body: { retentionDays: 14 },
+      });
+      const after = Array.from(
+        data.docs.get(AUDIT_EVENTS_COLLECTION)?.values() ?? []
+      ).length;
+      expect(after).toBe(before);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a per-tenant override for the deployment-wide `TRASH_RETENTION_DAYS` default, so hosts reselling AuraPix can offer different Trash retention windows per plan tier (e.g. Free=7d, Pro=30d, Business=90d) without redeploying. Reuses the existing `tenantFeaturesConfig` collection (from #175) and the `tenant.config` host-API-key scope; honored inside the existing per-tenant loop in `purgeTrash`.

## Changes

- **Model** (`functions/src/models/TenantFeaturesConfig.ts`): adds `trashRetentionDays?: number | null` plus `TRASH_RETENTION_MIN_DAYS=1` / `TRASH_RETENTION_MAX_DAYS=365`.
- **Service** (`functions/src/services/host/tenantFeaturesConfigService.ts`): adds `clampTrashRetentionDays`, `resolveTenantTrashRetentionDays(tenantId, default)`, `patchTrashRetention`. Invalid stored overrides fall back to the default with a `warn` log. Patching flags preserves the retention field and vice versa.
- **Purge job** (`functions/src/jobs/purgeTrash.ts` + `functions/src/domain/photos/PhotosService.ts`): `PhotosService.purgeExpired` now accepts an optional async `resolveRetentionDays(tenantId)`. The job wires `resolveTenantTrashRetentionDays` by default; resolver errors are swallowed and the default is used. A `disablePerTenantOverride` flag is exposed for tests/diagnostics.
- **Routes** (`functions/src/routes/tenantTrashConfigV1.ts`): `GET /v1/tenants/:tenantId/config/trash` and `PATCH /v1/tenants/:tenantId/config/trash` behind host API key + `tenant.config` scope. Strict body validation (`{ retentionDays: int|null }`), cross-tenant returns `403`. Mounted at both `/v1/tenants` and `/api/v1/tenants` in `server.ts`.
- **Metering**: PATCH emits a `feature.flag_changed` event with `feature="trash.retentionDays"` plus `oldValue`/`newValue` on transition; no event on no-op.
- **Audit**: PATCH records `tenant.config.trash.updated` audit event with the previous/next values on transition.
- **OpenAPI** (`contracts/openapi/tenant-trash-config.openapi.json`): new contract file. `npm run contract:check` passes (validate + breaking-change).
- **Docs** (`docs/features/library-and-organization.md`): replaces the prior "follow-up" note with a full per-tenant Trash retention section.

## Testing

- Service unit tests (`tenantFeaturesConfigService.test.ts`): clamp boundaries, `resolveTenantTrashRetentionDays` (no doc / override / invalid / null), `patchTrashRetention` (new/unchanged/clear/invalid/missing tenantId/flag-preservation in both directions) — **26 tests pass**.
- Job tests (`purgeTrash.test.ts`): no-override uses deployment default, valid override purges accordingly, higher override retains photos the default would purge, invalid/non-integer override falls back + warns, null override = no override, `disablePerTenantOverride` forces default — **11 tests pass**.
- Route integration tests (`functions/test/routes/tenantTrashConfigV1.test.ts`, mirrors existing host-API-key test shim pattern): 401 without key, 403 cross-tenant, 403 without `tenant.config` scope, GET defaults, GET with override, PATCH set/clear/range-reject/non-integer/strict-body, `feature.flag_changed` emitted on transition + suppressed on no-op, audit event recorded on transition + suppressed on no-op — **15 tests pass**.
- `npm run contract:check` — passes (validate + breaking-change).
- Full functions test suite: 525 pre-existing tests continue to pass; the 12 pre-existing failures in `photosV1.test.ts` and `tenantUsersV1.test.ts` are unrelated to this change (verified by running them on `main` without the patch — identical failures).

## Acceptance criteria

- [x] Schema + Firestore doc shape for `trashRetentionDays` documented in `docs/features/library-and-organization.md`.
- [x] `GET` and `PATCH` endpoints behind a host API key, with validation (`1..365`, integer) and `403` on cross-tenant access.
- [x] `purgeTrash` tests cover: no override (deployment default), valid override, invalid override (falls back + logs warn).
- [x] `feature.flag_changed` metering event emitted on `PATCH` with old/new value.
- [x] OpenAPI contract updated; `npm run contract:check` passes.
- [x] Audit event recorded for each change.

Fixes rwrife/AuraPix#183