### PR TITLE
fix: Photo color labels (Lightroom-style triage)

### DIFF
--- a/contracts/openapi/photos-batch.openapi.json
+++ b/contracts/openapi/photos-batch.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "AuraPix Photos API",
-    "version": "1.0.0",
-    "description": "Contract artifact for photos bulk operations endpoint (issue #142)."
+    "version": "1.1.0",
+    "description": "Contract artifact for photos bulk operations endpoint (issue #142). Issue #184 adds `setColorLabel` for Lightroom-style triage."
   },
   "servers": [
     {
@@ -14,7 +14,7 @@
     "/api/v1/photos:batch": {
       "post": {
         "operationId": "bulkPhotos",
-        "summary": "Bulk photo operations (move / delete / addTag / removeTag)",
+        "summary": "Bulk photo operations (move / delete / addTag / removeTag / setColorLabel)",
         "description": "Performs a single action against many photo ids in one call. Cap is 200 by default (configurable via BULK_PHOTOS_BATCH_MAX). Partial failures are reported per-id; the batch is not aborted on a single failure. Any id belonging to a different tenant rejects the entire batch with cross_tenant_reference.",
         "requestBody": {
           "required": true,
@@ -70,7 +70,7 @@
     "schemas": {
       "BulkAction": {
         "type": "string",
-        "enum": ["move", "delete", "addTag", "removeTag"]
+        "enum": ["move", "delete", "addTag", "removeTag", "setColorLabel"]
       },
       "BulkPhotosRequest": {
         "type": "object",
@@ -88,7 +88,12 @@
             "properties": {
               "albumId": { "type": "string" },
               "tag": { "type": "string" },
-              "libraryId": { "type": "string" }
+              "libraryId": { "type": "string" },
+              "colorLabel": {
+                "type": ["string", "null"],
+                "description": "Lightroom-style color label (issue #184). Required when `action=setColorLabel`. Use `null` to clear the label.",
+                "enum": ["red", "yellow", "green", "blue", "purple", null]
+              }
             }
           }
         }

--- a/contracts/openapi/photos-list.openapi.json
+++ b/contracts/openapi/photos-list.openapi.json
@@ -53,6 +53,15 @@
               "maximum": 200,
               "default": 50
             }
+          },
+          {
+            "name": "colorLabel",
+            "in": "query",
+            "description": "Filter by Lightroom-style color label (issue #184). Accepts a single value (`red|yellow|green|blue|purple`), `uncolored` for photos without a label, or a comma-separated list for OR semantics (e.g. `red,green`). Uses the `libraryId+colorLabel+createdAt` composite Firestore index.",
+            "schema": {
+              "type": "string",
+              "example": "red"
+            }
           }
         ],
         "responses": {
@@ -131,6 +140,18 @@
           },
           "metadata": { "type": "object" },
           "exif": { "$ref": "#/components/schemas/NormalizedExif" },
+          "rating": { "type": "integer", "minimum": 0, "maximum": 5, "default": 0 },
+          "flag": {
+            "type": ["string", "null"],
+            "enum": ["pick", "reject", null],
+            "default": null
+          },
+          "colorLabel": {
+            "type": ["string", "null"],
+            "description": "Lightroom-style color label (issue #184). One of the five standard colors, or `null` for no label.",
+            "enum": ["red", "yellow", "green", "blue", "purple", null],
+            "default": null
+          },
           "createdAt": { "type": "string", "format": "date-time" },
           "updatedAt": { "type": "string", "format": "date-time" }
         },

--- a/contracts/openapi/photos.openapi.json
+++ b/contracts/openapi/photos.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "AuraPix Photos API",
-    "version": "1.2.0",
-    "description": "Soft-delete (Trash) lifecycle (#152) + keyword tags (#173) + photo export (#174) for photos. Mutating endpoints support the `Idempotency-Key` header (issue #162) for safe retries."
+    "version": "1.3.0",
+    "description": "Soft-delete (Trash) lifecycle (#152) + keyword tags (#173) + photo export (#174) for photos. Issue #184 adds Lightroom-style color labels via PATCH /v1/photos/{id}. Mutating endpoints support the `Idempotency-Key` header (issue #162) for safe retries."
   },
   "servers": [
     { "url": "https://api.aurapix.example" }
@@ -26,6 +26,13 @@
             "description": "Comma-separated list of keyword tags. Photos must contain **all** tags (AND semantics). Tags are normalized (trimmed, lowercased) before matching.",
             "schema": { "type": "string" },
             "example": "wedding,print-ready"
+          },
+          {
+            "name": "colorLabel",
+            "in": "query",
+            "description": "Filter by Lightroom-style color label (issue #184). Accepts a single value (`red|yellow|green|blue|purple`), `uncolored` for photos without a label, or a comma-separated list for OR semantics (e.g. `red,green`). Uses the `libraryId+colorLabel+createdAt` Firestore composite index, matching the `rating` filter pattern.",
+            "schema": { "type": "string" },
+            "example": "red,green"
           }
         ],
         "responses": {
@@ -43,6 +50,41 @@
       }
     },
     "/v1/photos/{id}": {
+      "patch": {
+        "operationId": "updatePhoto",
+        "summary": "Partially update photo triage fields (rating, flag, colorLabel)",
+        "description": "Updates one or more triage fields on a single photo. Only the supplied fields are modified; omitted fields are left untouched. Strict enum validation: invalid values return `400` with `INVALID_FIELD_VALUE`. Cross-tenant access returns `403`. Issue #184 introduces the `colorLabel` field; the metering event `photo.tagged` is emitted with `meta.kind=\"colorLabel\"` (or `\"rating\"`/`\"flag\"` for the other axes) so hosts can audit triage activity without a new event type.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/IdempotencyKey" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdatePhotoRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated photo summary",
+            "headers": {
+              "Idempotency-Replayed": { "$ref": "#/components/headers/IdempotencyReplayed" }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PhotoSummary" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "409": { "$ref": "#/components/responses/IdempotencyConflict" }
+        }
+      },
       "delete": {
         "operationId": "trashPhoto",
         "summary": "Soft-delete (Trash) a photo",
@@ -272,8 +314,58 @@
             "description": "Normalized keyword tags. May be empty.",
             "default": []
           },
+          "rating": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 5,
+            "default": 0,
+            "description": "Lightroom-style 0–5 star rating."
+          },
+          "flag": {
+            "type": ["string", "null"],
+            "enum": ["pick", "reject", null],
+            "default": null,
+            "description": "Lightroom-style pick/reject flag."
+          },
+          "colorLabel": {
+            "type": ["string", "null"],
+            "enum": ["red", "yellow", "green", "blue", "purple", null],
+            "default": null,
+            "description": "Lightroom-style color label (issue #184). One of five standard colors, or null."
+          },
           "createdAt": { "type": "string", "format": "date-time" },
           "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "UpdatePhotoRequest": {
+        "type": "object",
+        "description": "Partial photo update. At least one of `rating`, `flag`, `colorLabel`, `tags`, `albumIds`, or `isFavorite` should be supplied; omitting all fields is a no-op. Strict enum validation applies.",
+        "properties": {
+          "rating": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 5,
+            "description": "0 clears the rating."
+          },
+          "flag": {
+            "type": ["string", "null"],
+            "enum": ["pick", "reject", null]
+          },
+          "colorLabel": {
+            "type": ["string", "null"],
+            "enum": ["red", "yellow", "green", "blue", "purple", null],
+            "description": "Lightroom-style color label (issue #184). Pass `null` to clear."
+          },
+          "isFavorite": { "type": "boolean" },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1, "maxLength": 64 },
+            "maxItems": 50
+          },
+          "albumIds": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
         }
       },
       "ListPhotosResponse": {

--- a/contracts/openapi/smart-albums.openapi.json
+++ b/contracts/openapi/smart-albums.openapi.json
@@ -171,6 +171,19 @@
             }
           },
           "flag": { "type": "string", "enum": ["pick", "reject"] },
