### PR TITLE
fix: Watermark option on export presets

### DIFF
--- a/contracts/openapi/export-presets.openapi.json
+++ b/contracts/openapi/export-presets.openapi.json
@@ -74,6 +74,20 @@
                 "web-large": {
                   "value": { "maxEdge": 2048, "quality": 85, "format": "jpeg", "label": "Web (large)" }
                 },
+                "web-large-with-watermark": {
+                  "value": {
+                    "maxEdge": 2048,
+                    "quality": 85,
+                    "format": "jpeg",
+                    "label": "Web (large) — watermarked",
+                    "watermark": {
+                      "enabled": true,
+                      "text": "PROOF — {tenantName}",
+                      "opacity": 0.5,
+                      "position": "bottom-right"
+                    }
+                  }
+                },
                 "original": {
                   "value": { "maxEdge": 8192, "quality": 100, "format": "original" }
                 }
@@ -186,6 +200,34 @@
             "type": "string",
             "maxLength": 128,
             "description": "Optional human-readable label for host admin UI."
+          },
+          "watermark": { "$ref": "#/components/schemas/ExportPresetWatermark" }
+        }
+      },
+      "ExportPresetWatermark": {
+        "type": "object",
+        "required": ["enabled", "text", "opacity", "position"],
+        "description": "Per-preset watermark configuration (issue #185). Hosts reselling AuraPix for client-proofing can apply a watermark (e.g. `PROOF — {tenantName}`) to exported JPEGs without affecting share-link delivery. Ignored when `format` is `original` because passthrough delivery must not modify the source bytes.\n\nToken substitution supports `{tenantName}` (branding `appName`), `{photoId}`, and `{date}` (UTC `YYYY-MM-DD`) only — no user PII tokens. Other `{...}` sequences are passed through verbatim.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "When false the watermark renderer is skipped entirely."
+          },
+          "text": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Watermark text. Must be non-empty when `enabled` is true. Supports `{tenantName}`, `{photoId}`, and `{date}` tokens."
+          },
+          "opacity": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Watermark layer opacity in `[0, 1]`. Out-of-range values are rejected with HTTP 400."
+          },
+          "position": {
+            "type": "string",
+            "enum": ["top-left", "top-right", "bottom-left", "bottom-right"],
+            "description": "Anchor corner for the watermark layer."
           }
         }
       },
@@ -196,9 +238,10 @@
           "maxEdge": { "type": "integer", "minimum": 1, "maximum": 8192 },
           "quality": { "type": "integer", "minimum": 1, "maximum": 100 },
           "format": { "type": "string", "enum": ["jpeg", "original"] },
-          "label": { "type": "string", "maxLength": 128 }
+          "label": { "type": "string", "maxLength": 128 },
+          "watermark": { "$ref": "#/components/schemas/ExportPresetWatermark" }
         },
