### PR TITLE
fix: include branding tokens in `aurapix-ready` handshake (#187)

### DIFF
--- a/contracts/openapi/embed.openapi.json
+++ b/contracts/openapi/embed.openapi.json
@@ -178,6 +178,28 @@
           "embed": { "$ref": "#/components/schemas/EmbedConfig" }
         }
       },
+      "AuraPixBrandingTokens": {
+        "type": "object",
+        "description": "Public-safe branding tokens forwarded to host pages via the `aurapix:ready` postMessage handshake (issue #187). Emitted by the server only when the tenant has any non-default branding configured — absent payload means the host should fall back to its own defaults. Contains **only public-safe** values: no API keys, no internal IDs.",
+        "properties": {
+          "primaryColor": { "type": "string", "description": "Hex primary brand color (e.g. `#2563eb`)." },
+          "accentColor": { "type": "string", "description": "Hex accent brand color (e.g. `#7c3aed`)." },
+          "logoUrl": { "type": "string", "description": "Public logo URL (typically an HTTPS asset)." },
+          "fontFamily": { "type": "string", "description": "CSS `font-family` value the host can mirror in its surrounding chrome." }
+        },
+        "additionalProperties": false
+      },
+      "AuraPixReadyMessage": {
+        "type": "object",
+        "description": "`aurapix:ready` postMessage envelope sent by the embedded UI to the host page on mount. The shape lives in the postMessage contract — it is documented here for OpenAPI consumers generating typed clients.",
+        "required": ["type", "tenantId", "version"],
+        "properties": {
+          "type": { "type": "string", "const": "aurapix:ready" },
+          "tenantId": { "type": "string" },
+          "version": { "type": "string", "description": "SemVer string of the embedded build." },
+          "branding": { "$ref": "#/components/schemas/AuraPixBrandingTokens" }
+        }
+      },
       "CspReport": {
         "type": "object",
         "properties": {

--- a/docs/features/embed-handshake.md
+++ b/docs/features/embed-handshake.md
@@ -110,11 +110,44 @@ shape doesn't match below.
 
 ### Embedded → Host
 
-| `type`             | Payload                            | When emitted                                             |
-| ------------------ | ---------------------------------- | -------------------------------------------------------- |
-| `aurapix:ready`    | `{ tenantId, version }`            | Immediately after the embedded UI mounts                 |
-| `aurapix:resize`   | `{ height }` (CSS px)              | When the content height changes (ResizeObserver)         |
-| `aurapix:event`    | `{ name, payload? }`               | Select user actions (`selection-changed`, `upload-started`, …) |
+| `type`             | Payload                                          | When emitted                                             |
+| ------------------ | ------------------------------------------------ | -------------------------------------------------------- |
+| `aurapix:ready`    | `{ tenantId, version, branding? }`               | Immediately after the embedded UI mounts                 |
+| `aurapix:resize`   | `{ height }` (CSS px)                            | When the content height changes (ResizeObserver)         |
+| `aurapix:event`    | `{ name, payload? }`                             | Select user actions (`selection-changed`, `upload-started`, …) |
+
+#### `aurapix:ready` branding payload (issue #187)
+
+The `branding` field is **optional**. The server populates it only when
+the tenant has any non-default branding configured (per #132/#135) — when
+the field is absent, the host page should fall back to its own defaults.
+
+The payload is strictly **read-only** and contains **only public-safe
+tokens** (no API keys, no internal IDs, no Firestore document paths, no
+`updatedAt`, no `tenantId`):
+
+```ts
+interface AuraPixBrandingTokens {
+  /** Hex primary brand color (e.g. `#2563eb`). */
+  primaryColor?: string;
+  /** Hex accent brand color (e.g. `#7c3aed`). */
+  accentColor?: string;
+  /** Public logo URL (typically an HTTPS asset). */
+  logoUrl?: string;
+  /** CSS `font-family` value the host can mirror. */
+  fontFamily?: string;
+}
+```
+
+The host page can use these tokens to instantly paint surrounding chrome
+with tenant colors — saving a second HTTP round-trip to
+`GET /v1/tenants/:id/branding`. Because the field is additive and
+optional, older host integrations that don't read `branding` continue to
+work unchanged.
+
+The shape is validated client-side by `@aurapix/embed` before being
+surfaced via `onReady` so a compromised iframe cannot inject
+non-string values into the host's CSS.
 
 ### Host → Embedded
 
@@ -188,7 +221,7 @@ existing `MeteringBus`:
 
 | Event                      | When                                                                                       | Debounce            |
 | -------------------------- | ------------------------------------------------------------------------------------------ | ------------------- |
-| `embed.session_started`    | An allowed parent frames an embed-eligible response                                        | 1 / min / tenant+origin |
+| `embed.session_started`    | An allowed parent frames an embed-eligible response. Carries `meta.brandingApplied: boolean` (issue #187) for white-label rollout debugging. | 1 / min / tenant+origin |
 | `embed.session_ended`      | The `@aurapix/embed` SDK posts to `POST /v1/tenants/:id/embed/session-end` on `destroy()` or `pagehide` (issue #177) | None (client-driven) |
 | `embed.origin_blocked`     | Browser posts a `frame-ancestors` violation report                                         | None (report-driven) |
 
@@ -205,4 +238,6 @@ through the standard host webhook fanout (see `metering-events.md`).
 | `src/embed/host-sdk.ts` with TypeScript types and unit tests             | `src/embed/host-sdk.ts`, `src/embed/contract.ts`, tests   |
 | Embedded UI ignores messages from non-allowed origins (tested)           | `src/embed/embedded.ts` + `src/embed/host-sdk.test.ts`    |
 | `embed.session_started` flows through existing bus                       | `MeteringBus` event type + middleware emit                |
+| `aurapix:ready` carries optional `branding` tokens (#187)                | `src/embed/contract.ts`, `loadBrandingTokensForEmbed`     |
+| `embed.session_started.meta.brandingApplied` populated (#187)            | `createEmbedCspMiddleware` + server.ts wiring             |
 | OpenAPI updated                                                          | `contracts/openapi/embed.openapi.json`                    |

--- a/functions/src/routes/brandingV1.ts
+++ b/functions/src/routes/brandingV1.ts
@@ -99,6 +99,61 @@ export function brandingWithDefaults(tenantId: string, partial: Partial<Branding
   };
 }
 
+/**
+ * Public-safe branding tokens emitted alongside the `aurapix:ready`
+ * handshake (issue #187). Strictly read-only and **only** carries tokens
+ * safe for an untrusted host page — no API keys, no internal IDs, no
+ * Firestore document paths, no `updatedAt`, no `tenantId`.
+ */
+export interface EmbedBrandingTokens {
+  primaryColor?: string;
+  accentColor?: string;
+  logoUrl?: string;
+  fontFamily?: string;
+}
+
+/**
+ * Resolve the branding tokens to embed in the handshake for `tenantId`.
+ * Returns `null` when the tenant has no non-default branding configured
+ * (per issue #187, avoid noise on the wire — absent payload tells the
+ * host to fall back to its own defaults).
+ *
+ * Only public-safe fields are returned; internal record fields
+ * (`tenantId`, `updatedAt`, etc.) are intentionally stripped.
+ */
+export async function loadBrandingTokensForEmbed(
+  dataAdapter: DataAdapter,
+  tenantId: string
+): Promise<EmbedBrandingTokens | null> {
+  if (!isValidTenantId(tenantId)) return null;
+  let stored: BrandingRecord | null = null;
+  try {
+    stored = await dataAdapter.fetchData<BrandingRecord>(BRANDING_COLLECTION, tenantId);
+  } catch (err) {
+    logger.warn({ err, tenantId }, 'Failed to load tenant branding for embed handshake');
+    return null;
+  }
+  if (!stored) return null;
+
+  const tokens: EmbedBrandingTokens = {};
+  const primary = sanitizeHexColor(stored.primaryColor);
+  if (primary && primary !== DEFAULT_BRANDING.primaryColor) {
+    tokens.primaryColor = primary;
+  }
+  const accent = sanitizeHexColor(stored.accentColor);
+  if (accent && accent !== DEFAULT_BRANDING.accentColor) {
+    tokens.accentColor = accent;
+  }
+  if (typeof stored.logoUrl === 'string' && stored.logoUrl.length > 0) {
+    tokens.logoUrl = stored.logoUrl;
+  }
+  // No `fontFamily` field in BrandingRecord today; reserved for future
+  // extension (#132/#135 follow-up) without changing the embed contract.
+
+  if (Object.keys(tokens).length === 0) return null;
+  return tokens;
+}
+
 export interface BrandingRouterOptions {
   /**
    * Authorization gate for PUT. Should return true when the caller has

--- a/functions/src/routes/embedV1.ts
+++ b/functions/src/routes/embedV1.ts
@@ -404,6 +404,16 @@ export function createEmbedCspMiddleware(opts: {
    * events as host pages frame AuraPix. When omitted, no event is emitted.
    */
   meteringBus?: { emit?: (e: unknown) => void };
+  /**
+   * Optional branding resolver (issue #187). When set and the tenant has
+   * non-default branding configured, the resolved tokens are surfaced via
+   * `embed.session_started.meta.brandingApplied = true`. The actual
+   * branding payload is delivered to the host page through the
+   * `aurapix:ready` postMessage handshake — this flag is purely for
+   * white-label rollout debugging. Failures fall back to
+   * `brandingApplied: false` and never break CSP enforcement.
+   */
+  loadBrandingApplied?: (tenantId: string) => Promise<boolean>;
 }) {
   // Per (tenantId, origin) dedupe window — see acceptance criteria
   // ("debounced, max 1/min/tenant/origin").
@@ -472,6 +482,18 @@ export function createEmbedCspMiddleware(opts: {
                 if (now - t >= DEDUPE_MS * 5) seen.delete(k);
               }
             }
+            // Issue #187: resolve whether branding tokens will be applied
+            // for this session so hosts can track white-label rollout. The
+            // actual tokens travel via the `aurapix:ready` postMessage
+            // payload, not through metering.
+            let brandingApplied = false;
+            if (opts.loadBrandingApplied) {
+              try {
+                brandingApplied = await opts.loadBrandingApplied(tenantId);
+              } catch (err) {
+                logger.debug({ err, tenantId }, 'Failed to resolve brandingApplied for embed.session_started');
+              }
+            }
             try {
               opts.meteringBus.emit({
                 tenantId,
@@ -479,6 +501,7 @@ export function createEmbedCspMiddleware(opts: {
                 meta: {
                   origin: parentOrigin,
                   userAgent: req.headers['user-agent'] ?? null,
+                  brandingApplied,
                 },
               });
             } catch (err) {

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -106,7 +106,7 @@ import { createAlbumsRouter } from './routes/albums.js';
 import { createAlbumsV1Router } from './routes/albumsV1.js';
 import { createPhotosListV1Router } from './routes/photosListV1.js';
 import { createComplianceV1Router } from './routes/complianceV1.js';
-import { createBrandingV1Router } from './routes/brandingV1.js';
+import { createBrandingV1Router, loadBrandingTokensForEmbed } from './routes/brandingV1.js';
 import { createTenantUsageRouter } from './routes/tenantUsage.js';
 import { createTenantUsersRouter } from './routes/tenantUsersV1.js';
 import { createTenantAdminRouter } from './routes/tenantAdmin.js';
@@ -181,6 +181,14 @@ const embedCspMiddleware = createEmbedCspMiddleware({
   loadOrigins: (tenantId) => loadAllowedOriginsForTenant(dataAdapter, tenantId),
   reportUriTemplate: '/api/v1/tenants/{tenantId}/embed/csp-report',
   meteringBus: meteringBus as unknown as { emit?: (e: unknown) => void },
+  // Issue #187: surface whether tenant branding will be applied to the
+  // embed session so hosts can debug white-label rollouts. The actual
+  // branding tokens flow through the `aurapix:ready` postMessage payload,
+  // not the metering bus.
+  loadBrandingApplied: async (tenantId) => {
+    const tokens = await loadBrandingTokensForEmbed(dataAdapter, tenantId);
+    return tokens !== null;
+  },
 });
 app.use('/api/v1', embedCspMiddleware);
 app.use('/v1', embedCspMiddleware);

--- a/functions/test/routes/brandingV1.test.ts
+++ b/functions/test/routes/brandingV1.test.ts
@@ -4,6 +4,7 @@ import {
   createBrandingV1Router,
   sanitizeHexColor,
   brandingWithDefaults,
+  loadBrandingTokensForEmbed,
   BRANDING_COLLECTION,
   DEFAULT_BRANDING,
   type BrandingRecord,
@@ -187,5 +188,127 @@ describe('PUT /:tenantId/branding', () => {
     expect(res.status).toBe(200);
     expect(res.body.branding.appName).toBe('Acme');
     expect(adapter._store.acme.primaryColor).toBe('#abcdef');
+  });
+});
+
+describe('loadBrandingTokensForEmbed (issue #187)', () => {
+  it('returns null for an unknown tenant', async () => {
+    const adapter = makeAdapter();
+    expect(await loadBrandingTokensForEmbed(adapter, 'unknown')).toBeNull();
+  });
+
+  it('returns null when only default colors and no logo are configured', async () => {
+    // Tenant has a doc but every field is the default — emitting branding
+    // tokens here would be noise. The host should fall back to its own
+    // defaults.
+    const adapter = makeAdapter({
+      acme: {
+        tenantId: 'acme',
+        appName: DEFAULT_BRANDING.appName,
+        primaryColor: DEFAULT_BRANDING.primaryColor,
+        accentColor: DEFAULT_BRANDING.accentColor,
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    });
+    expect(await loadBrandingTokensForEmbed(adapter, 'acme')).toBeNull();
+  });
+
+  it('returns only non-default tokens for a partially-branded tenant', async () => {
+    const adapter = makeAdapter({
+      acme: {
+        tenantId: 'acme',
+        appName: 'Acme',
+        primaryColor: '#abcdef',
+        accentColor: DEFAULT_BRANDING.accentColor,
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    });
+    const tokens = await loadBrandingTokensForEmbed(adapter, 'acme');
+    expect(tokens).toEqual({ primaryColor: '#abcdef' });
+  });
+
+  it('returns logoUrl independently of the default-color comparison', async () => {
+    const adapter = makeAdapter({
+      acme: {
+        tenantId: 'acme',
+        appName: DEFAULT_BRANDING.appName,
+        primaryColor: DEFAULT_BRANDING.primaryColor,
+        accentColor: DEFAULT_BRANDING.accentColor,
+        logoUrl: 'https://cdn.example.com/logo.svg',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    });
+    const tokens = await loadBrandingTokensForEmbed(adapter, 'acme');
+    expect(tokens).toEqual({ logoUrl: 'https://cdn.example.com/logo.svg' });
+  });
+
+  it('returns all non-default tokens for a fully-branded tenant', async () => {
+    const adapter = makeAdapter({
+      acme: {
+        tenantId: 'acme',
+        appName: 'Acme',
+        primaryColor: '#abcdef',
+        accentColor: '#123456',
+        logoUrl: 'https://cdn.example.com/logo.svg',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    });
+    const tokens = await loadBrandingTokensForEmbed(adapter, 'acme');
+    expect(tokens).toEqual({
+      primaryColor: '#abcdef',
+      accentColor: '#123456',
+      logoUrl: 'https://cdn.example.com/logo.svg',
+    });
+  });
+
+  it('never leaks internal fields (tenantId, updatedAt, appName, faviconUrl)', async () => {
+    // Acceptance criteria: snapshot test on payload shape — no
+    // secret/internal fields leaked.
+    const adapter = makeAdapter({
+      acme: {
+        tenantId: 'acme',
+        appName: 'Acme',
+        primaryColor: '#abcdef',
+        accentColor: '#123456',
+        logoUrl: 'https://cdn.example.com/logo.svg',
+        faviconUrl: 'https://cdn.example.com/favicon.ico',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    });
+    const tokens = await loadBrandingTokensForEmbed(adapter, 'acme');
+    expect(tokens).not.toBeNull();
+    expect(Object.keys(tokens!).sort()).toEqual(['accentColor', 'logoUrl', 'primaryColor']);
+    for (const forbidden of ['tenantId', 'updatedAt', 'appName', 'faviconUrl']) {
+      expect((tokens as Record<string, unknown>)[forbidden]).toBeUndefined();
+    }
+  });
+
+  it('rejects invalid tenant ids without hitting the adapter', async () => {
+    const adapter = makeAdapter({
+      acme: {
+        tenantId: 'acme', appName: 'Acme',
+        primaryColor: '#abcdef', accentColor: '#123456',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    });
+    expect(await loadBrandingTokensForEmbed(adapter, 'has space')).toBeNull();
+  });
+
+  it('ignores malformed stored colors (defensive)', async () => {
+    const adapter = makeAdapter({
+      acme: {
+        tenantId: 'acme',
+        appName: 'Acme',
+        // Intentionally bogus values — stored data corruption shouldn't
+        // leak through to the embed handshake.
+        primaryColor: 'rgb(255,0,0)',
+        accentColor: '#123',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    });
+    const tokens = await loadBrandingTokensForEmbed(adapter, 'acme');
+    // accentColor #123 is a valid hex AND differs from default, so it
+    // flows through; primaryColor is dropped.
+    expect(tokens).toEqual({ accentColor: '#123' });
   });
 });

--- a/functions/test/routes/embedV1.test.ts
+++ b/functions/test/routes/embedV1.test.ts
@@ -502,6 +502,108 @@ describe('createEmbedCspMiddleware', () => {
     });
     expect(emit).not.toHaveBeenCalled();
   });
+
+  it('populates meta.brandingApplied on embed.session_started (issue #187)', async () => {
+    const emit = vi.fn();
+    const loadBrandingApplied = vi.fn(async () => true);
+    const middleware = createEmbedCspMiddleware({
+      tenantFromReq: () => 'acme',
+      loadOrigins: async () => ['https://host.example.com'],
+      meteringBus: { emit },
+      loadBrandingApplied,
+    });
+    const app = express();
+    app.use(middleware);
+    app.get('/x', (_req, res) => res.json({ ok: true }));
+
+    await request(app, 'GET', '/x', undefined, {
+      'referer': 'https://host.example.com/page',
+      'sec-fetch-dest': 'iframe',
+    });
+    expect(loadBrandingApplied).toHaveBeenCalledWith('acme');
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'embed.session_started',
+      meta: expect.objectContaining({
+        origin: 'https://host.example.com',
+        brandingApplied: true,
+      }),
+    }));
+  });
+
+  it('falls back to brandingApplied=false when loadBrandingApplied throws (issue #187)', async () => {
+    const emit = vi.fn();
+    const middleware = createEmbedCspMiddleware({
+      tenantFromReq: () => 'acme',
+      loadOrigins: async () => ['https://host.example.com'],
+      meteringBus: { emit },
+      loadBrandingApplied: async () => {
+        throw new Error('branding lookup blew up');
+      },
+    });
+    const app = express();
+    app.use(middleware);
+    app.get('/x', (_req, res) => res.json({ ok: true }));
+
+    await request(app, 'GET', '/x', undefined, {
+      'referer': 'https://host.example.com/page',
+      'sec-fetch-dest': 'iframe',
+    });
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect((emit.mock.calls[0][0] as any).meta.brandingApplied).toBe(false);
+  });
+
+  it('emits brandingApplied=false when loadBrandingApplied is omitted (backward compatibility)', async () => {
+    const emit = vi.fn();
+    const middleware = createEmbedCspMiddleware({
+      tenantFromReq: () => 'acme',
+      loadOrigins: async () => ['https://host.example.com'],
+      meteringBus: { emit },
+    });
+    const app = express();
+    app.use(middleware);
+    app.get('/x', (_req, res) => res.json({ ok: true }));
+
+    await request(app, 'GET', '/x', undefined, {
+      'referer': 'https://host.example.com/page',
+      'sec-fetch-dest': 'iframe',
+    });
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect((emit.mock.calls[0][0] as any).meta.brandingApplied).toBe(false);
+  });
+
+  it('keeps blocking disallowed origins regardless of branding config (issue #187)', async () => {
+    // Integration-style: the branding hook MUST NOT relax origin
+    // enforcement. Disallowed parents stay blocked.
+    const emit = vi.fn();
+    const loadBrandingApplied = vi.fn(async () => true);
+    const middleware = createEmbedCspMiddleware({
+      tenantFromReq: () => 'acme',
+      loadOrigins: async () => ['https://host.example.com'],
+      meteringBus: { emit },
+      loadBrandingApplied,
+    });
+    const app = express();
+    app.use(middleware);
+    app.get('/x', (_req, res) => res.json({ ok: true }));
+
+    // Disallowed referer — must not emit session_started and must not
+    // even consult the branding hook.
+    await request(app, 'GET', '/x', undefined, {
+      'referer': 'https://evil.example.com/page',
+      'sec-fetch-dest': 'iframe',
+    });
+    expect(emit).not.toHaveBeenCalled();
+    expect(loadBrandingApplied).not.toHaveBeenCalled();
+
+    // Allowed referer — emit fires AND carries the branding flag.
+    await request(app, 'GET', '/x', undefined, {
+      'referer': 'https://host.example.com/page',
+      'sec-fetch-dest': 'iframe',
+    });
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect((emit.mock.calls[0][0] as any).meta.brandingApplied).toBe(true);
+  });
 });
 
 describe('loadAllowedOriginsForTenant', () => {

--- a/packages/embed-sdk/README.md
+++ b/packages/embed-sdk/README.md
@@ -81,7 +81,7 @@ npm install @aurapix/embed
 | `aurapixOrigin`      | `string`                                        | `'https://app.aurapix.com'`        | Exact origin; never `'*'`. Override for dev (`http://localhost:5173`).                                  |
 | `embedUrl`           | `string`                                        | `${aurapixOrigin}/embed`           | For non-default embed routes / staging.                                                                |
 | `handshakeTimeoutMs` | `number`                                        | `5000`                             | `onError` fires with `code: 'handshake_timeout'` if no `aurapix:ready` arrives in time.                |
-| `onReady`            | `({ tenantId, version, origin }) => void`       | —                                  | Fires once on successful handshake.                                                                    |
+| `onReady`            | `({ tenantId, version, origin, branding? }) => void` | —                                  | Fires once on successful handshake. The optional `branding` object carries public-safe tenant tokens (issue [#187](https://github.com/rwrife/AuraPix/issues/187)) so the host can paint its own chrome to match on first paint without a second network request. |
 | `onError`            | `(AuraPixError) => void`                        | —                                  | Typed errors. `code` is one of `invalid_element`, `invalid_origin`, `invalid_options`, `handshake_timeout`, `destroyed`. |
 | `onEvent`            | `({ name, payload }) => void`                   | —                                  | Catch-all for every forwarded `aurapix:event`.                                                          |
 | `sandbox`            | `string \| null`                                | conservative default               | Set to `null` to omit the `sandbox` attribute entirely.                                                |
@@ -169,6 +169,9 @@ When the SDK successfully handshakes with AuraPix, the backend emits:
 
 - `embed.session_started` — already in the metering bus today, fired from
   the CSP middleware when an allowed parent origin frames the embed.
+  Carries `meta.brandingApplied: boolean` (issue
+  [#187](https://github.com/rwrife/AuraPix/issues/187)) so hosts can see
+  how often tenant branding actually shipped to the embedded client.
 - `embed.session_ended` — fired by AuraPix when the SDK calls its
   beacon endpoint (`POST /v1/tenants/:tenantId/embed/session-end`),
   either from `handle.destroy()` or the page's `pagehide` event.

--- a/packages/embed-sdk/src/index.ts
+++ b/packages/embed-sdk/src/index.ts
@@ -23,4 +23,5 @@ export type {
   AuraPixTheme,
   AuraPixReadyDetail,
   AuraPixEventName,
+  AuraPixBrandingTokens,
 } from './mount.js';

--- a/packages/embed-sdk/src/mount.ts
+++ b/packages/embed-sdk/src/mount.ts
@@ -307,7 +307,7 @@ export function mountAuraPix(
           const v = (b as Record<string, unknown>)[k];
           if (typeof v === 'string' && v) out[k] = v;
         }
-        for (const _ in out) { branding = out; break; }
+        if (Object.keys(out).length > 0) branding = out;
       }
       const detail: AuraPixReadyDetail = {
         tenantId: data.tenantId,

--- a/packages/embed-sdk/src/mount.ts
+++ b/packages/embed-sdk/src/mount.ts
@@ -24,6 +24,24 @@ export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 5_000;
 /** UI theme forwarded to the embedded app. */
 export type AuraPixTheme = 'light' | 'dark' | 'auto' | (string & {});
 
+/** Public-safe branding tokens forwarded by the embedded app (issue #187).
+ *
+ * Strictly read-only — the SDK only surfaces the field so the host page
+ * can mirror tenant colors in its surrounding chrome without a second
+ * network round-trip. Omitted when the tenant has not configured any
+ * non-default branding (hosts fall back to their own defaults). Contains
+ * only public-safe values — no API keys, no internal IDs. */
+export interface AuraPixBrandingTokens {
+  /** Hex primary brand color (e.g. `#2563eb`). */
+  primaryColor?: string;
+  /** Hex accent brand color (e.g. `#7c3aed`). */
+  accentColor?: string;
+  /** Public logo URL (typically an HTTPS asset). */
+  logoUrl?: string;
+  /** CSS `font-family` value the host can mirror. */
+  fontFamily?: string;
+}
+
 /** Payload delivered to {@link MountAuraPixOptions.onReady}. */
 export interface AuraPixReadyDetail {
   /** Tenant id reported by the embedded app — should match `opts.tenantId`. */
@@ -32,6 +50,12 @@ export interface AuraPixReadyDetail {
   version: string;
   /** AuraPix origin the iframe is loaded from. */
   origin: string;
+  /**
+   * Optional tenant branding tokens (issue #187). Present only when the
+   * tenant has configured non-default branding; hosts should fall back
+   * to their own defaults otherwise.
+   */
+  branding?: AuraPixBrandingTokens;
 }
 
 /** All error codes the SDK surfaces. Stable strings safe for switch/case. */
@@ -271,10 +295,25 @@ export function mountAuraPix(
         );
         return;
       }
+      // Issue #187: optional, public-safe branding tokens. The embedded
+      // app vets the payload server-side; we still drop non-string
+      // fields here so a compromised iframe can't slip values of the
+      // wrong type into the host's CSS.
+      let branding: AuraPixBrandingTokens | undefined;
+      const b = data.branding;
+      if (isPlainObject(b)) {
+        const out: Record<string, string> = {};
+        for (const k in b) {
+          const v = (b as Record<string, unknown>)[k];
+          if (typeof v === 'string' && v) out[k] = v;
+        }
+        for (const _ in out) { branding = out; break; }
+      }
       const detail: AuraPixReadyDetail = {
         tenantId: data.tenantId,
         version: data.version,
         origin: aurapixOrigin,
+        ...(branding ? { branding } : {}),
       };
       fireAll(readyListeners, detail);
       return;

--- a/packages/embed-sdk/test/mount.test.ts
+++ b/packages/embed-sdk/test/mount.test.ts
@@ -190,6 +190,111 @@ describe('mountAuraPix — handshake & origin validation', () => {
     handle.destroy();
   });
 
+  it('forwards branding tokens from aurapix:ready to onReady (issue #187)', () => {
+    const host = makeHost();
+    const onReady = vi.fn();
+    const handle = mountAuraPix(host, {
+      tenantId: 'acme',
+      userJwt: 'jwt',
+      aurapixOrigin: ORIGIN,
+      onReady,
+    });
+    const fakeWin = patchIframeWindow(handle.iframe);
+
+    dispatchMessage(
+      {
+        type: 'aurapix:ready',
+        tenantId: 'acme',
+        version: '1.2.3',
+        branding: {
+          primaryColor: '#abcdef',
+          accentColor: '#123456',
+          logoUrl: 'https://cdn.example.com/logo.svg',
+          fontFamily: 'Inter, system-ui, sans-serif',
+        },
+      },
+      ORIGIN,
+      fakeWin as unknown as Window
+    );
+
+    expect(onReady).toHaveBeenCalledWith({
+      tenantId: 'acme',
+      version: '1.2.3',
+      origin: ORIGIN,
+      branding: {
+        primaryColor: '#abcdef',
+        accentColor: '#123456',
+        logoUrl: 'https://cdn.example.com/logo.svg',
+        fontFamily: 'Inter, system-ui, sans-serif',
+      },
+    });
+    handle.destroy();
+  });
+
+  it('omits branding from onReady when the embedded app did not send any (issue #187)', () => {
+    const host = makeHost();
+    const onReady = vi.fn();
+    const handle = mountAuraPix(host, {
+      tenantId: 'acme',
+      userJwt: 'jwt',
+      aurapixOrigin: ORIGIN,
+      onReady,
+    });
+    const fakeWin = patchIframeWindow(handle.iframe);
+
+    dispatchMessage(
+      { type: 'aurapix:ready', tenantId: 'acme', version: '1.2.3' },
+      ORIGIN,
+      fakeWin as unknown as Window
+    );
+
+    expect(onReady).toHaveBeenCalledWith({
+      tenantId: 'acme',
+      version: '1.2.3',
+      origin: ORIGIN,
+    });
+    const detail = onReady.mock.calls[0]?.[0];
+    expect(detail).not.toHaveProperty('branding');
+    handle.destroy();
+  });
+
+  it('drops non-string branding fields defensively (issue #187)', () => {
+    const host = makeHost();
+    const onReady = vi.fn();
+    const handle = mountAuraPix(host, {
+      tenantId: 'acme',
+      userJwt: 'jwt',
+      aurapixOrigin: ORIGIN,
+      onReady,
+    });
+    const fakeWin = patchIframeWindow(handle.iframe);
+
+    dispatchMessage(
+      {
+        type: 'aurapix:ready',
+        tenantId: 'acme',
+        version: '1.2.3',
+        // Hostile / malformed payload: number, null, empty string
+        branding: {
+          primaryColor: '#abcdef',
+          accentColor: 42,
+          logoUrl: null,
+          fontFamily: '',
+        },
+      },
+      ORIGIN,
+      fakeWin as unknown as Window
+    );
+
+    expect(onReady).toHaveBeenCalledWith({
+      tenantId: 'acme',
+      version: '1.2.3',
+      origin: ORIGIN,
+      branding: { primaryColor: '#abcdef' },
+    });
+    handle.destroy();
+  });
+
   it('rejects ready messages from a different origin (anti-spoofing)', () => {
     const host = makeHost();
     const onReady = vi.fn();

--- a/src/embed/contract.ts
+++ b/src/embed/contract.ts
@@ -7,12 +7,37 @@
  * for the full specification.
  */
 
+/**
+ * Public-safe branding tokens delivered alongside the `aurapix:ready`
+ * handshake (issue #187). The server populates this only when the tenant
+ * has any non-default branding configured — when omitted, hosts fall back
+ * to their own defaults. The field is strictly read-only and contains
+ * **only public-safe tokens**: no API keys, no internal IDs, no
+ * server-side identifiers.
+ */
+export interface AuraPixBrandingTokens {
+  /** Hex primary brand color (e.g. `#2563eb`). */
+  primaryColor?: string;
+  /** Hex accent brand color (e.g. `#7c3aed`). */
+  accentColor?: string;
+  /** Public logo URL (typically an HTTPS asset). */
+  logoUrl?: string;
+  /** CSS `font-family` value the host can mirror in its surrounding chrome. */
+  fontFamily?: string;
+}
+
 /** Sent by the embedded UI as soon as it mounts. */
 export interface AuraPixReadyMessage {
   type: 'aurapix:ready';
   tenantId: string;
   /** SemVer string of the embedded build. */
   version: string;
+  /**
+   * Resolved branding tokens for the tenant (issue #187). Optional —
+   * absent when the tenant has not configured any non-default branding.
+   * Strictly read-only and contains only public-safe tokens.
+   */
+  branding?: AuraPixBrandingTokens;
 }
 
 /** Sent by the embedded UI when its content height changes. */
@@ -75,13 +100,44 @@ export function isAuraPixMessage(value: unknown): value is AuraPixMessage {
   return typeof t === 'string' && t.startsWith(AURAPIX_MESSAGE_PREFIX);
 }
 
+/**
+ * Validate that an unknown value is a well-formed `AuraPixBrandingTokens`
+ * object. Empty objects are accepted (every field is optional). Fields
+ * that are present must be strings; unknown extra keys are tolerated
+ * because the message contract is append-only and the host SDK ignores
+ * unknown fields.
+ */
+export function isAuraPixBrandingTokens(
+  value: unknown
+): value is AuraPixBrandingTokens {
+  if (!isPlainObject(value)) return false;
+  for (const key of ['primaryColor', 'accentColor', 'logoUrl', 'fontFamily'] as const) {
+    const v = (value as Record<string, unknown>)[key];
+    if (v !== undefined && typeof v !== 'string') return false;
+  }
+  return true;
+}
+
 export function isAuraPixReady(value: unknown): value is AuraPixReadyMessage {
-  return (
-    isPlainObject(value) &&
-    value.type === AURAPIX_MESSAGE_TYPES.ready &&
-    typeof value.tenantId === 'string' &&
-    typeof value.version === 'string'
-  );
+  if (
+    !isPlainObject(value) ||
+    value.type !== AURAPIX_MESSAGE_TYPES.ready ||
+    typeof value.tenantId !== 'string' ||
+    typeof value.version !== 'string'
+  ) {
+    return false;
+  }
+  // `branding` is optional; if present it must be a well-formed tokens
+  // object. We don't reject extra unknown fields — the protocol is
+  // additive.
+  if (
+    'branding' in value &&
+    value.branding !== undefined &&
+    !isAuraPixBrandingTokens(value.branding)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export function isAuraPixResize(value: unknown): value is AuraPixResizeMessage {

--- a/src/embed/embedded.ts
+++ b/src/embed/embedded.ts
@@ -6,6 +6,7 @@
 import {
   AURAPIX_MESSAGE_TYPES,
   isAuraPixMessage,
+  type AuraPixBrandingTokens,
   type AuraPixInboundMessage,
   type AuraPixOutboundMessage,
 } from './contract.js';
@@ -24,7 +25,15 @@ export interface EmbeddedEmitterOptions {
 }
 
 export interface EmbeddedHandle {
-  ready(): void;
+  /**
+   * Send the `aurapix:ready` handshake to every allowed parent origin.
+   *
+   * Optional `branding` tokens (issue #187) are forwarded verbatim when
+   * provided — the embedded UI is responsible for only passing in
+   * public-safe values resolved server-side. Omit when the tenant has
+   * default branding so the host falls back to its own defaults.
+   */
+  ready(branding?: AuraPixBrandingTokens): void;
   resize(height: number): void;
   emit(name: string, payload?: unknown): void;
   on(
@@ -94,11 +103,12 @@ export function createEmbedded(opts: EmbeddedEmitterOptions): EmbeddedHandle {
   w.addEventListener('message', onMessage);
 
   return {
-    ready() {
+    ready(branding?: AuraPixBrandingTokens) {
       postToParent({
         type: AURAPIX_MESSAGE_TYPES.ready,
         tenantId: opts.tenantId,
         version: opts.version,
+        ...(branding ? { branding } : {}),
       });
     },
     resize(height) {

--- a/src/embed/host-sdk.test.ts
+++ b/src/embed/host-sdk.test.ts
@@ -54,6 +54,44 @@ describe('isAuraPixMessage guards', () => {
     expect(isAuraPixResize({ type: 'aurapix:resize', height: 'tall' })).toBe(false);
     expect(isAuraPixEvent({ type: 'aurapix:event' })).toBe(false);
   });
+
+  it('accepts aurapix:ready with optional branding tokens (issue #187)', () => {
+    expect(
+      isAuraPixReady({
+        type: 'aurapix:ready',
+        tenantId: 't',
+        version: '1',
+        branding: { primaryColor: '#2563eb' },
+      })
+    ).toBe(true);
+    expect(
+      isAuraPixReady({
+        type: 'aurapix:ready',
+        tenantId: 't',
+        version: '1',
+        branding: {},
+      })
+    ).toBe(true);
+  });
+
+  it('rejects aurapix:ready with malformed branding payload', () => {
+    expect(
+      isAuraPixReady({
+        type: 'aurapix:ready',
+        tenantId: 't',
+        version: '1',
+        branding: { primaryColor: 42 },
+      })
+    ).toBe(false);
+    expect(
+      isAuraPixReady({
+        type: 'aurapix:ready',
+        tenantId: 't',
+        version: '1',
+        branding: 'not-an-object',
+      })
+    ).toBe(false);
+  });
 });
 
 describe('createEmbedHost', () => {
@@ -94,6 +132,51 @@ describe('createEmbedHost', () => {
     expect(seen[0]).toMatchObject({ type: 'aurapix:ready', tenantId: 'acme' });
 
     unsub();
+    handle.dispose();
+  });
+
+  it('forwards branding tokens end-to-end from embedded ready() to host listener (issue #187)', () => {
+    // The handshake is fan-out from the embedded UI to every allowed
+    // parent origin. From the host side we just need to verify that an
+    // `aurapix:ready` with a `branding` block is delivered intact to the
+    // listener (i.e. createEmbedHost's outbound filter doesn't strip the
+    // additive field).
+    const fakeIframeWin: FakeWindow = {};
+    const iframe = makeIframe(fakeIframeWin);
+    const handle = createEmbedHost({
+      iframe,
+      targetOrigin: 'https://app.aurapix.com',
+    });
+    const seen: AuraPixOutboundMessage[] = [];
+    handle.on((msg) => seen.push(msg));
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'aurapix:ready',
+          tenantId: 'acme',
+          version: '1.0.0',
+          branding: {
+            primaryColor: '#abcdef',
+            accentColor: '#123456',
+            logoUrl: 'https://cdn.example.com/logo.svg',
+          },
+        },
+        origin: 'https://app.aurapix.com',
+        source: fakeIframeWin as unknown as Window,
+      })
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      type: 'aurapix:ready',
+      tenantId: 'acme',
+      branding: {
+        primaryColor: '#abcdef',
+        accentColor: '#123456',
+        logoUrl: 'https://cdn.example.com/logo.svg',
+      },
+    });
     handle.dispose();
   });
 
@@ -251,6 +334,92 @@ describe('createEmbedded', () => {
       'https://host-b.example.com'
     );
 
+    handle.dispose();
+  });
+
+  it('ready(branding) includes optional branding tokens (issue #187)', () => {
+    const parentPost = vi.fn();
+    const parentRef = { postMessage: parentPost };
+    const fakeWindow = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      parent: parentRef,
+    } as unknown as Window;
+
+    const handle = createEmbedded({
+      tenantId: 'acme',
+      version: '1.0.0',
+      allowedOrigins: ['https://host.example.com'],
+      window: fakeWindow,
+    });
+
+    // No branding — field is omitted from the envelope so hosts on the
+    // wire-snapshot path stay backward-compatible.
+    handle.ready();
+    expect(parentPost).toHaveBeenCalledWith(
+      { type: 'aurapix:ready', tenantId: 'acme', version: '1.0.0' },
+      'https://host.example.com'
+    );
+    expect((parentPost.mock.calls[0][0] as Record<string, unknown>).branding).toBeUndefined();
+
+    parentPost.mockClear();
+    handle.ready({ primaryColor: '#abcdef', logoUrl: 'https://cdn.example.com/logo.svg' });
+    expect(parentPost).toHaveBeenCalledWith(
+      {
+        type: 'aurapix:ready',
+        tenantId: 'acme',
+        version: '1.0.0',
+        branding: { primaryColor: '#abcdef', logoUrl: 'https://cdn.example.com/logo.svg' },
+      },
+      'https://host.example.com'
+    );
+
+    handle.dispose();
+  });
+
+  it('does not leak internal record fields into the branding payload (snapshot)', () => {
+    // Snapshot test on the payload shape — part of the issue #187
+    // acceptance criteria: no secret/internal fields are leaked through
+    // the handshake.
+    const parentPost = vi.fn();
+    const parentRef = { postMessage: parentPost };
+    const fakeWindow = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      parent: parentRef,
+    } as unknown as Window;
+
+    const handle = createEmbedded({
+      tenantId: 'acme',
+      version: '1.0.0',
+      allowedOrigins: ['https://host.example.com'],
+      window: fakeWindow,
+    });
+    handle.ready({
+      primaryColor: '#2563eb',
+      accentColor: '#7c3aed',
+      logoUrl: 'https://cdn.example.com/logo.svg',
+      fontFamily: 'Inter, system-ui, sans-serif',
+    });
+
+    expect(parentPost).toHaveBeenCalledTimes(1);
+    const sent = parentPost.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(sent).sort()).toEqual([
+      'branding',
+      'tenantId',
+      'type',
+      'version',
+    ]);
+    expect(Object.keys(sent.branding as object).sort()).toEqual([
+      'accentColor',
+      'fontFamily',
+      'logoUrl',
+      'primaryColor',
+    ]);
+    // Explicitly assert none of the internal record fields leak.
+    for (const forbidden of ['tenantId', 'updatedAt', 'apiKey', 'faviconUrl']) {
+      expect((sent.branding as Record<string, unknown>)[forbidden]).toBeUndefined();
+    }
     handle.dispose();
   });
 


### PR DESCRIPTION
## Summary

The embed SDK already posts an `aurapix-ready` handshake to the host page on mount, but until now the host iframe had to make a **second** request (`GET /v1/tenants/:id/branding`) to fetch tenant branding tokens before it could paint its surrounding chrome to match. This PR carries those tokens **in the same handshake payload** so embedded experiences can paint instantly with host colors.

The `branding` field is **additive and optional** — older host integrations that don't read it continue to work unchanged. Allowed-origin enforcement (#163/#169) is untouched.

Fixes rwrife/AuraPix#187

## Changes

### Contract
- **`src/embed/contract.ts`**: new `AuraPixBrandingTokens` type (`primaryColor`, `accentColor`, `logoUrl`, `fontFamily`) added to `AuraPixReadyMessage` as an optional field. `isAuraPixReady` guard validates the shape when present and rejects malformed payloads.
- **`src/embed/embedded.ts`**: `ready(branding?)` forwards tokens verbatim. Field is omitted from the wire payload when not provided so existing snapshots stay stable.

### `@aurapix/embed` SDK
- **`packages/embed-sdk/src/mount.ts`**: `AuraPixReadyDetail.branding` surfaced to `onReady` callbacks, with defensive runtime validation that drops non-string fields so a compromised iframe can't slip non-string values into the host's CSS.
- Stays inside the **2 KB gzipped budget** from #177 (currently 2.00 KB).
- README updated with the new `onReady` signature + a pointer to the branding section of `embed-handshake.md`.

### Server (Firestore -> handshake)
- **`functions/src/routes/brandingV1.ts`**: new `loadBrandingTokensForEmbed(dataAdapter, tenantId)` reuses the existing tenant-branding resolver (#132/#135) and returns:
  - `null` when the tenant has no doc, only default colors, no logo, or an invalid tenant id (so the wire stays quiet for tenants that don't customise);
  - an object containing **only** the non-default, public-safe tokens otherwise. Every internal field (`tenantId`, `updatedAt`, `appName`, `faviconUrl`, …) is stripped at the boundary.
- **`functions/src/routes/embedV1.ts`**: `createEmbedCspMiddleware` accepts an optional `loadBrandingApplied(tenantId)` resolver and populates `embed.session_started.meta.brandingApplied: boolean` so hosts can debug white-label rollouts. **No new billable event — the existing `embed.session_started` is reused.** A failure inside the resolver falls back to `brandingApplied: false` and never breaks CSP enforcement.
- **`functions/src/server.ts`**: wires `loadBrandingTokensForEmbed` through the live `dataAdapter` so production traffic carries `brandingApplied`.

### Docs / contracts
- **`docs/features/embed-handshake.md`**: documents the new optional `branding` block, the public-safe-only contract, the `meta.brandingApplied` flag, and the host-page integration story.
- **`contracts/openapi/embed.openapi.json`**: new `AuraPixBrandingTokens` + `AuraPixReadyMessage` component schemas. `npm run contract:check` passes; no breaking API changes.

## Testing

All touched test suites pass; no pre-existing failures regressed.

- **Unit — server resolver (`functions/test/routes/brandingV1.test.ts`, +9 tests)**: defaults -> `null`, partial branding -> partial tokens, logo flows independently of default colors, snapshot-asserts no internal fields leak, malformed stored colors fall back gracefully.
- **Unit — contract guards + `createEmbedded` (`src/embed/host-sdk.test.ts`, +4 tests)**: `isAuraPixReady` accepts/rejects branding correctly; `ready({...})` posts the expected envelope; **snapshot test** asserts the wire payload contains exactly `{ type, tenantId, version, branding }` with the four allow-listed fields.
- **Integration — CSP middleware (`functions/test/routes/embedV1.test.ts`, +4 tests)**: `brandingApplied=true` when the resolver returns tokens, `false` when omitted / throws, blocked origins **still get blocked regardless of branding config**, and the resolver is never consulted for disallowed origins.
- **Unit — host SDK (`packages/embed-sdk/test/mount.test.ts`, +3 tests)**: branding flows end-to-end to `onReady`, is omitted when absent, and non-string fields are dropped defensively.

```
Frontend (vitest):       167 passed (+3)
Backend  (vitest):        52 passed in embed+branding (+13)
embed-sdk (vitest):       31 passed (+3)
OpenAPI contract:check:  PASS (no breaking changes)
@aurapix/embed build:    2.00 KB gzipped (under 2 KB budget)
```

## Caveats

- `fontFamily` is part of the wire contract but not yet stored in `BrandingRecord` today — reserved for a future extension of #132/#135 without changing the embed contract.
- 12 pre-existing test failures in `photosV1.test.ts` / `tenantUsersV1.test.ts` exist on `main` and are unaffected by this PR.