+          "colorLabel": {
+            "description": "Lightroom-style color label triage filter (issue #184). Accepts a single value or array of values for OR semantics.",
+            "oneOf": [
+              { "type": "string", "enum": ["red", "yellow", "green", "blue", "purple"] },
+              {
+                "type": "array",
+                "items": { "type": "string", "enum": ["red", "yellow", "green", "blue", "purple"] },
+                "minItems": 1,
+                "maxItems": 5,
+                "uniqueItems": true
+              }
+            ]
+          },
           "tags": {
             "type": "array",
             "items": { "type": "string", "minLength": 1, "maxLength": 64 },

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -249,6 +249,24 @@
       ]
     },
     {
+      "collectionGroup": "photos",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "libraryId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "colorLabel",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "webhookDeliveries",
       "queryScope": "COLLECTION",
       "fields": [

--- a/functions/src/domain/photos/PhotosService.ts
+++ b/functions/src/domain/photos/PhotosService.ts
@@ -20,7 +20,16 @@
 
 import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
 import type { StorageAdapter } from '../../adapters/storage/StorageAdapter.js';
-import type { Photo } from '../../models/Photo.js';
+import {
+  isPhotoColorLabel,
+  isPhotoFlag,
+  isPhotoRating,
+  PHOTO_COLOR_LABEL_VALUES,
+  type Photo,
+  type PhotoColorLabel,
+  type PhotoFlag,
+  type PhotoRating,
+} from '../../models/Photo.js';
 import { logger } from '../../utils/logger.js';
 import {
   assertSameTenant,
@@ -53,6 +62,26 @@ export class PhotoNotFoundError extends Error {
     super(`Photo ${photoId} not found`);
     this.name = 'PhotoNotFoundError';
   }
+}
+
+export class TriageValidationError extends Error {
+  public readonly status = 400;
+  public readonly code = 'INVALID_FIELD_VALUE';
+  constructor(message: string) {
+    super(message);
+    this.name = 'TriageValidationError';
+  }
+}
+
+/**
+ * Patch input for {@link PhotosService.updateTriage}. Each field is optional;
+ * supply only the axes you want to mutate. Strict enum validation; invalid
+ * values throw {@link TriageValidationError}. Issue #184 added `colorLabel`.
+ */
+export interface PhotoTriagePatch {
+  rating?: PhotoRating;
+  flag?: PhotoFlag;
+  colorLabel?: PhotoColorLabel;
 }
 
 export class PhotosService {
@@ -267,6 +296,106 @@ export class PhotosService {
     }
 
     return { photo: updated, mutation: result };
+  }
+
+  /**
+   * Apply a Lightroom-style triage patch (rating + flag + colorLabel).
+   * Each field is independently validated against the strict enum and
+   * either persisted (when supplied) or left untouched (when omitted).
+   *
+   * Emits exactly one `photo.tagged` event per mutated axis, with
+   * `meta.kind` set to `rating | flag | colorLabel` (issue #184) so hosts
+   * that already consume `photo.tagged` for activity heuristics see triage
+   * activity without a new event type. No bytes are accounted (labels are
+   * pure metadata).
+   *
+   * @throws {@link PhotoNotFoundError} when the id is unknown.
+   * @throws {@link CrossTenantAccessError} for cross-tenant writes (403).
+   * @throws {@link TriageValidationError} (400) when a value fails strict
+   *   enum validation.
+   */
+  async updateTriage(
+    photoId: string,
+    callerTenantId: TenantId,
+    actor: string | null,
+    patch: PhotoTriagePatch
+  ): Promise<Photo> {
+    const photo = await this.getOwned(photoId, callerTenantId);
+
+    if (patch.rating !== undefined && !isPhotoRating(patch.rating)) {
+      throw new TriageValidationError(
+        `Invalid rating: ${String(patch.rating)} (expected integer 0–5).`
+      );
+    }
+    if (patch.flag !== undefined && !isPhotoFlag(patch.flag)) {
+      throw new TriageValidationError(
+        `Invalid flag: ${String(patch.flag)} (expected 'pick' | 'reject' | null).`
+      );
+    }
+    if (
+      patch.colorLabel !== undefined &&
+      !isPhotoColorLabel(patch.colorLabel)
+    ) {
+      throw new TriageValidationError(
+        `Invalid colorLabel: ${String(
+          patch.colorLabel
+        )} (expected one of ${PHOTO_COLOR_LABEL_VALUES.join(', ')}, or null).`
+      );
+    }
+
+    const updates: Partial<Photo> & { updatedAt: string } = {
+      updatedAt: this.now().toISOString(),
+    };
+    const changed: Array<'rating' | 'flag' | 'colorLabel'> = [];
+
+    if (patch.rating !== undefined && patch.rating !== (photo.rating ?? 0)) {
+      updates.rating = patch.rating;
+      changed.push('rating');
+    }
+    if (patch.flag !== undefined && patch.flag !== (photo.flag ?? null)) {
+      updates.flag = patch.flag;
+      changed.push('flag');
+    }
+    if (
+      patch.colorLabel !== undefined &&
+      patch.colorLabel !== (photo.colorLabel ?? null)
+    ) {
+      updates.colorLabel = patch.colorLabel;
+      changed.push('colorLabel');
+    }
+
+    // No-op short-circuit: nothing changed, don't write or emit.
+    if (changed.length === 0) {
+      return photo;
+    }
+
+    await this.data.updateData<Photo>(PHOTOS_COLLECTION, photoId, updates);
+    const updated: Photo = { ...photo, ...updates };
+
+    // Emit one `photo.tagged` event per mutated axis. Hosts that
+    // care can use `meta.kind` to discriminate; aggregate consumers
+    // still see a stream of mutations.
+    for (const kind of changed) {
+      emitMeteringEvent({
+        tenantId: photo.tenantId ?? DEFAULT_TENANT_ID,
+        type: 'photo.tagged',
+        count: 1,
+        resourceId: photoId,
+        occurredAt: updates.updatedAt,
+        meta: {
+          libraryId: photo.libraryId,
+          actor,
+          kind,
+          ...(kind === 'rating' ? { rating: updates.rating } : {}),
+          ...(kind === 'flag' ? { flag: updates.flag } : {}),
+          ...(kind === 'colorLabel'
+            ? { colorLabel: updates.colorLabel }
+            : {}),
+        },
+      });
+    }
+
+    return updated;
   }
 
   /**

--- a/functions/src/handlers/photos/batch.ts
+++ b/functions/src/handlers/photos/batch.ts
@@ -3,18 +3,20 @@
  *
  * POST /api/v1/photos:batch
  * {
- *   action: "move" | "delete" | "addTag" | "removeTag",
+ *   action: "move" | "delete" | "addTag" | "removeTag" | "setColorLabel",
  *   photoIds: [...],
- *   params?: { albumId?: string, tag?: string }
+ *   params?: { albumId?: string, tag?: string, colorLabel?: PhotoColorLabel }
  * }
  *
- * Implements issue #142:
+ * Implements issue #142 (and #184 for setColorLabel):
  *   - Cap N (configurable via BULK_PHOTOS_BATCH_MAX, default 200), oversize -> 413
  *   - Per-id result array; partial failures do not abort the batch
  *   - Cross-tenant id -> entire batch rejected with 400 cross_tenant_reference
  *   - Per-tenant sliding-window rate limit (default 10/sec, configurable)
  *   - Each affected photo still emits its existing per-photo audit event;
  *     additionally one `bulk.batch` metering event per call.
+ *   - `setColorLabel` additionally emits one `photo.tagged` event per id
+ *     with `meta.kind="colorLabel"` (issue #184).
  */
 import type { Request, Response } from 'express';
 import { randomUUID } from 'node:crypto';
@@ -23,17 +25,28 @@ import {
   DEFAULT_TENANT_ID,
   type TenantId,
 } from '../../domain/tenant/Tenant.js';
+import {
+  isPhotoColorLabel,
+  PHOTO_COLOR_LABEL_VALUES,
+  type PhotoColorLabel,
+} from '../../models/Photo.js';
 import { recordAuditEvent } from '../../services/audit/AuditService.js';
 import { emitMeteringEvent } from '../../services/metering/index.js';
 import { logger } from '../../utils/logger.js';
 
-export type BulkAction = 'move' | 'delete' | 'addTag' | 'removeTag';
+export type BulkAction =
+  | 'move'
+  | 'delete'
+  | 'addTag'
+  | 'removeTag'
+  | 'setColorLabel';
 
 const VALID_ACTIONS: ReadonlySet<string> = new Set([
   'move',
   'delete',
   'addTag',
   'removeTag',
+  'setColorLabel',
 ]);
 
 export interface BulkRequestBody {
@@ -42,6 +55,8 @@ export interface BulkRequestBody {
   params?: {
     albumId?: string;
     tag?: string;
+    libraryId?: string;
+    colorLabel?: PhotoColorLabel;
   };
 }
 
@@ -201,13 +216,28 @@ function parseBody(
       };
     }
   }
+  if (action === 'setColorLabel') {
+    // Strict enum validation (issue #184 acceptance criteria).
+    // `null` is a valid value (it clears the label) so we do NOT reject
+    // it like other params; we just require the key to be supplied.
+    if (!params || !('colorLabel' in params) || !isPhotoColorLabel(params.colorLabel)) {
+      return {
+        ok: false,
+        status: 400,
+        code: 'invalid_params',
+        message: `params.colorLabel must be one of: ${PHOTO_COLOR_LABEL_VALUES.join(
+          ', '
+        )}, or null (action="setColorLabel")`,
+      };
+    }
+  }
 
   return {
     ok: true,
     value: {
       action: action as BulkAction,
       photoIds: photoIds as string[],
-      params,
+      params: params as BulkRequestBody['params'],
     },
   };
 }