-        "description": "Body of `PUT /export-presets/{name}`. The URL `name` is authoritative; any `name` field in the body is ignored. `maxEdge` / `quality` are optional when `format` is `original`."
+        "description": "Body of `PUT /export-presets/{name}`. The URL `name` is authoritative; any `name` field in the body is ignored. `maxEdge` / `quality` are optional when `format` is `original`. `watermark` is ignored when `format` is `original`."
       },
       "TenantExportPresetsResponse": {
         "type": "object",

--- a/docs/features/metering-events.md
+++ b/docs/features/metering-events.md
@@ -47,8 +47,8 @@ discarded; there is no outbound traffic.
 | `plugin.blocked` | 1 | — | An edit operation referenced a plugin not in the tenant allowlist. |
 | `photo.trashed` | 1 | — | A photo was soft-deleted (moved to trash). |
 | `photo.purged` | 1 | — | A trashed photo was permanently purged and its bytes freed. `bytes` is negative. |
-| `photo.tagged` | 1 | — | A photo had tags added or removed. One event per mutation, not per tag. |
-| `photo.exported` | 1 | ✅ | A photo was successfully exported (cache hit or miss). Drives the `exportBytes` rollup. |
+| `photo.tagged` | 1 | — | A photo had tags, rating, flag, or color label changed. One event per mutation, not per tag. Issue #184 added `meta.kind` to disambiguate (`tag` \| `rating` \| `flag` \| `colorLabel`). |
+| `photo.exported` | 1 | ✅ | A photo was successfully exported (cache hit or miss). Drives the `exportBytes` rollup. Issue #185 added `meta.watermark` (boolean) to distinguish watermarked vs clean exports. |
 | `audit.queried` | 1 | — | The host audit-events API was queried. |
 | `tenant.export.requested` | 1 | — | A tenant data export was initiated via the offboarding API. |
 | `tenant.export.completed` | 1 | — | A tenant data export finished and the bundle is available. |

--- a/docs/features/uploads-processing-storage.md
+++ b/docs/features/uploads-processing-storage.md
@@ -86,3 +86,119 @@ photo has no `exif.capturedAt`. Results are tenant-scoped. See
 
 Backfill of `exif` on photos uploaded before this change is out of scope and
 will ship as a separate maintenance script.
+
+## Export presets (Issue #174)
+
+Tenants can define a list of named **export presets** that the
+`POST /v1/photos/{id}/export` and `GET /v1/photos/{id}/export/{token}`
+endpoints select from. The preset doc lives at
+`tenants_export_presets/{tenantId}` and is managed via
+`GET|PUT|DELETE /v1/tenants/{tenantId}/export-presets[/{name}]`. Presets
+are tenant-scoped; cross-tenant reads / writes are rejected with
+`CROSS_TENANT_FORBIDDEN`.
+
+A preset has the following shape:
+
+| Field | Notes |
+|-------|-------|
+| `name` | URL-safe id (`^[a-z0-9][a-z0-9-]{0,31}$`) |
+| `maxEdge` | Integer 1-8192. Ignored when `format = original`. |
+| `quality` | JPEG quality 1-100. Ignored when `format = original`. |
+| `format` | `jpeg` (default, re-encoded) or `original` (passthrough bytes) |
+| `label` | Optional human-readable label (≤128 chars) |
+| `watermark` | Optional watermark config — see below (issue #185) |
+
+The render pipeline caches results under
+`exports/{libraryId}/{photoId}.{recipeHash}.{preset}[.wm-{hash}].jpg` so
+re-downloads of the same `(photo, edit recipe, preset[, watermark])`
+tuple are served from disk without re-encoding.
+
+## Export watermarks (Issue #185)
+
+Share-link delivery already supports a watermark policy (#32/#46). For
+hosts who resell AuraPix as a client-proofing platform, the export
+pipeline now supports a per-preset watermark independent from share
+delivery, so they can ship watermarked exports without changing how
+links work.
+
+**Schema** (added to `ExportPreset`):
+
+```json
+{
+  "watermark": {
+    "enabled": true,
+    "text": "PROOF — {tenantName}",
+    "opacity": 0.5,
+    "position": "bottom-right"
+  }
+}
+```
+
+**Token substitution.** The `text` field supports three non-PII tokens
+substituted at render time:
+
+- `{tenantName}` — the tenant's branding `appName`, falling back to
+  the tenant id when branding is not configured.
+- `{photoId}` — the photo id.
+- `{date}` — UTC `YYYY-MM-DD` at render time.
+
+Any other `{foo}` sequence is passed through verbatim (no error, no PII
+leak).
+
+**Validation rules.** All return HTTP 400 with an explicit error code:
+
+- `INVALID_WATERMARK_TEXT` — non-string, blank when `enabled: true`,
+  or longer than 256 characters.
+- `INVALID_WATERMARK_OPACITY` — not a finite number in `[0, 1]`.
+- `INVALID_WATERMARK_POSITION` — must be one of `top-left`,
+  `top-right`, `bottom-left`, `bottom-right`.
+
+**Format interaction.** `watermark` is ignored when `format =
+original` — passthrough delivery must not modify the source bytes. A
+host that wants watermarked originals ships a separate `jpeg` preset
+with `maxEdge: 8192`.
+
+**Cache partitioning.** Enabling or changing a watermark on an existing
+preset automatically invalidates the cache for that preset — the cache
+key includes a 12-character hash of the watermark config when enabled.
+Clean exports (no watermark) keep their existing cache key shape so
+pre-#185 cache entries remain valid.
+
+**Renderer.** The watermark renderer lives in
+`functions/src/services/watermark/` and is intended as a shared util:
+both the export pipeline and (in a future change) share delivery
+should use it instead of duplicating SVG/Sharp wiring. The renderer
+composites an SVG `<text>` layer over the encoded JPEG using Sharp's
+`composite()`, scales font size to the image's shortest edge, and
+draws white text with a black stroke so it stays legible on both
+bright and dark images.
+
+**Metering.** The existing `photo.exported` event gains
+`meta.watermark: boolean` so hosts can price watermarked vs clean
+exports differently. This is an **additive** field on the same event
+version (`photo.exported` v1); no event-version bump per the rules in
+`eventCatalog.ts`.
+
+### Example: configure a watermarked preset
+
+```http
+PUT /v1/tenants/tenant-a/export-presets/web-large HTTP/1.1
+Authorization: Bearer tak_...
+
+{
+  "maxEdge": 2048,
+  "quality": 85,
+  "format": "jpeg",
+  "label": "Web (large) — watermarked",
+  "watermark": {
+    "enabled": true,
+    "text": "PROOF — {tenantName}",
+    "opacity": 0.5,
+    "position": "bottom-right"
+  }
+}
+```
+
+Subsequent calls to `POST /v1/photos/{id}/export` with
+`{"preset":"web-large"}` will composite the watermark on the rendered
+JPEG and emit `photo.exported` with `meta.watermark: true`.

--- a/functions/src/models/ExportPreset.ts
+++ b/functions/src/models/ExportPreset.ts
@@ -22,6 +22,57 @@
 export const TENANT_EXPORT_PRESETS_COLLECTION = 'tenantExportPresets';
 
 /**
+ * Optional watermark configuration for an export preset (issue #185).
+ *
+ * Independent from share-link watermarking (#32/#46): hosts reselling
+ * AuraPix for client-proofing want a per-preset watermark ("PROOF —
+ * example.com") applied during the export pipeline. The renderer is
+ * the same as share delivery via the shared `watermark` util.
+ *
+ * `text` may include the following non-PII tokens, substituted at
+ * render time:
+ *   - `{tenantName}` — branding `appName`, or the tenantId when unset
+ *   - `{photoId}`    — the photo's id
+ *   - `{date}`       — `YYYY-MM-DD` in UTC at render time
+ *
+ * `opacity` is the watermark layer opacity in `[0, 1]`. `position`
+ * controls which corner the watermark anchors to.
+ */
+export interface ExportPresetWatermark {
+  /** When false the watermark renderer is skipped entirely. */
+  enabled: boolean;
+  /**
+   * Display text. Up to 256 characters after token substitution; must
+   * be non-empty when `enabled` is true. Tokens not in the allowlist
+   * are passed through verbatim (no error) so a host can include
+   * literal `{` characters in their watermark.
+   */
+  text: string;
+  /** Opacity in `[0, 1]`. Validated; out-of-range values are rejected. */
+  opacity: number;
+  /** Anchor corner for the watermark layer. */
+  position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+}
+
+/**
+ * Allowed `position` values for an export-preset watermark. Mirrors the
+ * `ExportPresetWatermark.position` union so the validator can iterate
+ * without re-declaring the literal list.
+ */
+export const EXPORT_PRESET_WATERMARK_POSITIONS = [
+  'top-left',
+  'top-right',
+  'bottom-left',
+  'bottom-right',
+] as const;
+
+export type ExportPresetWatermarkPosition =
+  (typeof EXPORT_PRESET_WATERMARK_POSITIONS)[number];
+
+/** Max length of the (pre-substitution) watermark text. */
+export const EXPORT_PRESET_WATERMARK_MAX_TEXT_LENGTH = 256;
+
+/**
  * A single named export preset. `format` is either `jpeg` (default,
  * matches the issue: rendered JPEG output) or `original` (no transcode,
  * stream the bytes already on disk). Sizes are an upper bound — the
@@ -47,12 +98,22 @@ export interface ExportPreset {
   /**
    * Output format. `original` returns the stored original bytes
    * unchanged (no recompression, no resize).
+   *
+   * NOTE: `watermark` is ignored when `format === 'original'` because
+   * passthrough delivery must not modify the source bytes (a host that
+   * needs a watermarked original should ship a separate JPEG preset).
    */
   format: 'jpeg' | 'original';
   /**
    * Optional human-readable label shown in host admin UI.
    */
   label?: string;
+  /**
+   * Optional watermark configuration (issue #185). Missing means "no
+   * watermark" — semantically identical to `{ enabled: false }`.
+   * Ignored when `format === 'original'`.
+   */
+  watermark?: ExportPresetWatermark;
 }
 
 export interface TenantExportPresetsRecord {

--- a/functions/src/routes/photoExportV1.test.ts
+++ b/functions/src/routes/photoExportV1.test.ts
@@ -319,6 +319,90 @@ describe('POST /v1/photos/:id/export', () => {
     expect(counts[0]?.value).toBeGreaterThan(0);
   });
 
+  it('applies a watermark when the preset declares one and emits meta.watermark:true (issue #185)', async () => {
+    const tiny = await makeTinyJpeg();
+    const photo = makePhoto({ tenantId: 'tenant-a' });
+    const presetDoc: TenantExportPresetsRecord = {
+      tenantId: 'tenant-a',
+      presets: [
+        {
+          name: 'web-small',
+          maxEdge: 1280,
+          quality: 80,
+          format: 'jpeg',
+          label: 'Web (small)',
+          watermark: {
+            enabled: true,
+            text: 'PROOF — {tenantName}',
+            opacity: 0.5,
+            position: 'bottom-right',
+          },
+        },
+        {
+          name: 'web-small-clean',
+          maxEdge: 1280,
+          quality: 80,
+          format: 'jpeg',
+          label: 'Web (small) clean',
+        },
+      ],
+      updatedAt: new Date().toISOString(),
+      updatedBy: 'tak_x',
+    };
+    const data = makeData(photo, presetDoc);
+    const { storage, files } = makeStorage({
+      [`images/lib-1/photo-1/original.jpg`]: tiny,
+    });
+    const app = makeApp({
+      data,
+      storage,
+      inject: (req) => {
+        req.user = { uid: 'u_1' };
+        req.tenantId = 'tenant-a';
+      },
+    });
+
+    // Watermarked preset.
+    const wm = await request(app, 'post', '/v1/photos/photo-1/export', {
+      preset: 'web-small',
+    });
+    expect(wm.status).toBe(200);
+    expect(wm.body.cacheHit).toBe(false);
+
+    // Clean preset (no watermark on this one).
+    const clean = await request(app, 'post', '/v1/photos/photo-1/export', {
+      preset: 'web-small-clean',
+    });
+    expect(clean.status).toBe(200);
+
+    await bus.flush();
+    const exportEvents = sink.events.filter((e) => e.type === 'photo.exported');
+    expect(exportEvents).toHaveLength(2);
+    const wmEvent = exportEvents.find(
+      (e) => (e.meta as any).preset === 'web-small'
+    );
+    const cleanEvent = exportEvents.find(
+      (e) => (e.meta as any).preset === 'web-small-clean'
+    );
+    expect((wmEvent?.meta as any).watermark).toBe(true);
+    expect((cleanEvent?.meta as any).watermark).toBe(false);
+
+    // Watermarked and clean variants should land in distinct cache entries
+    // (cache key includes a watermark hash when enabled).
+    const exportKeys = [...files.keys()].filter((k) =>
+      k.startsWith('exports/lib-1/')
+    );
+    expect(exportKeys.length).toBe(2);
+    expect(exportKeys.some((k) => k.includes('.wm-'))).toBe(true);
+    expect(exportKeys.some((k) => !k.includes('.wm-'))).toBe(true);
+
+    // A re-export of the watermarked preset still hits the cache.
+    const wm2 = await request(app, 'post', '/v1/photos/photo-1/export', {
+      preset: 'web-small',
+    });
+    expect(wm2.body.cacheHit).toBe(true);
+  });
+
   it('rejects cross-tenant access with 403', async () => {
     const tiny = await makeTinyJpeg();
     const photo = makePhoto({ tenantId: 'tenant-a' });

--- a/functions/src/routes/photoExportV1.ts
+++ b/functions/src/routes/photoExportV1.ts
@@ -168,6 +168,7 @@ export function createPhotoExportRouter(
         storage: deps.storageAdapter,
         photo,
         preset,
+        data: deps.dataAdapter,
       });
 
       // Build a short-lived signed URL pointing back at the GET handler.
@@ -198,6 +199,8 @@ export function createPhotoExportRouter(
           outputHeight: rendered.outputHeight,
           cacheHit: rendered.cacheHit,
           actor: req.tenant?.keyId ?? req.user?.uid ?? null,
+          // #185: hosts price watermarked vs clean exports differently.
+          watermark: rendered.watermarkApplied,
         },
       });
 
@@ -310,6 +313,7 @@ export function createPhotoExportRouter(
           storage: deps.storageAdapter,
           photo,
           preset,
+          data: deps.dataAdapter,
         });
         res.set({
           'Content-Type': 'image/jpeg',

--- a/functions/src/routes/tenantExportPresetsV1.test.ts
+++ b/functions/src/routes/tenantExportPresetsV1.test.ts
@@ -217,6 +217,130 @@ describe('createTenantExportPresetsRouter', () => {
       expect(res.body.error.code).toBe('INVALID_FORMAT');
     });
 
+    it('returns 400 when watermark.opacity is out of [0,1] (issue #185)', async () => {
+      const { app } = hostKeyApp();
+      const res = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/export-presets/web-small',
+        {
+          maxEdge: 1280,
+          quality: 80,
+          format: 'jpeg',
+          watermark: {
+            enabled: true,
+            text: 'PROOF',
+            opacity: 1.5,
+            position: 'bottom-right',
+          },
+        }
+      );
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('INVALID_WATERMARK_OPACITY');
+    });
+
+    it('returns 400 when watermark.position is unknown (issue #185)', async () => {
+      const { app } = hostKeyApp();
+      const res = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/export-presets/web-small',
+        {
+          maxEdge: 1280,
+          quality: 80,
+          format: 'jpeg',
+          watermark: {
+            enabled: true,
+            text: 'PROOF',
+            opacity: 0.5,
+            position: 'middle',
+          },
+        }
+      );
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('INVALID_WATERMARK_POSITION');
+    });
+
+    it('returns 400 when watermark.enabled is true but text is blank (issue #185)', async () => {
+      const { app } = hostKeyApp();
+      const res = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/export-presets/web-small',
+        {
+          maxEdge: 1280,
+          quality: 80,
+          format: 'jpeg',
+          watermark: {
+            enabled: true,
+            text: '   ',
+            opacity: 0.5,
+            position: 'bottom-right',
+          },
+        }
+      );
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('INVALID_WATERMARK_TEXT');
+    });
+
+    it('persists a watermark block when provided (issue #185)', async () => {
+      const { app, store } = hostKeyApp();
+      const wm = {
+        enabled: true,
+        text: 'PROOF — {tenantName}',
+        opacity: 0.5,
+        position: 'bottom-right' as const,
+      };
+      const res = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/export-presets/web-large',
+        {
+          maxEdge: 2048,
+          quality: 85,
+          format: 'jpeg',
+          label: 'Web (large)',
+          watermark: wm,
+        }
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.preset.watermark).toEqual(wm);
+      const persisted: any = store
+        .get(TENANT_EXPORT_PRESETS_COLLECTION)
+        ?.get('tenant-a');
+      const found = persisted.presets.find((p: any) => p.name === 'web-large');
+      expect(found.watermark).toEqual(wm);
+    });
+
+    it('rejects cross-tenant preset write with 403 (issue #185 AC)', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        req.tenant = {
+          id: 'tenant-other',
+          scopes: ['export-presets.write'],
+          keyId: 'tak_x',
+        };
+      });
+      const res = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/export-presets/web-small',
+        {
+          maxEdge: 1280,
+          quality: 80,
+          format: 'jpeg',
+          watermark: {
+            enabled: true,
+            text: 'PROOF',
+            opacity: 0.5,
+            position: 'bottom-right',
+          },
+        }
+      );
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('CROSS_TENANT_FORBIDDEN');
+    });
+
     it('creates a new preset and reports `changed: true`', async () => {
       const { app, store } = hostKeyApp();
       const res = await request(

--- a/functions/src/services/host/exportPresetService.ts
+++ b/functions/src/services/host/exportPresetService.ts
@@ -19,9 +19,12 @@ import {
   EXPORT_PRESET_MIN_EDGE,
   EXPORT_PRESET_MIN_QUALITY,
   EXPORT_PRESET_NAME_PATTERN,
+  EXPORT_PRESET_WATERMARK_MAX_TEXT_LENGTH,
+  EXPORT_PRESET_WATERMARK_POSITIONS,
   TENANT_EXPORT_PRESETS_COLLECTION,
   defaultExportPresets,
   type ExportPreset,
+  type ExportPresetWatermark,
   type TenantExportPresetsRecord,
 } from '../../models/ExportPreset.js';
 
@@ -111,14 +114,88 @@ export function validatePresetBody(
     );
   }
 
+  const watermark =
+    b.watermark === undefined ? undefined : validateWatermark(b.watermark);
+
   const preset: ExportPreset = {
     name,
     maxEdge: maxEdgeRaw,
     quality: qualityRaw,
     format,
     ...(typeof label === 'string' ? { label } : {}),
+    ...(watermark ? { watermark } : {}),
   };
   return preset;
+}
+
+/**
+ * Validate the optional `watermark` block on an export preset (issue #185).
+ * `enabled: false` is accepted with no further checks so a host can keep
+ * a watermark template around but disable it without dropping the config.
+ */
+export function validateWatermark(value: unknown): ExportPresetWatermark {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new ExportPresetValidationError(
+      'INVALID_WATERMARK',
+      'watermark must be a JSON object'
+    );
+  }
+  const w = value as Record<string, unknown>;
+  if (typeof w.enabled !== 'boolean') {
+    throw new ExportPresetValidationError(
+      'INVALID_WATERMARK_ENABLED',
+      'watermark.enabled must be a boolean'
+    );
+  }
+  const text = w.text;
+  if (typeof text !== 'string') {
+    throw new ExportPresetValidationError(
+      'INVALID_WATERMARK_TEXT',
+      'watermark.text must be a string'
+    );
+  }
+  if (w.enabled && text.trim().length === 0) {
+    throw new ExportPresetValidationError(
+      'INVALID_WATERMARK_TEXT',
+      'watermark.text must be non-empty when watermark.enabled is true'
+    );
+  }
+  if (text.length > EXPORT_PRESET_WATERMARK_MAX_TEXT_LENGTH) {
+    throw new ExportPresetValidationError(
+      'INVALID_WATERMARK_TEXT',
+      `watermark.text must be at most ${EXPORT_PRESET_WATERMARK_MAX_TEXT_LENGTH} characters`
+    );
+  }
+  const opacity = w.opacity;
+  if (
+    typeof opacity !== 'number' ||
+    !Number.isFinite(opacity) ||
+    opacity < 0 ||
+    opacity > 1
+  ) {
+    throw new ExportPresetValidationError(
+      'INVALID_WATERMARK_OPACITY',
+      'watermark.opacity must be a number in [0, 1]'
+    );
+  }
+  const position = w.position;
+  if (
+    typeof position !== 'string' ||
+    !EXPORT_PRESET_WATERMARK_POSITIONS.includes(
+      position as ExportPresetWatermark['position']
+    )
+  ) {
+    throw new ExportPresetValidationError(
+      'INVALID_WATERMARK_POSITION',
+      `watermark.position must be one of: ${EXPORT_PRESET_WATERMARK_POSITIONS.join(', ')}`
+    );
+  }
+  return {
+    enabled: w.enabled,
+    text,
+    opacity,
+    position: position as ExportPresetWatermark['position'],
+  };
 }
 
 /**
@@ -304,6 +381,35 @@ function isValidPreset(p: unknown): p is ExportPreset {
   if (o.quality < EXPORT_PRESET_MIN_QUALITY || o.quality > EXPORT_PRESET_MAX_QUALITY) {
     return false;
   }
+  // Watermark is optional. If present, it must be structurally sound;
+  // a malformed persisted watermark drops the whole preset so we never
+  // half-apply a bad config.
+  if (o.watermark !== undefined && !isValidWatermark(o.watermark)) {
+    return false;
+  }
+  return true;
+}
+
+function isValidWatermark(w: unknown): w is ExportPresetWatermark {
+  if (!w || typeof w !== 'object') return false;
+  const o = w as Partial<ExportPresetWatermark>;
+  if (typeof o.enabled !== 'boolean') return false;
+  if (typeof o.text !== 'string') return false;
+  if (o.text.length > EXPORT_PRESET_WATERMARK_MAX_TEXT_LENGTH) return false;
+  if (
+    typeof o.opacity !== 'number' ||
+    !Number.isFinite(o.opacity) ||
+    o.opacity < 0 ||
+    o.opacity > 1
+  ) {
+    return false;
+  }
+  if (
+    !o.position ||
+    !EXPORT_PRESET_WATERMARK_POSITIONS.includes(o.position)
+  ) {
+    return false;
+  }
   return true;
 }
 
@@ -313,7 +419,22 @@ function presetsEqual(a: ExportPreset, b: ExportPreset): boolean {
     a.maxEdge === b.maxEdge &&
     a.quality === b.quality &&
     a.format === b.format &&
-    (a.label ?? null) === (b.label ?? null)
+    (a.label ?? null) === (b.label ?? null) &&
+    watermarksEqual(a.watermark, b.watermark)
+  );
+}
+
+function watermarksEqual(
+  a: ExportPresetWatermark | undefined,
+  b: ExportPresetWatermark | undefined
+): boolean {
+  if (a === undefined && b === undefined) return true;
+  if (a === undefined || b === undefined) return false;
+  return (
+    a.enabled === b.enabled &&
+    a.text === b.text &&
+    a.opacity === b.opacity &&
+    a.position === b.position
   );
 }
 

--- a/functions/src/services/image/exportService.ts
+++ b/functions/src/services/image/exportService.ts
@@ -16,12 +16,25 @@
 
 import { createHash, createHmac } from 'node:crypto';
 import sharp from 'sharp';
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
 import type { StorageAdapter } from '../../adapters/storage/StorageAdapter.js';
 import type { Photo } from '../../models/Photo.js';
-import type { ExportPreset } from '../../models/ExportPreset.js';
+import type { ExportPreset, ExportPresetWatermark } from '../../models/ExportPreset.js';
 import { applyEdits } from '../edits/EditProcessor.js';
 import { signingConfig } from '../../config/index.js';
 import { signData, verifySignature } from '../../utils/crypto.js';
+import { renderWatermark } from '../watermark/index.js';
+
+/**
+ * Local re-declaration of the branding-doc shape used for `{tenantName}`
+ * substitution. Kept here — rather than importing from
+ * `routes/brandingV1.ts` — to avoid pulling express + zod into the
+ * services layer for a single string lookup.
+ */
+const BRANDING_COLLECTION = 'tenants_branding';
+interface BrandingDoc {
+  appName?: string;
+}
 
 /**
  * Result of rendering a photo to an export preset.
@@ -37,6 +50,12 @@ export interface RenderedExport {
   outputHeight: number;
   cacheHit: boolean;
   cacheKey: string;
+  /**
+   * True when the rendered bytes had a watermark composited on them
+   * (issue #185). Forwarded to the metering layer as `meta.watermark`
+   * so hosts can price watermarked vs clean exports differently.
+   */
+  watermarkApplied: boolean;
 }
 
 /**
@@ -78,14 +97,42 @@ export function computeRecipeHash(photo: Photo): string {
 }
 
 /**
- * Composite cache key: `(photoId, recipeHash, preset)` per the issue.
+ * Composite cache key: `(photoId, recipeHash, preset[, watermarkHash])`.
+ *
+ * When the preset declares an enabled watermark we include a short
+ * hash of the watermark config so changing the watermark text/opacity/
+ * position automatically produces a cache miss — otherwise we'd keep
+ * serving the previously-watermarked bytes after a host updated the
+ * preset. Presets without a watermark keep the original key shape so
+ * pre-#185 cache entries remain valid.
  */
 export function computeCacheKey(
   photoId: string,
   recipeHash: string,
-  presetName: string
+  presetName: string,
+  watermark?: ExportPresetWatermark
 ): string {
+  if (watermark && watermark.enabled) {
+    const wmHash = computeWatermarkHash(watermark);
+    return `${photoId}.${recipeHash}.${presetName}.wm-${wmHash}.jpg`;
+  }
   return `${photoId}.${recipeHash}.${presetName}.jpg`;
+}
+
+/**
+ * Short stable hash of the watermark config used to partition the
+ * export cache. Exported for tests.
+ */
+export function computeWatermarkHash(watermark: ExportPresetWatermark): string {
+  // Stringify with a stable property order; watermark only has four
+  // documented fields so we don't need a deep sort.
+  const payload = JSON.stringify({
+    enabled: watermark.enabled,
+    text: watermark.text,
+    opacity: watermark.opacity,
+    position: watermark.position,
+  });
+  return createHash('sha256').update(payload).digest('hex').slice(0, 12);
 }
 
 /**
@@ -112,17 +159,39 @@ function normalize(path: string): string {
  * possible. The caller is responsible for tenant + auth checks.
  *
  * For `preset.format === 'original'` we serve the original bytes
- * unchanged (no resize, no transcode). For `jpeg` we apply the active
- * edit recipe and then resize/encode via the existing Sharp pipeline.
+ * unchanged (no resize, no transcode, no watermark — see
+ * `ExportPreset.watermark`). For `jpeg` we apply the active edit
+ * recipe, resize/encode via the existing Sharp pipeline, and
+ * (when enabled on the preset) composite a watermark over the
+ * resulting JPEG using the shared `renderWatermark` util.
+ *
+ * Pass `data` so the renderer can resolve `{tenantName}` from the
+ * tenant's branding doc; without it the token substitutes to an empty
+ * string.
  */
 export async function renderExport(opts: {
   storage: StorageAdapter;
   photo: Photo;
   preset: ExportPreset;
+  /**
+   * Optional data adapter used to fetch the tenant branding doc when
+   * substituting `{tenantName}` in a watermark template. When omitted
+   * the token falls back to the tenantId.
+   */
+  data?: DataAdapter;
 }): Promise<RenderedExport> {
-  const { storage, photo, preset } = opts;
+  const { storage, photo, preset, data } = opts;
   const recipeHash = computeRecipeHash(photo);
-  const cacheKey = computeCacheKey(photo.id, recipeHash, preset.name);
+  const watermarkActive =
+    preset.format === 'jpeg' &&
+    preset.watermark !== undefined &&
+    preset.watermark.enabled;
+  const cacheKey = computeCacheKey(
+    photo.id,
+    recipeHash,
+    preset.name,
+    watermarkActive ? preset.watermark : undefined
+  );
   const cachePath = cacheStoragePath(photo.libraryId, cacheKey);
 
   // 1. Cache lookup (works for both formats).
@@ -138,6 +207,7 @@ export async function renderExport(opts: {
       outputHeight: meta.height ?? 0,
       cacheHit: true,
       cacheKey,
+      watermarkApplied: watermarkActive,
     };
   }
 
@@ -150,6 +220,9 @@ export async function renderExport(opts: {
   let height: number;
 
   if (preset.format === 'original') {
+    // `original` format intentionally skips watermarking: passthrough
+    // delivery must not modify the source bytes. A host that wants a
+    // watermarked original ships a separate jpeg preset.
     outputBuffer = sourceBuffer;
     const meta = await sharp(sourceBuffer).metadata();
     width = meta.width ?? 0;
@@ -182,6 +255,31 @@ export async function renderExport(opts: {
     outputBuffer = out.data;
     width = out.info.width;
     height = out.info.height;
+
+    // Composite the watermark on top of the encoded JPEG. We re-encode
+    // at the preset quality so the watermark layer doesn't degrade the
+    // image any more than the original encode pass.
+    if (watermarkActive && preset.watermark) {
+      const tenantName = await resolveTenantName(
+        data,
+        photo.tenantId ?? null
+      );
+      const watermarked = await renderWatermark({
+        inputBuffer: outputBuffer,
+        watermark: preset.watermark,
+        tokens: {
+          tenantName,
+          photoId: photo.id,
+        },
+        jpegQuality: preset.quality,
+      });
+      outputBuffer = watermarked;
+      // Dimensions are preserved by the composite; re-probe in case
+      // Sharp normalized orientation differently on the second pass.
+      const wmMeta = await sharp(outputBuffer).metadata();
+      width = wmMeta.width ?? width;
+      height = wmMeta.height ?? height;
+    }
   }
 
   // 3. Write to cache (best-effort; failures here must not block the export).
@@ -194,7 +292,29 @@ export async function renderExport(opts: {
     outputHeight: height,
     cacheHit: false,
     cacheKey,
+    watermarkApplied: watermarkActive,
   };
+}
+
+/**
+ * Resolve the tenant's display name (branding `appName`) for `{tenantName}`
+ * watermark substitution. Falls back to the tenantId, then the empty
+ * string, so a missing branding doc never throws.
+ */
+async function resolveTenantName(
+  data: DataAdapter | undefined,
+  tenantId: string | null
+): Promise<string> {
+  if (!data || !tenantId) return tenantId ?? '';
+  try {
+    const branding = await data.fetchData<BrandingDoc>(
+      BRANDING_COLLECTION,
+      tenantId
+    );
+    return branding?.appName ?? tenantId;
+  } catch {
+    return tenantId;
+  }
 }
 
 async function tryReadCache(

--- a/functions/src/services/metering/eventCatalog.ts
+++ b/functions/src/services/metering/eventCatalog.ts
@@ -324,7 +324,7 @@ export const EVENT_CATALOG = [
     version: 1,
     billable: true,
     description:
-      'A photo was successfully exported (cache hit or miss). Drives the `exportBytes` rollup.',
+      'A photo was successfully exported (cache hit or miss). Drives the `exportBytes` rollup. Issue #185 added `meta.watermark` (boolean) to distinguish watermarked vs clean exports.',
     schema: metaSchema({
       libraryId: S_STRING,
       preset: S_STRING,
@@ -332,6 +332,10 @@ export const EVENT_CATALOG = [
       outputHeight: S_INTEGER,
       cacheHit: S_BOOLEAN,
       actor: S_STRING,
+      // Issue #185: hosts can price watermarked vs clean exports
+      // differently. Additive; no version bump per `eventCatalog.ts`
+      // rules (the `meta` schema is `additionalProperties: true`).
+      watermark: S_BOOLEAN,
     }),
   },
   {

--- a/functions/src/services/watermark/index.test.ts
+++ b/functions/src/services/watermark/index.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import sharp from 'sharp';
+import {
+  buildWatermarkSvg,
+  escapeSvgText,
+  renderWatermark,
+  substituteWatermarkTokens,
+} from './index.js';
+import type { ExportPresetWatermark } from '../../models/ExportPreset.js';
+
+describe('substituteWatermarkTokens', () => {
+  it('replaces {tenantName}, {photoId}, and {date}', () => {
+    const result = substituteWatermarkTokens(
+      'PROOF — {tenantName} / {photoId} @ {date}',
+      { tenantName: 'Acme', photoId: 'p_1', date: '2026-06-24' }
+    );
+    expect(result).toBe('PROOF — Acme / p_1 @ 2026-06-24');
+  });
+
+  it('fills in today’s UTC date when {date} token is unfilled', () => {
+    const result = substituteWatermarkTokens('shot on {date}', {});
+    // ISO date prefix shape: YYYY-MM-DD
+    expect(result).toMatch(/^shot on \d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('substitutes missing tenantName / photoId to empty string', () => {
+    expect(substituteWatermarkTokens('a-{tenantName}-b-{photoId}-c', {})).toBe(
+      'a--b--c'
+    );
+  });
+
+  it('passes through unknown {foo} tokens verbatim (no user PII tokens)', () => {
+    // {email} is not an allowed token; it must be left intact so a host
+    // accidentally including it doesn't leak PII *and* doesn't error.
+    expect(substituteWatermarkTokens('hi {email}', { tenantName: 'X' })).toBe(
+      'hi {email}'
+    );
+  });
+});
+
+describe('escapeSvgText', () => {
+  it('escapes the five XML entities and leaves other text alone', () => {
+    expect(escapeSvgText(`Tom & Jerry "<3" 'won'`)).toBe(
+      'Tom &amp; Jerry &quot;&lt;3&quot; &apos;won&apos;'
+    );
+    expect(escapeSvgText('plain text 123')).toBe('plain text 123');
+  });
+});
+
+describe('buildWatermarkSvg', () => {
+  it('anchors bottom-right by default with end text-anchor', () => {
+    const svg = buildWatermarkSvg({
+      imageWidth: 1000,
+      imageHeight: 500,
+      text: 'hi',
+      opacity: 0.5,
+      position: 'bottom-right',
+    });
+    expect(svg).toContain('text-anchor="end"');
+    expect(svg).toMatch(/x="(\d+)"/);
+    // y should be near imageHeight (less padding)
+    expect(svg).toMatch(/y="(4\d\d|500)"/);
+    expect(svg).toContain('opacity="0.5"');
+  });
+
+  it('anchors top-left with start text-anchor', () => {
+    const svg = buildWatermarkSvg({
+      imageWidth: 1000,
+      imageHeight: 500,
+      text: 'hi',
+      opacity: 0.7,
+      position: 'top-left',
+    });
+    expect(svg).toContain('text-anchor="start"');
+  });
+
+  it('clamps opacity to [0,1] when given out-of-range input', () => {
+    const high = buildWatermarkSvg({
+      imageWidth: 100,
+      imageHeight: 100,
+      text: 'x',
+      opacity: 5,
+      position: 'top-right',
+    });
+    expect(high).toContain('opacity="1"');
+    const low = buildWatermarkSvg({
+      imageWidth: 100,
+      imageHeight: 100,
+      text: 'x',
+      opacity: -1,
+      position: 'top-right',
+    });
+    expect(low).toContain('opacity="0"');
+  });
+
+  it('XML-escapes the text so the SVG cannot be injection-broken', () => {
+    const svg = buildWatermarkSvg({
+      imageWidth: 100,
+      imageHeight: 100,
+      text: '</text><script>alert(1)</script>',
+      opacity: 0.5,
+      position: 'bottom-right',
+    });
+    expect(svg).not.toContain('<script>');
+    expect(svg).toContain('&lt;/text&gt;&lt;script&gt;');
+  });
+});
+
+describe('renderWatermark', () => {
+  async function tinyJpeg(): Promise<Buffer> {
+    return sharp({
+      create: {
+        width: 64,
+        height: 48,
+        channels: 3,
+        background: { r: 50, g: 50, b: 50 },
+      },
+    })
+      .jpeg({ quality: 90 })
+      .toBuffer();
+  }
+
+  it('returns the input unchanged when enabled is false', async () => {
+    const input = await tinyJpeg();
+    const out = await renderWatermark({
+      inputBuffer: input,
+      watermark: {
+        enabled: false,
+        text: 'PROOF',
+        opacity: 0.5,
+        position: 'bottom-right',
+      } satisfies ExportPresetWatermark,
+    });
+    expect(out).toBe(input);
+  });
+
+  it('returns the input unchanged when (substituted) text is empty', async () => {
+    const input = await tinyJpeg();
+    const out = await renderWatermark({
+      inputBuffer: input,
+      watermark: {
+        enabled: true,
+        text: '{tenantName}', // tenantName not supplied -> empty
+        opacity: 0.5,
+        position: 'bottom-right',
+      } satisfies ExportPresetWatermark,
+    });
+    expect(out).toBe(input);
+  });
+
+  it('returns watermarked bytes that decode as a JPEG with the same dimensions', async () => {
+    const input = await tinyJpeg();
+    const out = await renderWatermark({
+      inputBuffer: input,
+      watermark: {
+        enabled: true,
+        text: 'PROOF — {tenantName}',
+        opacity: 0.5,
+        position: 'bottom-right',
+      } satisfies ExportPresetWatermark,
+      tokens: { tenantName: 'Acme' },
+    });
+    // Must still be a JPEG
+    expect(out[0]).toBe(0xff);
+    expect(out[1]).toBe(0xd8);
+    const meta = await sharp(out).metadata();
+    expect(meta.width).toBe(64);
+    expect(meta.height).toBe(48);
+    expect(meta.format).toBe('jpeg');
+    // Different bytes than the input.
+    expect(Buffer.compare(out, input)).not.toBe(0);
+  });
+});

--- a/functions/src/services/watermark/index.ts
+++ b/functions/src/services/watermark/index.ts
@@ -1,0 +1,220 @@
+/**
+ * Shared watermark rendering utility (issue #185).
+ *
+ * Composites a single-line text watermark over a JPEG buffer, anchored
+ * to one of the four image corners. Used by:
+ *   - the export pipeline (`exportService.ts`) when an export preset
+ *     declares `watermark.enabled: true`
+ *   - share delivery (when wired up; today the share service only
+ *     records a `watermarkApplied` flag without producing rendered
+ *     bytes)
+ *
+ * Co-locating the renderer here is the "shared util" called for in the
+ * issue, so future watermark consumers can `import { renderWatermark }`
+ * rather than duplicate SVG/Sharp wiring.
+ *
+ * Design notes:
+ *   - The watermark is drawn as an SVG layer and composited with Sharp,
+ *     so the rendering does NOT require a system font \u2014 SVG `<text>`
+ *     elements fall back to the default sans-serif glyph metrics in
+ *     librsvg, which Sharp ships with.
+ *   - Watermark size scales with the rendered image's shortest edge so
+ *     a 1280px preset and an 8192px preset produce visually comparable
+ *     watermarks.
+ *   - All untrusted text is XML-escaped before substitution to prevent
+ *     SVG injection from a host-supplied watermark template.
+ */
+import sharp from 'sharp';
+import type { ExportPresetWatermark } from '../../models/ExportPreset.js';
+
+/**
+ * Tokens substituted into the watermark text. Intentionally limited to
+ * non-PII fields per issue #185 ("no user PII tokens").
+ */
+export interface WatermarkTokens {
+  /** Tenant display name (typically branding `appName`). */
+  tenantName?: string;
+  /** Photo id. */
+  photoId?: string;
+  /**
+   * Optional `YYYY-MM-DD` date. When omitted, `renderWatermark` fills in
+   * today's UTC date so `{date}` always produces a value.
+   */
+  date?: string;
+}
+
+/** Allow `{tenantName}`, `{photoId}`, `{date}` only. */
+const TOKEN_PATTERN = /\{(tenantName|photoId|date)\}/g;
+
+/**
+ * Substitute the allow-listed tokens in `template`. Unknown `{foo}`
+ * sequences are left intact so a host can include literal curly braces
+ * in their watermark text without escaping.
+ *
+ * Exported for unit tests.
+ */
+export function substituteWatermarkTokens(
+  template: string,
+  tokens: WatermarkTokens
+): string {
+  const date = tokens.date ?? isoDateUtc(new Date());
+  return template.replace(TOKEN_PATTERN, (_match, key: string) => {
+    switch (key) {
+      case 'tenantName':
+        return tokens.tenantName ?? '';
+      case 'photoId':
+        return tokens.photoId ?? '';
+      case 'date':
+        return date;
+      default:
+        return _match;
+    }
+  });
+}
+
+/**
+ * Format a `Date` as `YYYY-MM-DD` in UTC. We don't pull in a date library
+ * for this; the slice avoids locale formatting.
+ */
+function isoDateUtc(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * XML-escape user-supplied text so it can be safely interpolated into
+ * an SVG `<text>` body. Covers the five XML entities; everything else
+ * (including curly braces) is allowed through.
+ */
+export function escapeSvgText(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Build the SVG overlay used by `renderWatermark`. Exported so tests
+ * can assert on the generated markup without exercising Sharp.
+ */
+export function buildWatermarkSvg(opts: {
+  imageWidth: number;
+  imageHeight: number;
+  text: string;
+  opacity: number;
+  position: ExportPresetWatermark['position'];
+}): string {
+  const { imageWidth, imageHeight, text, opacity, position } = opts;
+
+  // Font size scales with the shortest edge so a small thumbnail and a
+  // huge full-resolution export both end up with a readable watermark.
+  // Clamp to a sensible range so 32px previews don't get an unreadable
+  // 4px font and 8192px exports don't get an 80px font that dominates.
+  const shortestEdge = Math.max(1, Math.min(imageWidth, imageHeight));
+  const fontSize = Math.max(10, Math.min(48, Math.round(shortestEdge * 0.04)));
+  const padding = Math.max(6, Math.round(fontSize * 0.6));
+
+  // Anchor + baseline depend on which corner we're targeting. Sharp
+  // composites the SVG at (0,0) over the image and inherits the
+  // image's dimensions, so we position the text within the SVG itself
+  // rather than via composite offsets \u2014 simpler and avoids a separate
+  // Sharp call to measure text bounds.
+  let x: number;
+  let y: number;
+  let textAnchor: 'start' | 'end';
+  switch (position) {
+    case 'top-left':
+      x = padding;
+      y = padding + fontSize;
+      textAnchor = 'start';
+      break;
+    case 'top-right':
+      x = imageWidth - padding;
+      y = padding + fontSize;
+      textAnchor = 'end';
+      break;
+    case 'bottom-left':
+      x = padding;
+      y = imageHeight - padding;
+      textAnchor = 'start';
+      break;
+    case 'bottom-right':
+    default:
+      x = imageWidth - padding;
+      y = imageHeight - padding;
+      textAnchor = 'end';
+      break;
+  }
+
+  // White text with a subtle black stroke so it stays legible on both
+  // bright and dark images. `opacity` controls the layer opacity rather
+  // than per-fill opacity so the stroke contrast is preserved.
+  const safeText = escapeSvgText(text);
+  const layerOpacity = clampOpacity(opacity);
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${imageWidth}" height="${imageHeight}" viewBox="0 0 ${imageWidth} ${imageHeight}">` +
+    `<g opacity="${layerOpacity}">` +
+    `<text x="${x}" y="${y}" font-family="sans-serif" font-size="${fontSize}" font-weight="600" fill="#ffffff" stroke="#000000" stroke-width="${Math.max(1, Math.round(fontSize * 0.06))}" paint-order="stroke" text-anchor="${textAnchor}">${safeText}</text>` +
+    `</g>` +
+    `</svg>`
+  );
+}
+
+/**
+ * Clamp the opacity into `[0, 1]`. The validation layer rejects values
+ * outside the range, but we double-guard here so a buggy caller cannot
+ * produce a malformed SVG attribute.
+ */
+function clampOpacity(opacity: number): number {
+  if (!Number.isFinite(opacity)) return 1;
+  if (opacity < 0) return 0;
+  if (opacity > 1) return 1;
+  return opacity;
+}
+
+/**
+ * Render `inputBuffer` with the watermark composited over it. The
+ * caller is responsible for ensuring the input is a renderable JPEG
+ * (Sharp will reject other formats). The returned buffer is a
+ * re-encoded JPEG with the same quality as the input pipeline expects.
+ *
+ * No-ops (returns the input unchanged) when `watermark.enabled` is
+ * false or `watermark.text` (after substitution) is empty.
+ */
+export async function renderWatermark(opts: {
+  inputBuffer: Buffer;
+  watermark: ExportPresetWatermark;
+  tokens?: WatermarkTokens;
+  /** JPEG quality to re-encode at. Defaults to 90. */
+  jpegQuality?: number;
+}): Promise<Buffer> {
+  const { inputBuffer, watermark, tokens, jpegQuality = 90 } = opts;
+  if (!watermark.enabled) return inputBuffer;
+  const finalText = substituteWatermarkTokens(watermark.text, tokens ?? {});
+  if (!finalText.trim()) return inputBuffer;
+
+  const pipeline = sharp(inputBuffer);
+  const meta = await pipeline.metadata();
+  const width = meta.width ?? 0;
+  const height = meta.height ?? 0;
+  if (width <= 0 || height <= 0) {
+    // Cannot place a watermark without dimensions; fail open with the
+    // unwatermarked bytes rather than throwing \u2014 export pipelines that
+    // already wrote a cache entry can still serve the source.
+    return inputBuffer;
+  }
+
+  const svg = buildWatermarkSvg({
+    imageWidth: width,
+    imageHeight: height,
+    text: finalText,
+    opacity: watermark.opacity,
+    position: watermark.position,
+  });
+
+  return pipeline
+    .composite([{ input: Buffer.from(svg, 'utf8'), top: 0, left: 0 }])
+    .jpeg({ quality: jpegQuality, progressive: true, mozjpeg: true })
+    .toBuffer();
+}


### PR DESCRIPTION
## Summary

Adds per-preset watermark configuration to the export pipeline so hosts reselling AuraPix for client-proofing can ship watermarked exports without changing how share links work (issue #185, complements share-link watermarking #32/#46).

## Changes

- ExportPreset schema gains optional `watermark: { enabled, text, opacity, position }`.
- New shared watermark util at `functions/src/services/watermark/` — composites SVG text over the encoded JPEG via Sharp `composite()`. XML-escapes templates to block SVG injection.
- Token substitution: `{tenantName}`, `{photoId}`, `{date}` only (no user PII tokens). Unknown `{foo}` passes through verbatim.
- Export pipeline applies the watermark on `jpeg` presets only; `original` passthrough is intentionally untouched. Cache key now includes a 12-char watermark hash when enabled so config changes invalidate cache. Pre-#185 cache keys remain valid for clean exports.
- Tenant name is resolved from branding `appName` with tenantId fallback.
- `photo.exported` metering event gains `meta.watermark: boolean` — additive on v1 (no version bump per eventCatalog rules).
- OpenAPI contract documents `ExportPresetWatermark` + adds a watermarked example. `contract:check` passes.
- Docs: new sections in `docs/features/uploads-processing-storage.md`; `metering-events.md` regenerated.

## Acceptance criteria

- [x] OpenAPI contract update; `contract:check` passes.
- [x] Shared watermark util used by export pipeline (ready for share delivery to adopt).
- [x] Export pipeline writes watermarked variant and emits `photo.exported` with `meta.watermark: true`.
- [x] Unit tests: enabled/disabled, token substitution, invalid opacity rejected (`[0,1]`), cross-tenant preset access forbidden.
- [x] `docs/features/uploads-processing-storage.md` updated with examples.
- [x] Webhook event catalog regenerated.

## Testing

- Watermark renderer: 12/12 pass.
- Tenant export presets routes: 19/19 pass (5 new watermark / cross-tenant tests).
- Photo export routes: 10/10 pass (1 new integration test for `meta.watermark`, cache partitioning, re-hit).
- Contract check: clean (validate + breaking).

Total: 81 tests across touched areas pass. 12 pre-existing failures in `photosV1.test.ts` and `tenantUsersV1.test.ts` are unrelated.

## Caveats

- `format: 'original'` presets ignore `watermark` by design — passthrough must not modify source bytes.
- Share delivery still only sets a `watermarkApplied` flag; adopting `renderWatermark` is left as a follow-up to keep this PR scoped to #185.

Fixes rwrife/AuraPix#185