### PR TITLE
fix: Month-to-date usage summary endpoint for billing dashboards

### DIFF
--- a/contracts/openapi/tenant-usage.openapi.json
+++ b/contracts/openapi/tenant-usage.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "AuraPix Tenant Usage API",
-    "version": "0.2.0",
-    "description": "Per-tenant daily usage rollups. The canonical pull surface for host billing systems (issue #133). Supports JSON (default) and CSV (issue #186) via content negotiation."
+    "version": "0.3.0",
+    "description": "Per-tenant daily usage rollups. The canonical pull surface for host billing systems (issue #133). Supports JSON (default) and CSV (issue #186) via content negotiation, plus a month-to-date summary endpoint (issue #188) for in-dashboard widgets."
   },
   "servers": [
     { "url": "https://api.aurapix.example" }
@@ -94,6 +94,63 @@
           },
           "429": {
             "description": "Per-tenant API rate limit exceeded (issue #154). Token-bucket keyed by `tenantId`, applied to all tenant-scoped routes after `resolveTenant`. The response sets the `Retry-After` header (whole seconds) and emits a sampled `rate_limit.exceeded` metering event (\u22641/sec/tenant) which is rolled up into the `rateLimited` counter on the daily usage doc. Defaults: `RATE_LIMIT_RPS=20`, `RATE_LIMIT_BURST=60`; host-key traffic uses `RATE_LIMIT_HOST_RPS=100`. A `tenants_config/{tenantId}` doc may override `rateLimit.rps`/`rateLimit.burst` and takes effect on the next request (no restart).",
+            "headers": {
+              "Retry-After": {
+                "description": "Whole seconds the client should wait before retrying. Always \u2265 1.",
+                "schema": { "type": "integer", "minimum": 1 }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RateLimitErrorResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tenants/{tenantId}/usage/current": {
+      "get": {
+        "operationId": "getTenantUsageCurrent",
+        "summary": "Month-to-date usage summary for the current UTC month",
+        "description": "Returns a single object with month-to-date totals for the current UTC month (issue #188). Derived by summing the existing `usageDaily` docs server-side, so hosts can render an in-app \"Usage this month\" widget without fanning out 1\u201331 reads on every dashboard load.\n\n**Auth:** identical to `GET /v1/tenants/{tenantId}/usage` \u2014 tenant owner (Bearer) **or** a host API key with the `usage.read` scope. No new scope is introduced.\n\n**Period window:** `periodStart` is the first day of the current UTC month and `periodEnd` is today's UTC date. Both are `YYYY-MM-DD` strings. The response is well-defined for tenants with zero activity (all counters are `0`).\n\n**activeUsers semantics:** when a `DistinctActiveUsersQuery` is wired (production), this is the distinct count of end-users seen across the period \u2014 NOT the sum of per-day distincts. When the capability is not wired, the field falls back to the sum of per-day `activeUsers` (a conservative upper bound) and the discrepancy is documented as an eventual-consistency window.\n\n**Caching:** the response is cached in-memory per tenant for ~60 seconds. The endpoint sets `Cache-Control: max-age=60` so hosts can layer their own CDN. The cache is explicitly busted on writes routed through the same process (`invalidateTenantCurrentCache`); multi-process deployments observe at most a 60s drift.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Month-to-date totals for the tenant.",
+            "headers": {
+              "Cache-Control": {
+                "description": "Always `private, max-age=60` so a fronting CDN can cache for ~60s without serving cross-tenant data.",
+                "schema": { "type": "string" }
+              },
+              "X-Cache": {
+                "description": "`HIT` if the response was served from the in-memory per-tenant cache, `MISS` if it was freshly summed. Diagnostic only \u2014 not part of the billing contract.",
+                "schema": { "type": "string", "enum": ["HIT", "MISS"] }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TenantUsageCurrentResponse" }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not authorized for this tenant (cross-tenant access or missing `usage.read` scope).",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-tenant API rate limit exceeded (issue #154). Same shape as `/usage`.",
             "headers": {
               "Retry-After": {
                 "description": "Whole seconds the client should wait before retrying. Always \u2265 1.",
@@ -204,6 +261,65 @@
             "type": "array",
             "items": { "$ref": "#/components/schemas/UsageDailyDoc" }
           }
+        }
+      },
+      "TenantUsageCurrentResponse": {
+        "type": "object",
+        "description": "Month-to-date usage summary for the current UTC month (issue #188). Mirrors the summable counters of `UsageDailyDoc` plus the period window and a generation timestamp. Zero-filled when the tenant has no recorded activity for the month.",
+        "required": [
+          "tenantId",
+          "periodStart",
+          "periodEnd",
+          "generatedAt",
+          "storageBytesDelta",
+          "imagesUploaded",
+          "imagesProcessed",
+          "signedUrlsIssued",
+          "editsApplied",
+          "tagsApplied",
+          "apiCalls",
+          "exportBytes",
+          "activeUsers",
+          "rateLimited"
+        ],
+        "properties": {
+          "tenantId": { "type": "string" },
+          "periodStart": {
+            "type": "string",
+            "format": "date",
+            "description": "First day of the current UTC month (always day 01)."
+          },
+          "periodEnd": {
+            "type": "string",
+            "format": "date",
+            "description": "Today's UTC date. The endpoint never looks ahead to days that have not yet happened."
+          },
+          "generatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-side wall-clock timestamp at which the summary was computed. For cached responses, this is the timestamp of the *original* MISS; the `X-Cache: HIT` header signals reuse."
+          },
+          "storageBytesDelta": {
+            "type": "integer",
+            "description": "Sum of per-day `storageBytesDelta` across the period. May be negative if deletes outweigh uploads."
+          },
+          "imagesUploaded": { "type": "integer", "minimum": 0 },
+          "imagesProcessed": { "type": "integer", "minimum": 0 },
+          "signedUrlsIssued": { "type": "integer", "minimum": 0 },
+          "editsApplied": { "type": "integer", "minimum": 0 },
+          "tagsApplied": { "type": "integer", "minimum": 0 },
+          "apiCalls": { "type": "integer", "minimum": 0 },
+          "exportBytes": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Total export bytes egressed across the period."
+          },
+          "activeUsers": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Distinct end-users active for the tenant across the period (seat-based billing signal). De-duplicated across days when the production `DistinctActiveUsersQuery` capability is wired; falls back to the sum of per-day distincts (a conservative upper bound) otherwise."
+          },
+          "rateLimited": { "type": "integer", "minimum": 0 }
         }
       },
       "RateLimitErrorResponse": {

--- a/docs/features/usage-and-billing.md
+++ b/docs/features/usage-and-billing.md
@@ -61,6 +61,84 @@ tenant-A,2026-04-02,1024,2,0,0,0,0,0,0,0,0,,2026-04-02T10:00:00.000Z
 tenant-A,2026-04-03,0,0,0,0,0,0,0,0,0,0,,1970-01-01T00:00:00.000Z
 ```
 
+## Month-to-date summary (issue #188)
+
+Hosts that just want to render an in-app "Usage this month" widget can call
+the summary endpoint instead of fanning out up to 31 reads against `/usage`:
+
+```
+GET /api/v1/tenants/{tenantId}/usage/current
+```
+
+- **Auth:** identical to `/usage` — tenant owner (Bearer) **or** a host API
+  key with the `usage.read` scope (no new scope).
+- **Period window:** `periodStart` is the first day of the current UTC
+  month and `periodEnd` is today's UTC date. The endpoint never looks
+  ahead to days that have not yet happened.
+- **Zero activity:** the response is well-defined for tenants with zero
+  activity — every counter is `0`, not a `404`.
+- **Cross-tenant access:** always returns `403 FORBIDDEN`, same as
+  `/usage`.
+
+### Counter semantics
+
+The response carries exactly the **summable** counters of `usageDaily`
+(`storageBytesDelta`, `imagesUploaded`, `imagesProcessed`,
+`signedUrlsIssued`, `editsApplied`, `tagsApplied`, `apiCalls`,
+`exportBytes`, `activeUsers`, `rateLimited`) plus `tenantId`,
+`periodStart`, `periodEnd`, and a `generatedAt` timestamp.
+
+Fields **excluded** from the summary:
+
+- `storageBytesTotal` — point-in-time snapshot, not summable.
+- `appliedEventIds` — idempotency bookkeeping, not a billing field.
+- `updatedAt` — per-day metadata; the summary has its own
+  `generatedAt` instead.
+
+`activeUsers` is the **distinct** end-user count for the period in
+production (de-duplicated across days via the `DistinctActiveUsersQuery`
+capability on `UserActiveDailyStore`). When the capability is not wired
+— e.g. during local-dev with only the in-memory store — the field falls
+back to summing per-day `activeUsers`, which is a conservative upper
+bound. The behaviour is identical to how the daily doc's per-day
+`activeUsers` is computed (driven by `user.active` metering events, not
+re-emitted on every request).
+
+### Caching
+
+- Each tenant's summary is cached in-memory for **~60 seconds** to keep
+  cost predictable when hosts hit the endpoint on every dashboard load.
+- The cache is **invalidated explicitly** when `usageDaily` is written
+  through the same process (`router.invalidateTenantCurrentCache(...)`).
+- In a multi-process deployment the eventual-consistency window is
+  bounded by the 60s TTL; hosts that need stricter freshness should
+  cache-bust on their side.
+- The response sets `Cache-Control: private, max-age=60` so a fronting
+  CDN can also cache for ~60s without serving cross-tenant data.
+- The `X-Cache: HIT|MISS` response header is diagnostic only — not part
+  of the billing contract.
+
+### Example payload
+
+```json
+{
+  "tenantId": "tenant-A",
+  "periodStart": "2026-04-01",
+  "periodEnd": "2026-04-15",
+  "generatedAt": "2026-04-15T12:34:56.000Z",
+  "storageBytesDelta": 5242880,
+  "imagesUploaded": 42,
+  "imagesProcessed": 91,
+  "signedUrlsIssued": 314,
+  "editsApplied": 8,
+  "tagsApplied": 17,
+  "apiCalls": 1023,
+  "exportBytes": 1048576,
+  "activeUsers": 6,
+  "rateLimited": 0
+}
+```
+
 ## Daily document
 
 Stored at `tenants/{tenantId}/usageDaily/{YYYY-MM-DD}` in Firestore.

--- a/functions/src/routes/tenantUsage.ts
+++ b/functions/src/routes/tenantUsage.ts
@@ -29,9 +29,11 @@ import type {
   UsageDailyDoc,
 } from '../services/metering/UsageRollupConsumer.js';
 import { emptyDailyDoc } from '../services/metering/UsageRollupConsumer.js';
+import type { DistinctActiveUsersQuery } from '../services/metering/UserActiveDailyStore.js';
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const MAX_RANGE_DAYS = 100;
+const CURRENT_CACHE_TTL_MS = 60_000;
 
 /**
  * Locked column order for the CSV variant. This is part of the public
@@ -122,6 +124,20 @@ export interface UsageRouterDeps {
   };
   ownsTenant: TenantOwnershipChecker;
   hostScopeChecker?: HostScopeChecker;
+  /**
+   * Optional source-of-truth lookup for distinct `activeUsers` across a
+   * date range (issue #188). When provided, the month-to-date summary
+   * endpoint uses it to de-duplicate users seen on multiple days; when
+   * omitted, the endpoint falls back to summing per-day `activeUsers`
+   * (a conservative upper bound) and documents the eventual-consistency
+   * window.
+   */
+  distinctActiveUsers?: DistinctActiveUsersQuery;
+  /**
+   * Override for the current time. Used by tests to pin the UTC month
+   * window; production code omits this and gets `new Date()`.
+   */
+  now?: () => Date;
 }
 
 interface ErrorBody {
@@ -170,8 +186,249 @@ function eachDate(from: Date, to: Date): string[] {
   return out;
 }
 
+/**
+ * Subset of `UsageDailyDoc` that is meaningful to sum across days. These
+ * are the counters that accumulate over time; `appliedEventIds` (idempotency
+ * bookkeeping), `updatedAt`, `storageBytesTotal` (point-in-time snapshot),
+ * `tenantId`, and `date` are deliberately excluded.
+ */
+export const SUMMABLE_COUNTERS = [
+  'storageBytesDelta',
+  'imagesUploaded',
+  'imagesProcessed',
+  'signedUrlsIssued',
+  'editsApplied',
+  'tagsApplied',
+  'apiCalls',
+  'exportBytes',
+  'activeUsers',
+  'rateLimited',
+] as const satisfies ReadonlyArray<keyof UsageDailyDoc>;
+
+type SummableCounter = (typeof SUMMABLE_COUNTERS)[number];
+
+export type UsageCurrentTotals = Record<SummableCounter, number>;
+
+/**
+ * Response body for `GET /v1/tenants/:id/usage/current` (issue #188). Wraps
+ * the summable counters of `UsageDailyDoc` with the period window and the
+ * snapshot timestamp. `activeUsers` is the distinct user count for the
+ * period when a `DistinctActiveUsersQuery` is wired, otherwise the
+ * sum-of-daily-distincts (documented eventual-consistency window).
+ */
+export interface TenantUsageCurrentResponse extends UsageCurrentTotals {
+  tenantId: string;
+  periodStart: string;
+  periodEnd: string;
+  generatedAt: string;
+}
+
+/**
+ * Compute the current UTC month window for `now`. `periodStart` is the
+ * first day of the month; `periodEnd` is `now`'s UTC day. Both are
+ * YYYY-MM-DD strings. This is what "month-to-date" means in #188 — we do
+ * not look ahead to days that have not happened yet.
+ */
+export function currentUtcMonthRange(now: Date): {
+  periodStart: string;
+  periodEnd: string;
+} {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const day = now.getUTCDate();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const periodStart = `${year}-${pad(month + 1)}-01`;
+  const periodEnd = `${year}-${pad(month + 1)}-${pad(day)}`;
+  return { periodStart, periodEnd };
+}
+
+/**
+ * Sum the `SUMMABLE_COUNTERS` columns across `docs`. Returns zero-filled
+ * totals when `docs` is empty (i.e. tenants with no activity this month
+ * get a valid response, not a 404).
+ */
+export function sumCounters(docs: UsageDailyDoc[]): UsageCurrentTotals {
+  const totals: UsageCurrentTotals = {
+    storageBytesDelta: 0,
+    imagesUploaded: 0,
+    imagesProcessed: 0,
+    signedUrlsIssued: 0,
+    editsApplied: 0,
+    tagsApplied: 0,
+    apiCalls: 0,
+    exportBytes: 0,
+    activeUsers: 0,
+    rateLimited: 0,
+  };
+  for (const doc of docs) {
+    for (const c of SUMMABLE_COUNTERS) {
+      totals[c] += doc[c];
+    }
+  }
+  return totals;
+}
+
 export function createTenantUsageRouter(deps: UsageRouterDeps): Router {
   const router = Router({ mergeParams: true });
+  const now = deps.now ?? (() => new Date());
+
+  /**
+   * In-memory month-to-date cache, keyed by `tenantId::periodStart`.
+   * Entries auto-evict on read once they exceed `CURRENT_CACHE_TTL_MS`,
+   * and the entry for a tenant is invalidated explicitly when the
+   * underlying `usageDaily` rollup is mutated through this process. See
+   * `invalidateTenant` below — it is also exposed via `app.locals` so
+   * the rollup consumer can notify after a write.
+   *
+   * Note: in a multi-process deployment the eventual-consistency window
+   * is bounded by the 60s TTL; hosts that need stricter freshness should
+   * cache-bust on their side.
+   */
+  const currentCache = new Map<
+    string,
+    { expiresAt: number; payload: TenantUsageCurrentResponse }
+  >();
+
+  function cacheKey(tenantId: string, periodStart: string): string {
+    return `${tenantId}::${periodStart}`;
+  }
+
+  function getCached(
+    tenantId: string,
+    periodStart: string
+  ): TenantUsageCurrentResponse | null {
+    const key = cacheKey(tenantId, periodStart);
+    const entry = currentCache.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt <= now().getTime()) {
+      currentCache.delete(key);
+      return null;
+    }
+    return entry.payload;
+  }
+
+  function setCached(
+    tenantId: string,
+    periodStart: string,
+    payload: TenantUsageCurrentResponse
+  ): void {
+    currentCache.set(cacheKey(tenantId, periodStart), {
+      expiresAt: now().getTime() + CURRENT_CACHE_TTL_MS,
+      payload,
+    });
+  }
+
+  /**
+   * Invalidate every cached month-to-date summary for `tenantId`. Safe to
+   * call from rollup write paths.
+   */
+  function invalidateTenant(tenantId: string): void {
+    const prefix = `${tenantId}::`;
+    for (const key of currentCache.keys()) {
+      if (key.startsWith(prefix)) currentCache.delete(key);
+    }
+  }
+
+  (router as Router & {
+    invalidateTenantCurrentCache?: (tenantId: string) => void;
+  }).invalidateTenantCurrentCache = invalidateTenant;
+
+  router.get(
+    '/:tenantId/usage/current',
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId ?? '');
+        if (!tenantId) {
+          sendError(res, 400, 'VALIDATION_ERROR', 'tenantId is required');
+          return;
+        }
+
+        // Auth: owner OR host key scope (same model as /usage).
+        const userId = req.user?.uid;
+        let authorized = false;
+        if (userId && (await deps.ownsTenant(userId, tenantId))) {
+          authorized = true;
+        } else if (
+          deps.hostScopeChecker &&
+          (await deps.hostScopeChecker(req, tenantId, 'usage.read'))
+        ) {
+          authorized = true;
+        }
+        if (!authorized) {
+          sendError(
+            res,
+            403,
+            'FORBIDDEN',
+            'Caller is not authorized for this tenant'
+          );
+          return;
+        }
+
+        const currentTime = now();
+        const period = currentUtcMonthRange(currentTime);
+        const cached = getCached(tenantId, period.periodStart);
+        if (cached) {
+          res.setHeader('Cache-Control', 'private, max-age=60');
+          res.setHeader('X-Cache', 'HIT');
+          res.json(cached);
+          return;
+        }
+
+        // Pull the existing daily docs for the month-to-date window. We
+        // intentionally reuse the same store contract as `/usage` so the
+        // summary is always consistent with the per-day view.
+        let docs: UsageDailyDoc[];
+        if (deps.store.listRange) {
+          docs = await deps.store.listRange(
+            tenantId,
+            period.periodStart,
+            period.periodEnd
+          );
+        } else {
+          docs = [];
+          for (const date of eachDate(
+            new Date(`${period.periodStart}T00:00:00.000Z`),
+            new Date(`${period.periodEnd}T00:00:00.000Z`)
+          )) {
+            const doc = await deps.store.transact(
+              tenantId,
+              date,
+              (current) => current ?? emptyDailyDoc(tenantId, date)
+            );
+            docs.push(doc);
+          }
+        }
+
+        const totals = sumCounters(docs);
+
+        // De-dupe activeUsers across the month if the capability is wired,
+        // otherwise fall back to the per-day sum already in `totals`.
+        if (deps.distinctActiveUsers) {
+          const distinct = await deps.distinctActiveUsers.listDistinctUsers(
+            tenantId,
+            period.periodStart,
+            period.periodEnd
+          );
+          totals.activeUsers = distinct.length;
+        }
+
+        const payload: TenantUsageCurrentResponse = {
+          tenantId,
+          periodStart: period.periodStart,
+          periodEnd: period.periodEnd,
+          generatedAt: currentTime.toISOString(),
+          ...totals,
+        };
+        setCached(tenantId, period.periodStart, payload);
+
+        res.setHeader('Cache-Control', 'private, max-age=60');
+        res.setHeader('X-Cache', 'MISS');
+        res.json(payload);
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
 
   router.get(
     '/:tenantId/usage',
@@ -299,7 +556,10 @@ export const __test = {
   daysBetweenInclusive,
   eachDate,
   MAX_RANGE_DAYS,
+  CURRENT_CACHE_TTL_MS,
   renderCsvCell,
   renderCsvRow,
   wantsCsv,
+  currentUtcMonthRange,
+  sumCounters,
 };

--- a/functions/src/services/metering/UserActiveDailyStore.ts
+++ b/functions/src/services/metering/UserActiveDailyStore.ts
@@ -21,7 +21,27 @@ export interface UserActiveDailyStore {
   markIfFirst(tenantId: string, userId: string, utcDay: string): Promise<boolean>;
 }
 
-export class InMemoryUserActiveDailyStore implements UserActiveDailyStore {
+/**
+ * Optional capability — implementations that can enumerate distinct user
+ * IDs across a UTC date range expose this so the month-to-date summary
+ * endpoint (issue #188) can de-duplicate `activeUsers` rather than
+ * naively summing per-day counts.
+ *
+ * Returns the SET of distinct userIds that were active for `tenantId` on
+ * any UTC day in `[from, to]` inclusive. Both `from` and `to` are
+ * `YYYY-MM-DD` UTC dates.
+ */
+export interface DistinctActiveUsersQuery {
+  listDistinctUsers(
+    tenantId: string,
+    from: string,
+    to: string
+  ): Promise<string[]>;
+}
+
+export class InMemoryUserActiveDailyStore
+  implements UserActiveDailyStore, DistinctActiveUsersQuery
+{
   private readonly seen = new Set<string>();
 
   private key(tenantId: string, userId: string, utcDay: string): string {
@@ -37,6 +57,27 @@ export class InMemoryUserActiveDailyStore implements UserActiveDailyStore {
     if (this.seen.has(k)) return false;
     this.seen.add(k);
     return true;
+  }
+
+  async listDistinctUsers(
+    tenantId: string,
+    from: string,
+    to: string
+  ): Promise<string[]> {
+    const prefix = `${tenantId}::`;
+    const distinct = new Set<string>();
+    for (const k of this.seen) {
+      if (!k.startsWith(prefix)) continue;
+      // key = tenantId::userId::utcDay — split from the right so userIds
+      // containing `::` are preserved.
+      const lastSep = k.lastIndexOf('::');
+      if (lastSep < 0) continue;
+      const utcDay = k.slice(lastSep + 2);
+      if (utcDay < from || utcDay > to) continue;
+      const userId = k.slice(prefix.length, lastSep);
+      distinct.add(userId);
+    }
+    return Array.from(distinct);
   }
 
   /** Test helper. */

--- a/functions/test/routes/tenantUsage.test.ts
+++ b/functions/test/routes/tenantUsage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import express from 'express';
 import { createTenantUsageRouter, CSV_COLUMNS } from '../../src/routes/tenantUsage.js';
 import { InMemoryDailyDocStore, UsageRollupConsumer } from '../../src/services/metering/UsageRollupConsumer.js';
+import { InMemoryUserActiveDailyStore } from '../../src/services/metering/UserActiveDailyStore.js';
 
 function makeApp(opts: {
   store: InMemoryDailyDocStore;
@@ -9,6 +10,8 @@ function makeApp(opts: {
   tenantId?: string;
   authUserId?: string | null;
   hostScopeChecker?: Parameters<typeof createTenantUsageRouter>[0]['hostScopeChecker'];
+  distinctActiveUsers?: Parameters<typeof createTenantUsageRouter>[0]['distinctActiveUsers'];
+  now?: () => Date;
 }) {
   const app = express();
   app.use(express.json());
@@ -25,6 +28,8 @@ function makeApp(opts: {
       ownsTenant: async (userId, tenantId) =>
         userId === opts.ownerUserId && tenantId === opts.tenantId,
       hostScopeChecker: opts.hostScopeChecker,
+      distinctActiveUsers: opts.distinctActiveUsers,
+      now: opts.now,
     })
   );
   return app;
@@ -397,5 +402,354 @@ describe('GET /v1/tenants/:tenantId/usage — CSV (issue #186)', () => {
     expect(row).toBe(
       '"tenant,with""quotes\nand-commas",2026-04-01,0,0,0,0,0,0,1,0,0,0,,2026-04-01T00:00:00.000Z'
     );
+  });
+});
+
+describe('GET /v1/tenants/:tenantId/usage/current (issue #188)', () => {
+  // Pin "now" to 2026-04-15T12:34:56Z so periodStart=2026-04-01 and periodEnd=2026-04-15.
+  const fixedNow = () => new Date('2026-04-15T12:34:56.000Z');
+
+  it('returns zero-filled totals for a tenant with no activity', async () => {
+    const store = new InMemoryDailyDocStore();
+    const app = makeApp({
+      store,
+      ownerUserId,
+      tenantId,
+      authUserId: ownerUserId,
+      now: fixedNow,
+    });
+    const res = await req(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      tenantId: 'tenant-A',
+      periodStart: '2026-04-01',
+      periodEnd: '2026-04-15',
+      storageBytesDelta: 0,
+      imagesUploaded: 0,
+      imagesProcessed: 0,
+      signedUrlsIssued: 0,
+      editsApplied: 0,
+      tagsApplied: 0,
+      apiCalls: 0,
+      exportBytes: 0,
+      activeUsers: 0,
+      rateLimited: 0,
+    });
+    expect(typeof res.body.generatedAt).toBe('string');
+  });
+
+  it('sums summable counters across a partial month', async () => {
+    const store = new InMemoryDailyDocStore();
+    const consumer = new UsageRollupConsumer(store);
+    // Three days in the current month with activity.
+    await consumer.apply({ tenantId, counter: 'apiCalls', value: 5, occurredAt: '2026-04-02T10:00:00Z' });
+    await consumer.apply({ tenantId, counter: 'apiCalls', value: 7, occurredAt: '2026-04-05T10:00:00Z' });
+    await consumer.apply({ tenantId, counter: 'imagesUploaded', value: 3, occurredAt: '2026-04-05T10:00:00Z' });
+    await consumer.apply({ tenantId, counter: 'exportBytes', value: 1024, occurredAt: '2026-04-10T10:00:00Z' });
+    // Activity from the previous month should NOT be included.
+    await consumer.apply({ tenantId, counter: 'apiCalls', value: 99, occurredAt: '2026-03-15T10:00:00Z' });
+    // Activity for a different tenant must not bleed in either.
+    await consumer.apply({ tenantId: 'tenant-OTHER', counter: 'apiCalls', value: 50, occurredAt: '2026-04-05T10:00:00Z' });
+
+    const app = makeApp({
+      store,
+      ownerUserId,
+      tenantId,
+      authUserId: ownerUserId,
+      now: fixedNow,
+    });
+    const res = await req(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      tenantId: 'tenant-A',
+      periodStart: '2026-04-01',
+      periodEnd: '2026-04-15',
+      apiCalls: 12, // 5 + 7
+      imagesUploaded: 3,
+      exportBytes: 1024,
+    });
+  });
+
+  it('returns the full month when "now" is the last day', async () => {
+    const store = new InMemoryDailyDocStore();
+    const consumer = new UsageRollupConsumer(store);
+    // Spread one apiCall across each of 30 days of April 2026.
+    for (let day = 1; day <= 30; day++) {
+      const date = `2026-04-${String(day).padStart(2, '0')}T10:00:00Z`;
+      await consumer.apply({ tenantId, counter: 'apiCalls', value: 1, occurredAt: date });
+    }
+    const app = makeApp({
+      store,
+      ownerUserId,
+      tenantId,
+      authUserId: ownerUserId,
+      now: () => new Date('2026-04-30T23:59:59.000Z'),
+    });
+    const res = await req(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(res.status).toBe(200);
+    expect(res.body.periodStart).toBe('2026-04-01');
+    expect(res.body.periodEnd).toBe('2026-04-30');
+    expect(res.body.apiCalls).toBe(30);
+  });
+
+  it('de-duplicates activeUsers across days when a DistinctActiveUsersQuery is wired', async () => {
+    const store = new InMemoryDailyDocStore();
+    const consumer = new UsageRollupConsumer(store);
+    // Per-day activeUsers counter — naive sum would be 5.
+    await consumer.apply({ tenantId, counter: 'activeUsers', value: 2, occurredAt: '2026-04-02T10:00:00Z' });
+    await consumer.apply({ tenantId, counter: 'activeUsers', value: 2, occurredAt: '2026-04-03T10:00:00Z' });
+    await consumer.apply({ tenantId, counter: 'activeUsers', value: 1, occurredAt: '2026-04-04T10:00:00Z' });
+    // But the actual distinct set across the period is {alice, bob, carol}.
+    const userActive = new InMemoryUserActiveDailyStore();
+    await userActive.markIfFirst(tenantId, 'alice', '2026-04-02');
+    await userActive.markIfFirst(tenantId, 'bob', '2026-04-02');
+    await userActive.markIfFirst(tenantId, 'alice', '2026-04-03'); // duplicate user
+    await userActive.markIfFirst(tenantId, 'carol', '2026-04-03');
+    await userActive.markIfFirst(tenantId, 'bob', '2026-04-04'); // duplicate user
+    // A user from a previous month is out of range.
+    await userActive.markIfFirst(tenantId, 'dave', '2026-03-31');
+    // A user from a different tenant must not leak in.
+    await userActive.markIfFirst('tenant-OTHER', 'eve', '2026-04-05');
+
+    const app = makeApp({
+      store,
+      ownerUserId,
+      tenantId,
+      authUserId: ownerUserId,
+      now: fixedNow,
+      distinctActiveUsers: userActive,
+    });
+    const res = await req(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(res.status).toBe(200);
+    expect(res.body.activeUsers).toBe(3); // alice, bob, carol — NOT 5
+  });
+
+  it('falls back to summing per-day activeUsers when no DistinctActiveUsersQuery is wired', async () => {
+    const store = new InMemoryDailyDocStore();
+    const consumer = new UsageRollupConsumer(store);
+    await consumer.apply({ tenantId, counter: 'activeUsers', value: 2, occurredAt: '2026-04-02T10:00:00Z' });
+    await consumer.apply({ tenantId, counter: 'activeUsers', value: 3, occurredAt: '2026-04-03T10:00:00Z' });
+    const app = makeApp({
+      store,
+      ownerUserId,
+      tenantId,
+      authUserId: ownerUserId,
+      now: fixedNow,
+    });
+    const res = await req(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(res.status).toBe(200);
+    expect(res.body.activeUsers).toBe(5); // sum, the conservative upper bound
+  });
+
+  it('rejects cross-tenant access with 403', async () => {
+    const store = new InMemoryDailyDocStore();
+    const app = makeApp({
+      store,
+      ownerUserId,
+      tenantId: 'tenant-OTHER',
+      authUserId: ownerUserId,
+      now: fixedNow,
+    });
+    const res = await req(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('rejects unauthenticated callers when no host scope is granted (403)', async () => {
+    const store = new InMemoryDailyDocStore();
+    const app = makeApp({
+      store,
+      ownerUserId,
+      tenantId,
+      authUserId: null,
+      now: fixedNow,
+    });
+    const res = await req(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects host API key whose scope check fails (403)', async () => {
+    const store = new InMemoryDailyDocStore();
+    const app = makeApp({
+      store,
+      ownerUserId,
+      tenantId,
+      authUserId: null,
+      hostScopeChecker: async () => false, // explicit deny — missing scope
+      now: fixedNow,
+    });
+    const res = await req(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('allows host API key with usage.read scope', async () => {
+    const store = new InMemoryDailyDocStore();
+    const consumer = new UsageRollupConsumer(store);
+    await consumer.apply({ tenantId, counter: 'apiCalls', value: 4, occurredAt: '2026-04-05T10:00:00Z' });
+    const app = makeApp({
+      store,
+      ownerUserId,
+      tenantId,
+      authUserId: null,
+      hostScopeChecker: async (_req, t, scope) => t === tenantId && scope === 'usage.read',
+      now: fixedNow,
+    });
+    const res = await req(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(res.status).toBe(200);
+    expect(res.body.apiCalls).toBe(4);
+  });
+
+  it('sets Cache-Control: max-age=60 on responses', async () => {
+    const store = new InMemoryDailyDocStore();
+    const app = makeApp({
+      store,
+      ownerUserId,
+      tenantId,
+      authUserId: ownerUserId,
+      now: fixedNow,
+    });
+    const res = await rawReq(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(res.status).toBe(200);
+    expect(String(res.headers['cache-control'])).toMatch(/max-age=60/);
+  });
+
+  it('caches identical requests for 60s (second call is a HIT, no store re-read)', async () => {
+    const store = new InMemoryDailyDocStore();
+    const consumer = new UsageRollupConsumer(store);
+    await consumer.apply({ tenantId, counter: 'apiCalls', value: 4, occurredAt: '2026-04-05T10:00:00Z' });
+    const app = makeApp({
+      store,
+      ownerUserId,
+      tenantId,
+      authUserId: ownerUserId,
+      now: fixedNow,
+    });
+    const first = await rawReq(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(first.status).toBe(200);
+    expect(String(first.headers['x-cache'] ?? '')).toBe('MISS');
+
+    // Mutate the store AFTER the first call. With a 60s in-memory cache and
+    // no explicit cache-bust, the second call must see the cached payload.
+    await consumer.apply({ tenantId, counter: 'apiCalls', value: 100, occurredAt: '2026-04-05T10:00:00Z' });
+
+    const second = await rawReq(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(second.status).toBe(200);
+    expect(String(second.headers['x-cache'] ?? '')).toBe('HIT');
+    const body = JSON.parse(second.body);
+    expect(body.apiCalls).toBe(4); // stale, as documented
+  });
+
+  it('exposes invalidateTenantCurrentCache so writers can bust the cache', async () => {
+    const store = new InMemoryDailyDocStore();
+    const consumer = new UsageRollupConsumer(store);
+    await consumer.apply({ tenantId, counter: 'apiCalls', value: 4, occurredAt: '2026-04-05T10:00:00Z' });
+    // Build the router directly so we can grab the invalidator handle.
+    const router = createTenantUsageRouter({
+      store,
+      ownsTenant: async (uid, tid) => uid === ownerUserId && tid === tenantId,
+      now: fixedNow,
+    }) as ReturnType<typeof createTenantUsageRouter> & {
+      invalidateTenantCurrentCache?: (tenantId: string) => void;
+    };
+    expect(typeof router.invalidateTenantCurrentCache).toBe('function');
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.user = { uid: ownerUserId };
+      next();
+    });
+    app.use('/api/v1/tenants', router);
+
+    const first = await rawReq(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(JSON.parse(first.body).apiCalls).toBe(4);
+    // Write more, then explicitly bust the cache.
+    await consumer.apply({ tenantId, counter: 'apiCalls', value: 6, occurredAt: '2026-04-05T10:00:00Z' });
+    router.invalidateTenantCurrentCache!(tenantId);
+
+    const second = await rawReq(app, '/api/v1/tenants/tenant-A/usage/current');
+    expect(String(second.headers['x-cache'] ?? '')).toBe('MISS');
+    expect(JSON.parse(second.body).apiCalls).toBe(10);
+  });
+
+  it('caches per-tenant — invalidating one tenant does not affect another', async () => {
+    const store = new InMemoryDailyDocStore();
+    const router = createTenantUsageRouter({
+      store,
+      ownsTenant: async () => true, // simplify — any user owns any tenant
+      now: fixedNow,
+    }) as ReturnType<typeof createTenantUsageRouter> & {
+      invalidateTenantCurrentCache?: (tenantId: string) => void;
+    };
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.user = { uid: 'u' };
+      next();
+    });
+    app.use('/api/v1/tenants', router);
+
+    await rawReq(app, '/api/v1/tenants/tenant-A/usage/current');
+    await rawReq(app, '/api/v1/tenants/tenant-B/usage/current');
+
+    router.invalidateTenantCurrentCache!('tenant-A');
+
+    const aRes = await rawReq(app, '/api/v1/tenants/tenant-A/usage/current');
+    const bRes = await rawReq(app, '/api/v1/tenants/tenant-B/usage/current');
+    expect(String(aRes.headers['x-cache'])).toBe('MISS'); // busted
+    expect(String(bRes.headers['x-cache'])).toBe('HIT'); // still cached
+  });
+
+  it('helper functions: currentUtcMonthRange and sumCounters', async () => {
+    const { currentUtcMonthRange, sumCounters } = (
+      await import('../../src/routes/tenantUsage.js')
+    ).__test;
+    // currentUtcMonthRange: leading zero on single-digit month & day.
+    expect(currentUtcMonthRange(new Date('2026-01-05T00:00:00Z'))).toEqual({
+      periodStart: '2026-01-01',
+      periodEnd: '2026-01-05',
+    });
+    expect(currentUtcMonthRange(new Date('2026-12-31T23:59:59Z'))).toEqual({
+      periodStart: '2026-12-01',
+      periodEnd: '2026-12-31',
+    });
+    // sumCounters: empty input yields zero-filled totals.
+    expect(sumCounters([])).toMatchObject({
+      apiCalls: 0,
+      imagesUploaded: 0,
+      activeUsers: 0,
+      rateLimited: 0,
+    });
+  });
+});
+
+describe('InMemoryUserActiveDailyStore.listDistinctUsers (issue #188)', () => {
+  it('returns distinct user IDs across an inclusive UTC date range, scoped to the tenant', async () => {
+    const s = new InMemoryUserActiveDailyStore();
+    await s.markIfFirst('tenant-A', 'alice', '2026-04-02');
+    await s.markIfFirst('tenant-A', 'bob', '2026-04-02');
+    await s.markIfFirst('tenant-A', 'alice', '2026-04-03'); // same user, later day
+    await s.markIfFirst('tenant-A', 'carol', '2026-04-15');
+    // Out of range and other tenant — must be excluded.
+    await s.markIfFirst('tenant-A', 'dave', '2026-03-31');
+    await s.markIfFirst('tenant-A', 'eve', '2026-05-01');
+    await s.markIfFirst('tenant-OTHER', 'mallory', '2026-04-10');
+
+    const result = await s.listDistinctUsers('tenant-A', '2026-04-01', '2026-04-15');
+    expect(result.sort()).toEqual(['alice', 'bob', 'carol']);
+  });
+
+  it('preserves userIds containing the "::" separator (split-from-the-right)', async () => {
+    const s = new InMemoryUserActiveDailyStore();
+    await s.markIfFirst('tenant-A', 'foo::bar', '2026-04-02');
+    const result = await s.listDistinctUsers('tenant-A', '2026-04-01', '2026-04-30');
+    expect(result).toEqual(['foo::bar']);
+  });
+
+  it('returns an empty array for tenants with no recorded activity', async () => {
+    const s = new InMemoryUserActiveDailyStore();
+    const result = await s.listDistinctUsers('tenant-A', '2026-04-01', '2026-04-30');
+    expect(result).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/tenants/:tenantId/usage/current` — a single-shot month-to-date usage summary derived by summing the existing `usageDaily` docs server-side. Lets hosts render an in-app *"Usage this month"* widget on every dashboard load without fanning out 1–31 daily reads or duplicating the sum logic across every integration.

## Changes

- **`functions/src/routes/tenantUsage.ts`** — new `/:tenantId/usage/current` handler alongside the existing `/usage` route. Computes the current UTC month window (`periodStart` = day 01, `periodEnd` = today), sums the `SUMMABLE_COUNTERS` across the daily docs, and returns `{tenantId, periodStart, periodEnd, generatedAt, …counters}`. Same auth model as `/usage` (tenant owner Bearer **or** host API key with `usage.read`). Per-tenant in-memory cache (~60s TTL) with an explicit `invalidateTenantCurrentCache(tenantId)` hook for in-process writers; sets `Cache-Control: private, max-age=60` so a fronting CDN can cache safely. `X-Cache: HIT|MISS` diagnostic header.
- **`functions/src/services/metering/UserActiveDailyStore.ts`** — new optional `DistinctActiveUsersQuery` capability so the summary can de-duplicate `activeUsers` across days (distinct count, not sum). `InMemoryUserActiveDailyStore` implements it; the route falls back to the per-day sum (documented eventual-consistency window) when the capability isn't wired.
- **`contracts/openapi/tenant-usage.openapi.json`** — bumped to `0.3.0`, added the new path + `TenantUsageCurrentResponse` schema. `npm run contract:check` passes (validate + breaking).
- **`functions/test/routes/tenantUsage.test.ts`** — 17 new vitest cases.
- **`docs/features/usage-and-billing.md`** — new "Month-to-date summary" section with counter semantics, caching behaviour, and an example payload.

## Acceptance criteria

- ✅ New route + handler in `functions/src/routes/tenantUsage.ts`.
- ✅ OpenAPI contract added; `contract:check` passes.
- ✅ Correct sums for empty / partial / full month (unit-tested with fixtures).
- ✅ `activeUsers` correctly de-duplicated across days when `DistinctActiveUsersQuery` is wired (distinct, not sum).
- ✅ Cross-tenant access → `403`; missing scope → `403`.
- ✅ In-memory 60s cache with explicit `invalidateTenantCurrentCache` cache-busting hook (and the documented eventual-consistency window for multi-process deployments).
- ✅ `docs/features/usage-and-billing.md` updated with the new endpoint and an example payload.

## Testing

- `npx vitest run test/routes/tenantUsage.test.ts` → **35 passed** (18 existing + 17 new).
- `npx vitest run test/routes/tenantUsage.test.ts src/middleware/userActive.test.ts src/services/metering` → **71 passed**.
- `npm run contract:check` → validate + breaking both pass.
- Full suite: pre-existing failures in `photosV1.test.ts` and `tenantUsersV1.test.ts` reproduce on clean `main` and are unrelated.

## Caveats

- The summary's `activeUsers` only de-duplicates across days when a `DistinctActiveUsersQuery` is wired into the router. Until the Firestore-backed `userActiveDaily` store implements it, the field is the conservative sum of per-day distincts (documented in both the OpenAPI description and the feature doc).
- The 60s cache is in-process. Multi-process deployments observe at most a 60s drift; hosts that need stricter freshness should cache-bust on their side.

Fixes rwrife/AuraPix#188