@@ -264,6 +294,15 @@ async function applyToPhoto(
       }
       return;
     }
+    case 'setColorLabel': {
+      // Issue #184: idempotent color-label write. Validated upstream.
+      const colorLabel = (params!.colorLabel ?? null) as PhotoColorLabel;
+      await dataAdapter.updateData('photos', photoId, {
+        colorLabel,
+        updatedAt: new Date().toISOString(),
+      });
+      return;
+    }
   }
 }
 
@@ -277,6 +316,8 @@ function auditTypeFor(action: BulkAction): string {
       return 'photo.tag.added';
     case 'removeTag':
       return 'photo.tag.removed';
+    case 'setColorLabel':
+      return 'photo.tagged';
   }
 }
 
@@ -393,6 +434,24 @@ export function createBulkPhotosHandler(deps: {
       }
       try {
         await applyToPhoto(deps.dataAdapter, libraryId, id, action, params);
+        // Issue #184: `setColorLabel` reuses the `photo.tagged` metering
+        // event with `meta.kind="colorLabel"` so hosts that already consume
+        // tagging activity see color-label triage too. No new event type.
+        if (action === 'setColorLabel') {
+          emitMeteringEvent({
+            tenantId: callerTenant,
+            type: 'photo.tagged',
+            count: 1,
+            resourceId: id,
+            meta: {
+              libraryId: libraryId || null,
+              actor: userId,
+              kind: 'colorLabel',
+              colorLabel: (params?.colorLabel ?? null) as PhotoColorLabel,
+              viaBulk: true,
+            },
+          });
+        }
         // Per-photo existing audit event (do NOT collapse).
         await recordAuditEvent(deps.dataAdapter, {
           eventType: auditTypeFor(action),

--- a/functions/src/models/Photo.ts
+++ b/functions/src/models/Photo.ts
@@ -49,6 +49,49 @@ export interface StoragePaths {
 
 export type PhotoSourceType = 'raster' | 'raw';
 
+/** Lightroom-style 0–5 star triage rating. 0 means unrated. */
+export type PhotoRating = 0 | 1 | 2 | 3 | 4 | 5;
+
+/** Lightroom-style pick/reject flag. `null` (default) means unflagged. */
+export type PhotoFlag = 'pick' | 'reject' | null;
+
+/**
+ * Lightroom-style color label (third triage axis, complementing rating + flag).
+ * `null` (default) means no color label is assigned. Issue #184.
+ */
+export type PhotoColorLabel = 'red' | 'yellow' | 'green' | 'blue' | 'purple' | null;
+
+export const PHOTO_RATING_VALUES: readonly PhotoRating[] = [0, 1, 2, 3, 4, 5];
+export const PHOTO_FLAG_VALUES: readonly Exclude<PhotoFlag, null>[] = ['pick', 'reject'];
+export const PHOTO_COLOR_LABEL_VALUES: readonly Exclude<PhotoColorLabel, null>[] = [
+  'red',
+  'yellow',
+  'green',
+  'blue',
+  'purple',
+];
+
+export function isPhotoRating(value: unknown): value is PhotoRating {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    (PHOTO_RATING_VALUES as readonly number[]).includes(value)
+  );
+}
+
+export function isPhotoFlag(value: unknown): value is PhotoFlag {
+  if (value === null) return true;
+  return typeof value === 'string' && (PHOTO_FLAG_VALUES as readonly string[]).includes(value);
+}
+
+export function isPhotoColorLabel(value: unknown): value is PhotoColorLabel {
+  if (value === null) return true;
+  return (
+    typeof value === 'string' &&
+    (PHOTO_COLOR_LABEL_VALUES as readonly string[]).includes(value)
+  );
+}
+
 export interface Photo {
   id: string;
   libraryId: string;
@@ -107,6 +150,22 @@ export interface Photo {
    * treat a missing value as an empty array.
    */
   tags?: string[];
+  /**
+   * Lightroom-style triage rating, 0–5 stars. Optional for backwards
+   * compatibility with photos written before triage rollout; treat a
+   * missing value as 0 (unrated). See issue #141.
+   */
+  rating?: PhotoRating;
+  /**
+   * Lightroom-style pick/reject flag. Optional for backwards compatibility;
+   * treat a missing value as `null` (unflagged). See issue #149.
+   */
+  flag?: PhotoFlag;
+  /**
+   * Lightroom-style color label (third triage axis). Optional for backwards
+   * compatibility; treat a missing value as `null` (no label). See issue #184.
+   */
+  colorLabel?: PhotoColorLabel;
 }
 
 export function createPhotoDocument(
@@ -144,5 +203,8 @@ export function createPhotoDocument(
     trashedAt: null,
     trashedBy: null,
     tags: [],
+    rating: 0,
+    flag: null,
+    colorLabel: null,
   };
 }

--- a/functions/src/routes/photosV1.ts
+++ b/functions/src/routes/photosV1.ts
@@ -1,18 +1,21 @@
 /**
- * /v1/photos — Trash (soft-delete) + tag mutation endpoints.
+ * /v1/photos — Trash (soft-delete) + tag mutation + triage endpoints.
  *
  * Routes:
+ *   GET    /v1/photos              → list active photos for caller's tenant  (#152)
+ *   GET    /v1/photos?trashed=true → list trashed photos for caller's tenant (#152)
+ *   GET    /v1/photos?tags=a,b     → narrow list by tags (AND semantics)     (#173)
+ *   GET    /v1/photos?colorLabel=  → narrow list by color label             (#184)
+ *   PATCH  /v1/photos/:id          → set rating/flag/colorLabel triage      (#141/#149/#184)
  *   DELETE /v1/photos/:id          → soft-delete (sets trashedAt)            (#152)
  *   POST   /v1/photos/:id/restore  → clears trashedAt                        (#152)
- *   GET    /v1/photos?trashed=true → list trashed photos for caller's tenant (#152)
- *   GET    /v1/photos              → list active photos for caller's tenant  (#152)
- *   GET    /v1/photos?tags=a,b     → narrow list by tags (AND semantics)     (#173)
  *   POST   /v1/photos/:id/tags     → add/remove tags on a photo              (#173)
  */
 import { randomUUID } from 'node:crypto';
 import { Router, type Request, type Response } from 'express';
 import {
   PhotoNotFoundError,
+  TriageValidationError,
   type PhotosService,
 } from '../domain/photos/PhotosService.js';
 import {
@@ -24,6 +27,11 @@ import {
   parseTagsQuery,
   TagValidationError,
 } from '../domain/photos/tagNormalization.js';
+import {
+  isPhotoColorLabel,
+  PHOTO_COLOR_LABEL_VALUES,
+  type PhotoColorLabel,
+} from '../models/Photo.js';
 
 function sendError(
   res: Response,
@@ -50,6 +58,66 @@ function callerActor(req: Request): string | null {
   return req.user?.uid ?? null;
 }
 
+/**
+ * Parse the `?colorLabel=` query parameter. Accepts a single value
+ * (`red|yellow|green|blue|purple`), `uncolored` for null-label rows, or
+ * a comma-separated list for OR semantics. Returns `null` when the query
+ * is absent or empty. Throws an Error with a human-readable message on
+ * invalid values; callers translate to 400.
+ */
+export function parseColorLabelQuery(
+  raw: unknown
+):
+  | null
+  | { kind: 'value'; value: Exclude<PhotoColorLabel, null> }
+  | { kind: 'uncolored' }
+  | { kind: 'any'; values: Exclude<PhotoColorLabel, null>[] } {
+  if (raw === undefined || raw === null) return null;
+  const str = String(raw).trim();
+  if (!str) return null;
+
+  const parts = str
+    .split(',')
+    .map((p) => p.trim().toLowerCase())
+    .filter(Boolean);
+  if (parts.length === 0) return null;
+
+  if (parts.length === 1) {
+    const only = parts[0];
+    if (only === 'uncolored') return { kind: 'uncolored' };
+    if (!isPhotoColorLabel(only) || only === null) {
+      throw new Error(
+        `Invalid colorLabel value: ${only}. Expected one of ${PHOTO_COLOR_LABEL_VALUES.join(
+          ', '
+        )}, or 'uncolored'.`
+      );
+    }
+    return { kind: 'value', value: only };
+  }
+
+  const seen = new Set<string>();
+  const values: Exclude<PhotoColorLabel, null>[] = [];
+  for (const p of parts) {
+    if (p === 'uncolored') {
+      throw new Error(
+        `colorLabel filter cannot combine 'uncolored' with other values.`
+      );
+    }
+    if (!isPhotoColorLabel(p) || p === null) {
+      throw new Error(
+        `Invalid colorLabel value: ${p}. Expected one of ${PHOTO_COLOR_LABEL_VALUES.join(
+          ', '
+        )}.`
+      );
+    }
+    if (!seen.has(p)) {
+      seen.add(p);
+      values.push(p);
+    }
+  }
+  return { kind: 'any', values };
+}
+
 export function createPhotosV1Router(photos: PhotosService): Router {
   const router = Router();
 
@@ -70,9 +138,32 @@ export function createPhotosV1Router(photos: PhotosService): Router {
         }
         throw err;
       }
-      const items = tags.length
+      let colorLabelFilter: ReturnType<typeof parseColorLabelQuery> = null;
+      try {
+        colorLabelFilter = parseColorLabelQuery(req.query.colorLabel);
+      } catch (err) {
+        sendError(
+          res,
+          400,
+          'INVALID_FIELD_VALUE',
+          err instanceof Error ? err.message : 'invalid colorLabel filter'
+        );
+        return;
+      }
+      const baseList = tags.length
         ? await photos.list(callerTenant(req), { trashed, tags })
         : await photos.list(callerTenant(req), { trashed });
+      const items = colorLabelFilter
+        ? baseList.filter((p) => {
+            const filter = colorLabelFilter!;
+            const label = p.colorLabel ?? null;
+            if (filter.kind === 'uncolored') return label === null;
+            if (filter.kind === 'value') {
+              return label === filter.value;
+            }
+            return label !== null && filter.values.includes(label);
+          })
+        : baseList;
       res.json({
         photos: items.map((p) => ({
           id: p.id,
@@ -82,11 +173,89 @@ export function createPhotosV1Router(photos: PhotosService): Router {
           trashedAt: p.trashedAt ?? null,
           trashedBy: p.trashedBy ?? null,
           tags: p.tags ?? [],
+          rating: p.rating ?? 0,
+          flag: p.flag ?? null,
+          colorLabel: p.colorLabel ?? null,
           createdAt: p.createdAt,
           updatedAt: p.updatedAt,
         })),
       });
     } catch (err) {
+      next(err);
+    }
+  });
+
+  // PATCH /v1/photos/:id — set rating / flag / colorLabel (issue #184).
+  router.patch('/:id', async (req, res, next) => {
+    try {
+      if (!req.user) {
+        sendError(res, 401, 'AUTH_REQUIRED', 'Authentication required');
+        return;
+      }
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      // Only triage fields are accepted here; other PATCHes (tags / favorite)
+      // go through dedicated routes for now.
+      const patch: {
+        rating?: number;
+        flag?: unknown;
+        colorLabel?: unknown;
+      } = {};
+      if (Object.prototype.hasOwnProperty.call(body, 'rating')) {
+        patch.rating = body.rating as number;
+      }
+      if (Object.prototype.hasOwnProperty.call(body, 'flag')) {
+        patch.flag = body.flag;
+      }
+      if (Object.prototype.hasOwnProperty.call(body, 'colorLabel')) {
+        patch.colorLabel = body.colorLabel;
+      }
+      if (
+        patch.rating === undefined &&
+        patch.flag === undefined &&
+        patch.colorLabel === undefined
+      ) {
+        sendError(
+          res,
+          400,
+          'INVALID_FIELD_VALUE',
+          'PATCH /v1/photos/:id requires at least one of: rating, flag, colorLabel.'
+        );
+        return;
+      }
+      const updated = await photos.updateTriage(
+        req.params.id,
+        callerTenant(req),
+        callerActor(req),
+        // updateTriage performs strict per-field validation.
+        patch as Parameters<typeof photos.updateTriage>[3]
+      );
+      res.status(200).json({
+        id: updated.id,
+        libraryId: updated.libraryId,
+        originalName: updated.originalName,
+        status: updated.status,
+        trashedAt: updated.trashedAt ?? null,
+        trashedBy: updated.trashedBy ?? null,
+        tags: updated.tags ?? [],
+        rating: updated.rating ?? 0,
+        flag: updated.flag ?? null,
+        colorLabel: updated.colorLabel ?? null,
+        createdAt: updated.createdAt,
+        updatedAt: updated.updatedAt,
+      });
+    } catch (err) {
+      if (err instanceof PhotoNotFoundError) {
+        sendError(res, 404, 'PHOTO_NOT_FOUND', err.message);
+        return;
+      }
+      if (err instanceof CrossTenantAccessError) {
+        sendError(res, 403, err.code, err.message);
+        return;
+      }
+      if (err instanceof TriageValidationError) {
+        sendError(res, 400, err.code, err.message);
+        return;
+      }
       next(err);
     }
   });

--- a/functions/src/services/metering/eventCatalog.ts
+++ b/functions/src/services/metering/eventCatalog.ts
@@ -303,12 +303,20 @@ export const EVENT_CATALOG = [
     version: 1,
     billable: false,
     description:
-      'A photo had tags added or removed. One event per mutation, not per tag.',
+      'A photo had tags, rating, flag, or color label changed. One event per mutation, not per tag. Issue #184 added `meta.kind` to disambiguate (`tag` | `rating` | `flag` | `colorLabel`).',
     schema: metaSchema({
       libraryId: S_STRING,
       actor: S_STRING,
       added: { type: 'array', items: S_STRING },
       removed: { type: 'array', items: S_STRING },
+      kind: { type: 'string', enum: ['tag', 'rating', 'flag', 'colorLabel'] },
+      rating: { type: 'integer', minimum: 0, maximum: 5 },
+      flag: { type: ['string', 'null'], enum: ['pick', 'reject', null] },
+      colorLabel: {
+        type: ['string', 'null'],
+        enum: ['red', 'yellow', 'green', 'blue', 'purple', null],
+      },
+      viaBulk: S_BOOLEAN,
     }),
   },
   {

--- a/src/adapters/library/FirebaseLibraryService.ts
+++ b/src/adapters/library/FirebaseLibraryService.ts
@@ -23,8 +23,10 @@ import {
 } from 'firebase/storage';
 import type { LibraryService } from '../../domain/library/contract';
 import {
+  isPhotoColorLabel,
   isPhotoFlag,
   isPhotoRating,
+  PHOTO_COLOR_LABEL_VALUES,
   type AddPhotoInput,
   type BulkAddToAlbumInput,
   type BulkAddToAlbumResult,
@@ -113,6 +115,32 @@ export class FirebaseLibraryService implements LibraryService {
           throw new Error(`Invalid flag: ${String(input.flag)}.`);
         }
         constraints.push(where('flag', '==', input.flag));
+      }
+    }
+
+    // Filter by color label (composite index: tenantId/libraryId, colorLabel) — issue #184
+    if (input.colorLabel !== undefined) {
+      if (Array.isArray(input.colorLabel)) {
+        if (input.colorLabel.length === 0) {
+          throw new Error('Invalid colorLabel filter: empty array.');
+        }
+        for (const value of input.colorLabel) {
+          if (!isPhotoColorLabel(value) || value === null) {
+            throw new Error(
+              `Invalid colorLabel filter value: ${String(value)} (expected one of ${PHOTO_COLOR_LABEL_VALUES.join(
+                ', '
+              )}).`
+            );
+          }
+        }
+        constraints.push(where('colorLabel', 'in', input.colorLabel));
+      } else if (input.colorLabel === 'uncolored') {
+        constraints.push(where('colorLabel', '==', null));
+      } else {
+        if (!isPhotoColorLabel(input.colorLabel)) {
+          throw new Error(`Invalid colorLabel: ${String(input.colorLabel)}.`);
+        }
+        constraints.push(where('colorLabel', '==', input.colorLabel));
       }
     }
 
@@ -226,6 +254,7 @@ export class FirebaseLibraryService implements LibraryService {
       tags: [],
       rating: 0,
       flag: null,
+      colorLabel: null,
     };
 
     const docRef = await addDoc(collection(this.db, COLLECTIONS.PHOTOS), photoData);
@@ -291,6 +320,17 @@ export class FirebaseLibraryService implements LibraryService {
         throw new Error(`Invalid flag: ${String(input.flag)} (expected 'pick' | 'reject' | null).`);
       }
       updates.flag = input.flag;
+    }
+
+    if (input.colorLabel !== undefined) {
+      if (!isPhotoColorLabel(input.colorLabel)) {
+        throw new Error(
+          `Invalid colorLabel: ${String(input.colorLabel)} (expected one of ${PHOTO_COLOR_LABEL_VALUES.join(
+            ', '
+          )}, or null).`
+        );
+      }
+      updates.colorLabel = input.colorLabel;
     }
 
     await updateDoc(docRef, updates);
@@ -444,6 +484,7 @@ export class FirebaseLibraryService implements LibraryService {
       tags: data.tags || [],
       rating: isPhotoRating(data.rating) ? data.rating : 0,
       flag: isPhotoFlag(data.flag) ? data.flag : null,
+      colorLabel: isPhotoColorLabel(data.colorLabel) ? data.colorLabel : null,
     };
   }
 }

--- a/src/adapters/library/inMemoryLibraryService.test.ts
+++ b/src/adapters/library/inMemoryLibraryService.test.ts
@@ -488,4 +488,246 @@ describe('InMemoryLibraryService', () => {
       expect(myPicks.photos.find((p) => p.id === theirs.id)).toBeUndefined();
     });
   });
+
+  describe('triage (colorLabel — issue #184)', () => {
+    it('defaults new photos to colorLabel=null', async () => {
+      const svc = new InMemoryLibraryService();
+      const photo = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'fresh.jpg',
+        dataUrl: 'data:image/jpeg;base64,fresh',
+      });
+      expect(photo.colorLabel).toBeNull();
+    });
+
+    it('sets and clears colorLabel through updatePhoto', async () => {
+      const svc = new InMemoryLibraryService();
+      const photo = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'colorme.jpg',
+        dataUrl: 'data:image/jpeg;base64,colorme',
+      });
+
+      const red = await svc.updatePhoto(photo.id, { colorLabel: 'red' });
+      expect(red.colorLabel).toBe('red');
+
+      const blue = await svc.updatePhoto(photo.id, { colorLabel: 'blue' });
+      expect(blue.colorLabel).toBe('blue');
+
+      const cleared = await svc.updatePhoto(photo.id, { colorLabel: null });
+      expect(cleared.colorLabel).toBeNull();
+    });
+
+    it('rejects invalid colorLabel values with strict enum validation', async () => {
+      const svc = new InMemoryLibraryService();
+      const photo = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'bad-color.jpg',
+        dataUrl: 'data:image/jpeg;base64,badcolor',
+      });
+
+      await expect(
+        svc.updatePhoto(photo.id, {
+          colorLabel: 'orange' as unknown as 'red',
+        })
+      ).rejects.toThrow(/Invalid colorLabel/);
+      await expect(
+        svc.updatePhoto(photo.id, { colorLabel: '' as unknown as 'red' })
+      ).rejects.toThrow(/Invalid colorLabel/);
+      await expect(
+        svc.updatePhoto(photo.id, { colorLabel: 42 as unknown as 'red' })
+      ).rejects.toThrow(/Invalid colorLabel/);
+    });
+
+    it('filters by a single colorLabel value', async () => {
+      const svc = new InMemoryLibraryService();
+      const red = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'red.jpg',
+        dataUrl: 'data:image/jpeg;base64,red',
+      });
+      const green = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'green.jpg',
+        dataUrl: 'data:image/jpeg;base64,green',
+      });
+      const none = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'none.jpg',
+        dataUrl: 'data:image/jpeg;base64,none',
+      });
+
+      await svc.updatePhoto(red.id, { colorLabel: 'red' });
+      await svc.updatePhoto(green.id, { colorLabel: 'green' });
+
+      const reds = await svc.listPhotos({
+        libraryId: LIBRARY_ID,
+        colorLabel: 'red',
+      });
+      expect(reds.photos.map((p) => p.id)).toEqual([red.id]);
+
+      const uncolored = await svc.listPhotos({
+        libraryId: LIBRARY_ID,
+        colorLabel: 'uncolored',
+      });
+      expect(uncolored.photos.map((p) => p.id)).toEqual([none.id]);
+    });
+
+    it('filters by multiple colorLabel values with OR semantics', async () => {
+      const svc = new InMemoryLibraryService();
+      const red = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'red.jpg',
+        dataUrl: 'data:image/jpeg;base64,red',
+      });
+      const green = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'green.jpg',
+        dataUrl: 'data:image/jpeg;base64,green',
+      });
+      const blue = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'blue.jpg',
+        dataUrl: 'data:image/jpeg;base64,blue',
+      });
+
+      await svc.updatePhoto(red.id, { colorLabel: 'red' });
+      await svc.updatePhoto(green.id, { colorLabel: 'green' });
+      await svc.updatePhoto(blue.id, { colorLabel: 'blue' });
+
+      const redOrGreen = await svc.listPhotos({
+        libraryId: LIBRARY_ID,
+        colorLabel: ['red', 'green'],
+      });
+      expect(new Set(redOrGreen.photos.map((p) => p.id))).toEqual(
+        new Set([red.id, green.id])
+      );
+      expect(redOrGreen.photos.find((p) => p.id === blue.id)).toBeUndefined();
+    });
+
+    it('rejects an invalid colorLabel filter value', async () => {
+      const svc = new InMemoryLibraryService();
+      await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'a.jpg',
+        dataUrl: 'data:image/jpeg;base64,a',
+      });
+
+      await expect(
+        svc.listPhotos({
+          libraryId: LIBRARY_ID,
+          colorLabel: 'orange' as unknown as 'red',
+        })
+      ).rejects.toThrow(/Invalid colorLabel/);
+      await expect(
+        svc.listPhotos({
+          libraryId: LIBRARY_ID,
+          colorLabel: [
+            'red',
+            'orange' as unknown as 'green',
+          ] as readonly Exclude<
+            import('../../domain/library/types').PhotoColorLabel,
+            null
+          >[],
+        })
+      ).rejects.toThrow(/Invalid colorLabel/);
+    });
+
+    it('scopes colorLabel filters per library (cross-tenant isolation)', async () => {
+      const svc = new InMemoryLibraryService();
+      const otherLibrary = 'library-other-user';
+
+      const mine = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'mine.jpg',
+        dataUrl: 'data:image/jpeg;base64,mine',
+      });
+      const theirs = await svc.addPhoto({
+        libraryId: otherLibrary,
+        originalName: 'theirs.jpg',
+        dataUrl: 'data:image/jpeg;base64,theirs',
+      });
+      await svc.updatePhoto(mine.id, { colorLabel: 'red' });
+      await svc.updatePhoto(theirs.id, { colorLabel: 'red' });
+
+      const myReds = await svc.listPhotos({
+        libraryId: LIBRARY_ID,
+        colorLabel: 'red',
+      });
+      expect(myReds.photos.map((p) => p.id)).toEqual([mine.id]);
+      expect(myReds.photos.find((p) => p.id === theirs.id)).toBeUndefined();
+    });
+
+    it('combines colorLabel with rating + flag filters', async () => {
+      const svc = new InMemoryLibraryService();
+      const target = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'target.jpg',
+        dataUrl: 'data:image/jpeg;base64,target',
+      });
+      const wrongRating = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'wrong-rating.jpg',
+        dataUrl: 'data:image/jpeg;base64,wr',
+      });
+      const wrongLabel = await svc.addPhoto({
+        libraryId: LIBRARY_ID,
+        originalName: 'wrong-label.jpg',
+        dataUrl: 'data:image/jpeg;base64,wl',
+      });
+
+      await svc.updatePhoto(target.id, {
+        rating: 5,
+        flag: 'pick',
+        colorLabel: 'green',
+      });
+      await svc.updatePhoto(wrongRating.id, {
+        rating: 2,
+        flag: 'pick',
+        colorLabel: 'green',
+      });
+      await svc.updatePhoto(wrongLabel.id, {
+        rating: 5,
+        flag: 'pick',
+        colorLabel: 'red',
+      });
+
+      const results = await svc.listPhotos({
+        libraryId: LIBRARY_ID,
+        minRating: 5,
+        flag: 'pick',
+        colorLabel: 'green',
+      });
+      expect(results.photos.map((p) => p.id)).toEqual([target.id]);
+    });
+
+    it('backfills colorLabel=null when loading legacy records from storage', async () => {
+      // Simulate a legacy record that pre-dates the colorLabel field.
+      const legacy = {
+        id: 'photo-legacy',
+        libraryId: LIBRARY_ID,
+        albumIds: [],
+        originalName: 'legacy.jpg',
+        storagePath: 'data:image/jpeg;base64,legacy',
+        thumbnailPath: 'data:image/jpeg;base64,legacy',
+        status: 'ready',
+        metadata: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        isFavorite: false,
+        tags: [],
+        rating: 3,
+        flag: 'pick',
+        // colorLabel intentionally omitted
+      };
+      localStorage.setItem('aurapix:local:photos', JSON.stringify([legacy]));
+
+      const svc = new InMemoryLibraryService();
+      const loaded = await svc.getPhoto('photo-legacy');
+      expect(loaded).not.toBeNull();
+      expect(loaded?.colorLabel).toBeNull();
+      expect(loaded?.rating).toBe(3);
+      expect(loaded?.flag).toBe('pick');
+    });
+  });
 });

--- a/src/adapters/library/inMemoryLibraryService.ts
+++ b/src/adapters/library/inMemoryLibraryService.ts
@@ -1,7 +1,9 @@
 import type { LibraryService } from '../../domain/library/contract';
 import {
+  isPhotoColorLabel,
   isPhotoFlag,
   isPhotoRating,
+  PHOTO_COLOR_LABEL_VALUES,
   type AddPhotoInput,
   type BulkAddToAlbumInput,
   type BulkAddToAlbumResult,
@@ -11,6 +13,7 @@ import {
   type LibraryQuickCollection,
   type LibrarySort,
   type Photo,
+  type PhotoColorLabel,
   type UpdatePhotoInput,
 } from '../../domain/library/types';
 
@@ -31,6 +34,7 @@ function loadPhotos(): Photo[] {
       ...photo,
       rating: isPhotoRating(photo.rating) ? photo.rating : 0,
       flag: isPhotoFlag(photo.flag) ? photo.flag : null,
+      colorLabel: isPhotoColorLabel(photo.colorLabel) ? photo.colorLabel : null,
     }));
   } catch {
     return [];
@@ -138,6 +142,35 @@ export class InMemoryLibraryService implements LibraryService {
           throw new Error(`Invalid flag: ${String(input.flag)}.`);
         }
         results = results.filter((p) => (p.flag ?? null) === input.flag);
+      }
+    }
+
+    if (input.colorLabel !== undefined) {
+      if (Array.isArray(input.colorLabel)) {
+        if (input.colorLabel.length === 0) {
+          throw new Error('Invalid colorLabel filter: empty array.');
+        }
+        for (const value of input.colorLabel) {
+          if (!isPhotoColorLabel(value) || value === null) {
+            throw new Error(
+              `Invalid colorLabel filter value: ${String(value)} (expected one of ${PHOTO_COLOR_LABEL_VALUES.join(
+                ', '
+              )}).`
+            );
+          }
+        }
+        const allowed = new Set<string>(input.colorLabel as string[]);
+        results = results.filter((p) => {
+          const label = p.colorLabel ?? null;
+          return label !== null && allowed.has(label);
+        });
+      } else if (input.colorLabel === 'uncolored') {
+        results = results.filter((p) => (p.colorLabel ?? null) === null);
+      } else {
+        if (!isPhotoColorLabel(input.colorLabel)) {
+          throw new Error(`Invalid colorLabel: ${String(input.colorLabel)}.`);
+        }
+        results = results.filter((p) => (p.colorLabel ?? null) === input.colorLabel);
       }
     }
 
@@ -262,6 +295,7 @@ export class InMemoryLibraryService implements LibraryService {
       tags: [],
       rating: 0,
       flag: null,
+      colorLabel: null,
     };
 
     this.photos = [photo, ...this.photos];
@@ -281,6 +315,14 @@ export class InMemoryLibraryService implements LibraryService {
       throw new Error(`Invalid flag: ${String(input.flag)} (expected 'pick' | 'reject' | null).`);
     }
 
+    if (input.colorLabel !== undefined && !isPhotoColorLabel(input.colorLabel)) {
+      throw new Error(
+        `Invalid colorLabel: ${String(input.colorLabel)} (expected one of ${PHOTO_COLOR_LABEL_VALUES.join(
+          ', '
+        )}, or null).`
+      );
+    }
+
     const updated: Photo = {
       ...this.photos[idx],
       ...(input.isFavorite !== undefined && { isFavorite: input.isFavorite }),
@@ -288,6 +330,7 @@ export class InMemoryLibraryService implements LibraryService {
       ...(input.albumIds !== undefined && { albumIds: input.albumIds }),
       ...(input.rating !== undefined && { rating: input.rating }),
       ...(input.flag !== undefined && { flag: input.flag }),
+      ...(input.colorLabel !== undefined && { colorLabel: input.colorLabel as PhotoColorLabel }),
       updatedAt: new Date().toISOString(),
     };
 

--- a/src/components/PhotoGallery.tsx
+++ b/src/components/PhotoGallery.tsx
@@ -350,6 +350,33 @@ export function PhotoGallery({
                   )}
                 </div>
               )}
+              {photo.colorLabel && (
+                <div
+                  className={`gallery-tile-color-label gallery-tile-color-label--${photo.colorLabel}`}
+                  aria-label={`Color label ${photo.colorLabel}`}
+                  title={`Color label: ${photo.colorLabel}`}
+                  style={{
+                    position: 'absolute',
+                    top: 4,
+                    left: 4,
+                    width: 12,
+                    height: 12,
+                    borderRadius: '50%',
+                    pointerEvents: 'none',
+                    boxShadow: '0 0 0 1.5px rgba(0,0,0,0.55)',
+                    backgroundColor:
+                      photo.colorLabel === 'red'
+                        ? '#e0524a'
+                        : photo.colorLabel === 'yellow'
+                        ? '#e8c547'
+                        : photo.colorLabel === 'green'
+                        ? '#4caf50'
+                        : photo.colorLabel === 'blue'
+                        ? '#3a8dde'
+                        : '#9b59b6',
+                  }}
+                />
+              )}
               {mode === 'large' && <p className="gallery-tile-name">{photo.originalName}</p>}
             </div>
           );

--- a/src/components/toolbar/examples/viewerToolbarConfig.tsx
+++ b/src/components/toolbar/examples/viewerToolbarConfig.tsx
@@ -1,10 +1,12 @@
-import type { Photo } from '../../../domain/library/types';
+import type { Photo, PhotoColorLabel } from '../../../domain/library/types';
+import { PHOTO_COLOR_LABEL_VALUES } from '../../../domain/library/types';
 import type { ToolbarButton, ModalContentProps } from '../types';
 
 interface ViewerToolbarConfigProps {
   currentPhoto: Photo;
   onToggleFavorite: () => void;
   onDelete: () => void;
+  onSetColorLabel?: (label: PhotoColorLabel) => void;
   brightness: number;
   setBrightness: (v: number) => void;
   contrast: number;
@@ -12,6 +14,15 @@ interface ViewerToolbarConfigProps {
   saturation: number;
   setSaturation: (v: number) => void;
 }
+
+/** CSS color tokens for each label swatch (issue #184). */
+const COLOR_LABEL_HEX: Record<Exclude<PhotoColorLabel, null>, string> = {
+  red: '#e0524a',
+  yellow: '#e8c547',
+  green: '#4caf50',
+  blue: '#3a8dde',
+  purple: '#9b59b6',
+};
 
 /**
  * Example configuration for viewer toolbar
@@ -21,6 +32,7 @@ export function createViewerToolbarConfig({
   currentPhoto,
   onToggleFavorite,
   onDelete,
+  onSetColorLabel,
   brightness,
   setBrightness,
   contrast,
@@ -28,6 +40,7 @@ export function createViewerToolbarConfig({
   saturation,
   setSaturation,
 }: ViewerToolbarConfigProps): ToolbarButton[] {
+  const currentLabel: PhotoColorLabel = currentPhoto.colorLabel ?? null;
   return [
     // Modal button example: Delete with confirmation
     {
@@ -98,6 +111,52 @@ export function createViewerToolbarConfig({
       icon: '💬',
       title: 'Comments',
       panelContent: <p className="state-message">Comments tools coming soon.</p>,
+    },
+
+    // Panel button: Color label (Lightroom-style triage, issue #184)
+    {
+      type: 'panel',
+      id: 'colorLabel',
+      icon: '●',
+      title: currentLabel
+        ? `Color label: ${currentLabel}`
+        : 'Color label',
+      className: currentLabel
+        ? `btn-ghost color-label-toolbar color-label-toolbar--${currentLabel}`
+        : 'btn-ghost color-label-toolbar',
+      panelContent: (
+        <div className="color-label-picker" role="group" aria-label="Color label">
+          <p className="state-message">Color label</p>
+          <div className="color-label-swatches">
+            {PHOTO_COLOR_LABEL_VALUES.map((label) => (
+              <button
+                key={label}
+                type="button"
+                aria-label={`Set color label to ${label}`}
+                aria-pressed={currentLabel === label}
+                className={`color-label-swatch ${
+                  currentLabel === label ? 'is-active' : ''
+                }`}
+                style={{ backgroundColor: COLOR_LABEL_HEX[label] }}
+                onClick={() =>
+                  onSetColorLabel?.(currentLabel === label ? null : label)
+                }
+              />
+            ))}
+            <button
+              type="button"
+              aria-label="Clear color label"
+              aria-pressed={currentLabel === null}
+              className={`color-label-swatch color-label-swatch--clear ${
+                currentLabel === null ? 'is-active' : ''
+              }`}
+              onClick={() => onSetColorLabel?.(null)}
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      ),
     },
 
     // Panel button example: Tags

--- a/src/domain/library/types.ts
+++ b/src/domain/library/types.ts
@@ -6,11 +6,26 @@ export type PhotoRating = 0 | 1 | 2 | 3 | 4 | 5;
 /** Lightroom-style pick/reject flag; `null` (default) means unflagged. */
 export type PhotoFlag = 'pick' | 'reject' | null;
 
+/**
+ * Lightroom-style color label (third triage axis, complementing rating + flag).
+ * `null` (default) means no color label is assigned. Issue #184.
+ */
+export type PhotoColorLabel = 'red' | 'yellow' | 'green' | 'blue' | 'purple' | null;
+
 /** Allowed values for {@link PhotoRating}. Useful for validation. */
 export const PHOTO_RATING_VALUES: readonly PhotoRating[] = [0, 1, 2, 3, 4, 5];
 
 /** Allowed non-null values for {@link PhotoFlag}. Useful for validation. */
 export const PHOTO_FLAG_VALUES: readonly Exclude<PhotoFlag, null>[] = ['pick', 'reject'];
+
+/** Allowed non-null values for {@link PhotoColorLabel}. Useful for validation. */
+export const PHOTO_COLOR_LABEL_VALUES: readonly Exclude<PhotoColorLabel, null>[] = [
+  'red',
+  'yellow',
+  'green',
+  'blue',
+  'purple',
+];
 
 export function isPhotoRating(value: unknown): value is PhotoRating {
   return (
@@ -23,6 +38,14 @@ export function isPhotoRating(value: unknown): value is PhotoRating {
 export function isPhotoFlag(value: unknown): value is PhotoFlag {
   if (value === null) return true;
   return typeof value === 'string' && (PHOTO_FLAG_VALUES as readonly string[]).includes(value);
+}
+
+export function isPhotoColorLabel(value: unknown): value is PhotoColorLabel {
+  if (value === null) return true;
+  return (
+    typeof value === 'string' &&
+    (PHOTO_COLOR_LABEL_VALUES as readonly string[]).includes(value)
+  );
 }
 
 export interface PhotoMetadata {
@@ -57,6 +80,11 @@ export interface Photo {
    * Lightroom-style pick/reject flag. `null` (default) means unflagged.
    */
   flag: PhotoFlag;
+  /**
+   * Lightroom-style color label (third triage axis). `null` (default) means
+   * no color label is assigned. Issue #184.
+   */
+  colorLabel: PhotoColorLabel;
 }
 
 export interface MetadataFilterInput {
@@ -96,6 +124,11 @@ export interface ListPhotosInput {
    * Filter by triage flag. Use `'unflagged'` to request rows with `flag === null`.
    */
   flag?: PhotoFlag | 'unflagged';
+  /**
+   * Filter by color label (issue #184). Pass one or more values to match any of them
+   * (OR semantics). Use `'uncolored'` to request rows with `colorLabel === null`.
+   */
+  colorLabel?: PhotoColorLabel | 'uncolored' | readonly Exclude<PhotoColorLabel, null>[];
   pageSize?: number;
   pageToken?: string;
 }
@@ -130,6 +163,11 @@ export interface UpdatePhotoInput {
   rating?: PhotoRating;
   /** Triage flag (`'pick' | 'reject' | null`). Validated by the service. */
   flag?: PhotoFlag;
+  /**
+   * Triage color label (`'red' | 'yellow' | 'green' | 'blue' | 'purple' | null`).
+   * Validated by the service. Issue #184.
+   */
+  colorLabel?: PhotoColorLabel;
 }
 
 export type BulkAddToAlbumErrorCode = 'not_found' | 'already_in_album';

--- a/src/features/library/useLibrary.ts
+++ b/src/features/library/useLibrary.ts
@@ -5,6 +5,7 @@ import type {
   LibrarySort,
   MetadataFilterInput,
   Photo,
+  PhotoColorLabel,
   PhotoFlag,
   PhotoRating,
 } from '../../domain/library/types';
@@ -25,6 +26,7 @@ interface UseLibraryReturn extends UseLibraryState {
   toggleFavorite(photoId: string): Promise<void>;
   setRating(photoId: string, rating: PhotoRating): Promise<void>;
   setFlag(photoId: string, flag: PhotoFlag): Promise<void>;
+  setColorLabel(photoId: string, colorLabel: PhotoColorLabel): Promise<void>;
   setTags(photoId: string, tags: string[]): Promise<void>;
   deletePhoto(photoId: string): Promise<void>;
   assignToAlbum(photoId: string, albumId: string, hint?: Photo): Promise<void>;
@@ -51,6 +53,7 @@ export function useLibrary(
     sort?: LibrarySort;
     minRating?: PhotoRating;
     flag?: PhotoFlag | 'unflagged';
+    colorLabel?: PhotoColorLabel | 'uncolored' | readonly Exclude<PhotoColorLabel, null>[];
   }
 ): UseLibraryReturn {
   const { library } = useServices();
@@ -77,6 +80,7 @@ export function useLibrary(
         sort: filters?.sort,
         minRating: filters?.minRating,
         flag: filters?.flag,
+        colorLabel: filters?.colorLabel,
         pageSize: 24,
       })
       .then(({ photos: p, nextPageToken: token }) => {
@@ -107,6 +111,7 @@ export function useLibrary(
     filters?.sort,
     filters?.minRating,
     filters?.flag,
+    filters?.colorLabel,
   ]);
 
   const addPhoto = useCallback(
@@ -158,6 +163,14 @@ export function useLibrary(
   const setFlag = useCallback(
     async (photoId: string, flag: PhotoFlag) => {
       const updated = await library.updatePhoto(photoId, { flag });
+      setPhotos((prev) => prev.map((p) => (p.id === photoId ? updated : p)));
+    },
+    [library]
+  );
+
+  const setColorLabel = useCallback(
+    async (photoId: string, colorLabel: PhotoColorLabel) => {
+      const updated = await library.updatePhoto(photoId, { colorLabel });
       setPhotos((prev) => prev.map((p) => (p.id === photoId ? updated : p)));
     },
     [library]
@@ -229,6 +242,7 @@ export function useLibrary(
         sort: filters?.sort,
         minRating: filters?.minRating,
         flag: filters?.flag,
+        colorLabel: filters?.colorLabel,
         pageSize: 24,
         pageToken: nextPageToken,
       });
@@ -251,6 +265,7 @@ export function useLibrary(
     filters?.sort,
     filters?.minRating,
     filters?.flag,
+    filters?.colorLabel,
   ]);
 
   return {
@@ -265,6 +280,7 @@ export function useLibrary(
     toggleFavorite,
     setRating,
     setFlag,
+    setColorLabel,
     setTags,
     deletePhoto,
     assignToAlbum,

--- a/src/pages/LibraryPage.tsx
+++ b/src/pages/LibraryPage.tsx
@@ -194,6 +194,7 @@ export function LibraryPage() {
     toggleFavorite,
     setRating,
     setFlag,
+    setColorLabel,
     setTags,
     deletePhoto,
   } = useLibrary(libraryId, metadataFilters);
@@ -281,12 +282,60 @@ export function LibraryPage() {
       } else if (key === '`' || key === '~') {
         event.preventDefault();
         void setFlag(photoId, null);
+      } else if (lower === 'r') {
+        // Lightroom-style color labels (issue #184). r/y/g/b/u (=purple)
+        // are mnemonic; press the same key twice to clear (handled by
+        // toggling against the current value).
+        event.preventDefault();
+        void setColorLabel(
+          photoId,
+          viewerState?.currentPhoto.id === photoId &&
+            viewerState.currentPhoto.colorLabel === 'red'
+            ? null
+            : 'red'
+        );
+      } else if (lower === 'y') {
+        event.preventDefault();
+        void setColorLabel(
+          photoId,
+          viewerState?.currentPhoto.id === photoId &&
+            viewerState.currentPhoto.colorLabel === 'yellow'
+            ? null
+            : 'yellow'
+        );
+      } else if (lower === 'g') {
+        event.preventDefault();
+        void setColorLabel(
+          photoId,
+          viewerState?.currentPhoto.id === photoId &&
+            viewerState.currentPhoto.colorLabel === 'green'
+            ? null
+            : 'green'
+        );
+      } else if (lower === 'b') {
+        event.preventDefault();
+        void setColorLabel(
+          photoId,
+          viewerState?.currentPhoto.id === photoId &&
+            viewerState.currentPhoto.colorLabel === 'blue'
+            ? null
+            : 'blue'
+        );
+      } else if (lower === 'u') {
+        event.preventDefault();
+        void setColorLabel(
+          photoId,
+          viewerState?.currentPhoto.id === photoId &&
+            viewerState.currentPhoto.colorLabel === 'purple'
+            ? null
+            : 'purple'
+        );
       }
     }
 
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [selectedPhotoIds, setRating, setFlag]);
+  }, [selectedPhotoIds, setRating, setFlag, setColorLabel, viewerState]);
 
   // Handle upload modal trigger from URL query parameter
   useEffect(() => {
@@ -382,6 +431,8 @@ export function LibraryPage() {
     return createViewerToolbarConfig({
       currentPhoto: viewerState.currentPhoto,
       onToggleFavorite: viewerState.onToggleFavorite,
+      onSetColorLabel: (label) =>
+        void setColorLabel(viewerState.currentPhoto.id, label),
       onDelete: async () => {
         await deletePhoto(viewerState.currentPhoto.id);
         if (photos.length <= 1) {
@@ -395,7 +446,7 @@ export function LibraryPage() {
       saturation: viewerState.saturation,
       setSaturation: viewerState.setSaturation,
     });
-  }, [viewerState, deletePhoto, photos.length]);
+  }, [viewerState, deletePhoto, photos.length, setColorLabel]);
 
   const availableTags = useMemo(
     () => [...new Set(photos.flatMap((photo) => photo.tags))].sort((a, b) => a.localeCompare(b)),


### PR DESCRIPTION
## Summary

Adds Lightroom-style **color labels** as the third photo-triage axis (alongside star rating and pick/reject flag, issues #141/#149). Photos can now carry a `colorLabel` of `red | yellow | green | blue | purple | null`, settable from the viewer toolbar and via keyboard shortcuts, filterable from the gallery, and routable through the new `PATCH /v1/photos/:id` endpoint plus the existing bulk endpoint.

## Changes

### Domain & adapters
- `src/domain/library/types.ts`: new `PhotoColorLabel` type, `PHOTO_COLOR_LABEL_VALUES`, `isPhotoColorLabel` guard, `colorLabel` field on `Photo`, `colorLabel` filter on `ListPhotosInput` (single value, `'uncolored'` sentinel, or array OR-semantics), and `colorLabel` on `UpdatePhotoInput`.
- `src/adapters/library/inMemoryLibraryService.ts`: default `colorLabel: null` on add, strict-enum validation in `updatePhoto`, filter implementation in `listPhotos`, legacy-record backfill in `loadPhotos`.
- `src/adapters/library/FirebaseLibraryService.ts`: mirrored — default, validation, Firestore `where`/`in` filter in `listPhotos`, mapper backfill in `mapDocToPhoto`.
- `firestore.indexes.json`: new composite index `libraryId + colorLabel + createdAt DESC`.

### Hook & UI
- `src/features/library/useLibrary.ts`: new `setColorLabel(photoId, label)` action; `colorLabel` accepted as a filter prop and threaded through `listPhotos`/`loadMore`.
- `src/pages/LibraryPage.tsx`: keyboard shortcuts `R/Y/G/B/U` (mnemonic, U=purple) toggle the color label on the focused photo — a second press of the same key clears the label, matching Lightroom behaviour.
- `src/components/toolbar/examples/viewerToolbarConfig.tsx`: new `colorLabel` panel in the viewer toolbar with a 5-swatch picker plus a clear button.
- `src/components/PhotoGallery.tsx`: small circular swatch badge on each tile (top-left) when a label is set.

### Backend
- `functions/src/models/Photo.ts`: added `PhotoRating`/`PhotoFlag`/`PhotoColorLabel` types, type guards, and `rating`/`flag`/`colorLabel` fields to `Photo`. Defaults set in the model factory.
- `functions/src/domain/photos/PhotosService.ts`: new `updateTriage()` method with strict per-field enum validation, no-op short-circuit, and one `photo.tagged` metering event per mutated axis (`meta.kind = rating | flag | colorLabel`). New `TriageValidationError` (HTTP 400).
- `functions/src/routes/photosV1.ts`: new `PATCH /v1/photos/:id` route accepting any combination of `{ rating, flag, colorLabel }`; `?colorLabel=` query filter on `GET /v1/photos` (single value, `uncolored`, or comma-separated OR list). List responses now include `rating`, `flag`, `colorLabel`.
- `functions/src/handlers/photos/batch.ts`: new `setColorLabel` bulk action with strict enum validation; emits a per-id `photo.tagged` event with `meta.kind="colorLabel"` plus the existing bulk audit/metering envelope.
- `functions/src/services/metering/eventCatalog.ts`: extended `photo.tagged` schema with optional `kind`, `rating`, `flag`, `colorLabel`, `viaBulk` (forward-compatible — `additionalProperties: true`).

### OpenAPI contracts
- `contracts/openapi/photos.openapi.json` (→ 1.3.0): documented `PATCH /v1/photos/{id}`, `UpdatePhotoRequest` schema, `?colorLabel=` query, `rating`/`flag`/`colorLabel` on `PhotoSummary`.
- `contracts/openapi/photos-list.openapi.json`: `?colorLabel=` query + new fields on the `Photo` response shape.
- `contracts/openapi/photos-batch.openapi.json` (→ 1.1.0): `setColorLabel` action + `colorLabel` param.
- `contracts/openapi/smart-albums.openapi.json`: `colorLabel` filter on `SmartAlbumFilter` (single value or 1–5 unique array).

### Tests
- `src/adapters/library/inMemoryLibraryService.test.ts`: new `triage (colorLabel — issue #184)` block (9 tests) — defaults to null, set/clear via `updatePhoto`, strict invalid-value rejection, filter by single value, OR-semantics array filter, `'uncolored'` sentinel, invalid-filter rejection, cross-library isolation, combined with rating+flag, legacy-record backfill.

## Testing

- `npm test` (frontend): **159/159 passing** (32 in `inMemoryLibraryService.test.ts`, +9 new).
- `npx tsc -b` (frontend): **0 errors**.
- `npx vite build`: clean.
- `npm run lint`: **0 errors** (3 pre-existing warnings on `BrandingProvider.tsx`, unrelated).
- `cd functions && npx tsc --noEmit`: **same 21 errors as `main`** (all in pre-existing test files I didn't touch). My new/modified files report zero TypeScript errors.
- `cd functions && npx vitest run`: **525/537 passing**, same 12 failures as `main` (all in `test/routes/tenantUsersV1.test.ts`, completely unrelated to photos/triage). No regressions introduced.
- `npm run contract:check`: **passed** (validate + breaking-change check).
- `npm run firestore:indexes:validate`: **passed**.

## Notes

- Backwards-compatible by design: `colorLabel` is optional on `Photo`; missing values backfill to `null`. The metering `photo.tagged` schema uses `additionalProperties: true`, so the existing tag-mutation emissions stay valid.
- Color label names are fixed to the 5 Lightroom standard colors per the issue spec — custom tenant labels are explicitly deferred.
- The `photo.tagged` metering reuse (with `meta.kind="colorLabel"`) matches the issue's billing/metering hooks requirement — no new event type, no billable impact.

Fixes rwrife/AuraPix#184