### PR TITLE
feat: Host-issued embed session token API (SSO for embedded AuraPix) (#195)

### DIFF
--- a/contracts/openapi/embed.openapi.json
+++ b/contracts/openapi/embed.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "AuraPix Embed Handshake API",
-    "version": "0.1.0",
-    "description": "Per-tenant allowed-origins configuration for embedding AuraPix in host applications. Drives the server-emitted `Content-Security-Policy: frame-ancestors` header and the documented postMessage handshake. See `docs/features/embed-handshake.md`."
+    "version": "0.2.0",
+    "description": "Per-tenant allowed-origins configuration and host-issued session tokens for embedding AuraPix in host applications. Drives the server-emitted `Content-Security-Policy: frame-ancestors` header and the documented postMessage handshake. See `docs/features/embed-handshake.md`."
   },
   "paths": {
     "/v1/tenants/{tenantId}/embed/allowed-origins": {
@@ -102,6 +102,136 @@
         }
       }
     },
+    "/v1/tenants/{tenantId}/embed/session-tokens": {
+      "parameters": [
+        {
+          "name": "tenantId",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string", "pattern": "^[a-zA-Z0-9_-]{1,64}$" }
+        }
+      ],
+      "post": {
+        "summary": "Mint a host-issued embed session token",
+        "description": "Mints a short-lived signed JWT for an already-authenticated end user. The host passes this token to the embedded AuraPix iframe via the documented `aurapix:session` postMessage; AuraPix then exchanges it for a server-side session and the user lands logged in (no Firebase login prompt).\n\nThe token is signed with the tenant's existing webhook signing secret (issue #161 \u2014 rotation grace window is honored). Tokens are single-use within their TTL window; replays return `401 token_replayed` at exchange time.\n\nThe `userId` must already be a member of the tenant (provision via `POST /v1/tenants/{tenantId}/users` first). Auto-provisioning is intentionally out of scope.\n\nEmits the `embed.session.minted` metering event.",
+        "security": [{ "hostApiKey": ["tenants.write"] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/EmbedSessionTokenInput" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Token minted",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EmbedSessionTokenResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body or tenantId",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing tenants.write scope",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "409": {
+            "description": "User is not a member of the tenant (`user_not_member`) or the tenant has no webhook signing secret yet (`no_signing_secret`).",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/tenants/{tenantId}/embed/session-exchange": {
+      "parameters": [
+        {
+          "name": "tenantId",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string", "pattern": "^[a-zA-Z0-9_-]{1,64}$" }
+        }
+      ],
+      "post": {
+        "summary": "Exchange a host-issued embed session token for a server-side session",
+        "description": "Called by the embedded AuraPix UI after receiving an `aurapix:session` postMessage from the host page. Validates the JWT signature (against the tenant's webhook signing secret, honoring the rotation grace window), audience, expiry, tenant binding (the URL `tenantId` must equal the token's issuer), and one-time-use `jti`. On success, returns the user identity claims and an optional opaque `session` payload (e.g. a Firebase custom token) the embedded SDK can use to sign in. Emits the `embed.session.exchanged` metering event.\n\nNo Authorization header is required \u2014 the token IS the credential. Cross-tenant tokens are rejected at exchange time.",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/EmbedSessionExchangeInput" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Token verified and session established.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EmbedSessionExchangeResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body or tenantId",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "401": {
+            "description": "Token is malformed, expired, has an invalid signature, or has already been redeemed (`token_replayed`).",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "403": {
+            "description": "Token tenant does not match the iframe's tenant context (`tenant_mismatch`).",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
+          "409": {
+            "description": "User is no longer a member of the tenant (`user_not_member`).",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/tenants/{tenantId}/embed/csp-report": {
       "parameters": [
         {
@@ -144,6 +274,75 @@
       "hostApiKey": { "type": "apiKey", "in": "header", "name": "X-Host-API-Key" }
     },
     "schemas": {
+      "EmbedSessionTokenInput": {
+        "type": "object",
+        "required": ["userId"],
+        "properties": {
+          "userId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "Stable user id; must already be a member of the tenant."
+          },
+          "role": {
+            "type": "string",
+            "enum": ["owner", "editor", "viewer"],
+            "description": "Optional role override. Defaults to the membership's stored role."
+          },
+          "ttlSeconds": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 300,
+            "description": "Token lifetime in seconds. Capped at 300; defaults to 120."
+          }
+        },
+        "additionalProperties": false
+      },
+      "EmbedSessionTokenResponse": {
+        "type": "object",
+        "required": ["token", "expiresAt", "audience"],
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Compact JWT (HS256). Forward to the embedded UI via the `aurapix:session` postMessage."
+          },
+          "expiresAt": { "type": "string", "format": "date-time" },
+          "audience": {
+            "type": "string",
+            "enum": ["aurapix:embed"]
+          }
+        }
+      },
+      "EmbedSessionExchangeInput": {
+        "type": "object",
+        "required": ["token"],
+        "properties": {
+          "token": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096
+          }
+        },
+        "additionalProperties": false
+      },
+      "EmbedSessionExchangeResponse": {
+        "type": "object",
+        "required": ["tenantId", "userId", "role", "expiresAt"],
+        "properties": {
+          "tenantId": { "type": "string" },
+          "userId": { "type": "string" },
+          "role": {
+            "type": "string",
+            "enum": ["owner", "editor", "viewer"]
+          },
+          "expiresAt": { "type": "string", "format": "date-time" },
+          "session": {
+            "type": ["object", "null"],
+            "description": "Optional opaque payload (e.g. Firebase custom token) the embedded SDK can use to establish a real session without showing the login UI. Present only when the deployment wires `issueEmbedSession`.",
+            "additionalProperties": true
+          }
+        }
+      },
       "EmbedConfigInput": {
         "type": "object",
         "required": ["origins"],

--- a/docs/features/auth-and-user-management.md
+++ b/docs/features/auth-and-user-management.md
@@ -77,3 +77,29 @@ All three events are catalogued in
 `usage.read` and `tenants.read`). Granted via the existing admin endpoint
 (`POST /internal/tenants/:tenantId/api-keys`).
 
+---
+
+## Host-issued embed session tokens (SSO)
+
+_Tracking issue: [#195](https://github.com/rwrife/AuraPix/issues/195)._
+
+For host applications embedding AuraPix, asking already-signed-in end
+users to authenticate a second time with Firebase Auth is a major
+friction point. The embed session-token flow lets the host backend mint a
+short-lived signed credential the embedded UI can exchange for a real
+server-side session — no Firebase login prompt is shown.
+
+| Method | Path | Scope | Purpose |
+| --- | --- | --- | --- |
+| `POST` | `/v1/tenants/{tenantId}/embed/session-tokens` | `tenants.write` | Mint a short-lived JWT for an already-authenticated end user. Body: `{ userId, role?, ttlSeconds? }` (`ttlSeconds` ≤ 300, default 120). The `userId` MUST already be a tenant member; non-members get `409 user_not_member`. |
+| `POST` | `/v1/tenants/{tenantId}/embed/session-exchange` | (token in body) | Iframe-side redemption. Validates the JWT and returns the user's identity claims plus an optional opaque `session` payload (e.g. a Firebase custom token). Cross-tenant tokens are rejected; replays return `401 token_replayed`. |
+
+Tokens are signed with the tenant's existing webhook signing secret
+(issue #161), so secret rotation inherits the same dual-secret grace
+window. The full handshake — token mint, postMessage forwarding, exchange
+— is documented in [`embed-handshake.md`](./embed-handshake.md#host-issued-session-tokens-sso).
+
+Membership is re-validated at exchange time, so revoking a user (per the
+DELETE endpoint above) immediately invalidates any outstanding embed
+tokens for that user.
+

--- a/docs/features/embed-handshake.md
+++ b/docs/features/embed-handshake.md
@@ -122,6 +122,7 @@ shape doesn't match below.
 | ------------------- | --------------- | ------------------------------------------ |
 | `aurapix:set-theme` | `{ theme }`     | `light` \| `dark` \| `system` \| `<custom>` |
 | `aurapix:navigate`  | `{ path }`      | Path starts with `/`; routes inside AuraPix |
+| `aurapix:session`   | `{ token }`     | Forward a host-issued embed session token (SSO). See [Host-issued session tokens](#host-issued-session-tokens-sso) |
 
 ### Origin / source validation
 
@@ -180,6 +181,142 @@ host.dispose();
 The SDK enforces all of the origin/source checks above and throws on
 configuration mistakes (`'*'`, missing or malformed `targetOrigin`).
 
+## Host-issued session tokens (SSO)
+
+_Tracking issue: [#195](https://github.com/rwrife/AuraPix/issues/195)._
+
+When AuraPix is embedded inside a host application, end users have
+already authenticated with the host. Showing them a second Firebase login
+prompt breaks the illusion of a seamless host-branded experience. The
+embed session-token flow lets the host backend mint a short-lived signed
+credential that the embedded UI exchanges for a server-side session.
+
+### Mint a token (host backend)
+
+`POST /v1/tenants/{tenantId}/embed/session-tokens` — host-API-key
+authenticated with the `tenants.write` scope.
+
+Request body:
+
+```json
+{
+  "userId": "u_42",
+  "role": "editor",      // optional, defaults to the membership role
+  "ttlSeconds": 120      // optional, capped at 300, defaults to 120
+}
+```
+
+Response `201`:
+
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.<payload>.<sig>",
+  "expiresAt": "2026-06-29T16:21:00.000Z",
+  "audience": "aurapix:embed"
+}
+```
+
+The `userId` MUST already be a member of the tenant (provision via
+`POST /v1/tenants/{tenantId}/users` first). If not, the call returns
+`409 user_not_member` and the host must call the tenant-users API before
+retrying. Auto-provisioning from the embed flow is intentionally out of
+scope.
+
+### Token shape
+
+Compact JWT signed with HS256 using the tenant's existing webhook
+signing secret (issue #161 — the dual-secret rotation grace window is
+honoured at verification time). Claims:
+
+| Claim   | Value                                  |
+| ------- | -------------------------------------- |
+| `iss`   | `tenantId`                             |
+| `aud`   | `aurapix:embed`                        |
+| `sub`   | `userId`                               |
+| `role`  | `owner` \| `editor` \| `viewer`        |
+| `jti`   | UUID — one-time-use within the TTL     |
+| `iat`   | unix seconds                           |
+| `exp`   | unix seconds (`exp - iat ≤ 300`)       |
+
+### Forward over postMessage
+
+The host SDK accepts a `sessionToken` option on `createEmbedHost`:
+
+```ts
+import { createEmbedHost } from '@aurapix/embed-sdk'; // or src/embed/host-sdk.ts
+
+const handle = createEmbedHost({
+  iframe,
+  targetOrigin: 'https://app.aurapix.com',
+  sessionToken,            // minted above
+});
+```
+
+The SDK queues the token internally and forwards it as the first
+`postMessage` after the embedded UI announces `aurapix:ready`:
+
+```json
+{ "type": "aurapix:session", "token": "<jwt>" }
+```
+
+Callers can also set/replace the token after mount via
+`handle.sendSessionToken(token)`.
+
+### Exchange (embedded side)
+
+`POST /v1/tenants/{tenantId}/embed/session-exchange` — the token IS the
+credential, so no Authorization header is required. Body: `{ token }`.
+
+The server validates:
+
+- Signature against the tenant's current and (within the grace window)
+  previous webhook signing secret.
+- `aud === "aurapix:embed"`.
+- `iss === tenantId` from the URL path. Cross-tenant tokens are rejected
+  with `403 tenant_mismatch` so a token minted by tenant A can never be
+  relayed into tenant B's embed.
+- `exp` (with a 30s skew window).
+- `jti` has not been redeemed before — second redemption returns
+  `401 token_replayed`.
+- The user is still a member of the tenant — revoked users get
+  `409 user_not_member`.
+
+On success the response is:
+
+```json
+{
+  "tenantId": "acme",
+  "userId": "u_42",
+  "role": "editor",
+  "expiresAt": "2026-06-29T16:21:00.000Z",
+  "session": { ... }   // optional opaque payload (e.g. Firebase custom token)
+}
+```
+
+Deployments wire `issueEmbedSession` on the router so the `session`
+field can carry a Firebase custom token; the embedded SDK then signs in
+with `signInWithCustomToken` and no Firebase login UI is shown.
+
+### Allowed-origins still enforced
+
+The session-token flow does **not** bypass the per-tenant allowed-origins
+config (#163). The CSP `frame-ancestors` header is still emitted from the
+stored allow-list; a valid token cannot frame AuraPix from an origin the
+tenant hasn't approved.
+
+### Metering
+
+- `embed.session.minted` — emitted by the mint endpoint. Useful for
+  hosts that bill per session (`meta.userId`, `meta.role`,
+  `meta.ttlSeconds`, `meta.jtiHash`).
+- `embed.session.exchanged` — emitted by the exchange endpoint. The
+  meaningful "active embedded user" signal; complements `user.active`
+  with embed context (`meta.userId`, `meta.role`, `meta.jtiHash`,
+  `meta.matchedSecret`).
+
+The `jtiHash` is the first 16 hex characters of `sha256(jti)` — stable
+for correlation but non-reversible.
+
 ## Metering hooks
 
 The CSP middleware, the violation report endpoint, and the embed-SDK
@@ -206,3 +343,7 @@ through the standard host webhook fanout (see `metering-events.md`).
 | Embedded UI ignores messages from non-allowed origins (tested)           | `src/embed/embedded.ts` + `src/embed/host-sdk.test.ts`    |
 | `embed.session_started` flows through existing bus                       | `MeteringBus` event type + middleware emit                |
 | OpenAPI updated                                                          | `contracts/openapi/embed.openapi.json`                    |
+| `POST /v1/tenants/:id/embed/session-tokens` minted JWT, host-API-key gated (#195) | `functions/src/services/host/embedSessionTokenService.ts` + `embedV1.ts` route |
+| Replay defense (`token_replayed`) via single-use `jti` tracking (#195)   | `embedSessionTokenJtis` collection + `verifyAndRedeemEmbedSessionToken` |
+| Cross-tenant tokens rejected at exchange time (#195)                     | `iss` claim vs URL `tenantId` check in the exchange route |
+| `embed.session.minted` / `embed.session.exchanged` events catalogued (#195) | `functions/src/services/metering/eventCatalog.ts`        |

--- a/functions/src/routes/embedV1.ts
+++ b/functions/src/routes/embedV1.ts
@@ -3,6 +3,15 @@ import { Router, type Request, type Response, type NextFunction } from 'express'
 import { z } from 'zod';
 import type { DataAdapter } from '../adapters/data/DataAdapter.js';
 import { recordAuditEvent } from '../services/audit/AuditService.js';
+import {
+  EMBED_SESSION_TOKEN_AUDIENCE,
+  EMBED_SESSION_TOKEN_DEFAULT_TTL_SECONDS,
+  EMBED_SESSION_TOKEN_MAX_TTL_SECONDS,
+  hashJtiForMetering,
+  mintEmbedSessionToken,
+  verifyAndRedeemEmbedSessionToken,
+} from '../services/host/embedSessionTokenService.js';
+import { TENANT_MEMBER_ROLES } from '../models/TenantMember.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -99,6 +108,33 @@ export const EmbedAllowedOriginsSchema = z.object({
     ),
 });
 
+/**
+ * Body schema for `POST /v1/tenants/:tenantId/embed/session-tokens` (issue
+ * #195). Hosts pass `userId` (and optionally `role`/`ttlSeconds`) for an
+ * already-authenticated end user; the response is a short-lived signed
+ * token the host SDK forwards into the iframe.
+ */
+export const EmbedSessionTokenInputSchema = z.object({
+  userId: z.string().min(1).max(256),
+  role: z.enum(TENANT_MEMBER_ROLES as readonly [string, ...string[]]).optional(),
+  ttlSeconds: z
+    .number()
+    .int()
+    .positive()
+    .max(EMBED_SESSION_TOKEN_MAX_TTL_SECONDS)
+    .optional(),
+});
+
+/**
+ * Body schema for the iframe-side exchange endpoint
+ * `POST /v1/tenants/:tenantId/embed/session-exchange` — the embedded
+ * AuraPix UI POSTs the token it received from the host SDK and gets back
+ * a server-side session.
+ */
+export const EmbedSessionExchangeSchema = z.object({
+  token: z.string().min(1).max(4096),
+});
+
 interface ApiErrorPayload {
   error: {
     code: string;
@@ -154,6 +190,24 @@ export interface EmbedRouterOptions {
    * production this is wired to the host-API-key middleware.
    */
   canWriteEmbedConfig?: (req: Request, tenantId: string) => boolean | Promise<boolean>;
+
+  /**
+   * Optional callback invoked after a successful embed session-token
+   * exchange (issue #195). Lets the server.ts wiring layer mint a
+   * Firebase custom token, set a session cookie, or otherwise establish
+   * an authenticated server-side session for the user — without this
+   * route needing to know about Firebase Admin.
+   *
+   * Returned object is echoed back in the exchange response under the
+   * `session` field; callers can attach things like a Firebase custom
+   * token the SDK will sign in with (`signInWithCustomToken`) so the
+   * embedded UI never shows the Firebase login prompt.
+   */
+  issueEmbedSession?: (input: {
+    tenantId: string;
+    userId: string;
+    role: string;
+  }) => Promise<Record<string, unknown> | null> | Record<string, unknown> | null;
 }
 
 export function createEmbedV1Router(
@@ -359,6 +413,232 @@ export function createEmbedV1Router(
       res.status(204).end();
     } catch (error) {
       logger.debug({ err: error }, 'Failed to process embed session-end');
+      next(error);
+    }
+  });
+
+  // ---------------------------------------------------------------------
+  // Embed session tokens (issue #195) — host-side SSO mint endpoint.
+  // ---------------------------------------------------------------------
+  // Host-API-key only with the `tenants.write` scope. The same `canWrite`
+  // gate that protects the allowed-origins config is reused so hosts only
+  // need to manage one key/scope for the whole embed surface.
+  router.post('/:tenantId/embed/session-tokens', async (req, res, next) => {
+    try {
+      const tenantId = req.params.tenantId;
+      if (!isValidTenantId(tenantId)) {
+        sendError(res, 400, 'INVALID_TENANT_ID', 'tenantId must match [a-zA-Z0-9_-]{1,64}');
+        return;
+      }
+
+      const allowed = await canWrite(req, tenantId);
+      if (!allowed) {
+        sendError(
+          res,
+          403,
+          'FORBIDDEN',
+          'tenants.write scope required to mint embed session tokens'
+        );
+        return;
+      }
+
+      const parsed = EmbedSessionTokenInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        sendError(res, 400, 'INVALID_BODY', 'Invalid embed session token request', {
+          issues: parsed.error.issues,
+        });
+        return;
+      }
+
+      const result = await mintEmbedSessionToken(dataAdapter, {
+        tenantId,
+        userId: parsed.data.userId,
+        role: parsed.data.role as never,
+        ttlSeconds: parsed.data.ttlSeconds ?? EMBED_SESSION_TOKEN_DEFAULT_TTL_SECONDS,
+      });
+
+      if ('code' in result) {
+        switch (result.code) {
+          case 'invalid_input':
+            sendError(res, 400, 'INVALID_BODY', result.message);
+            return;
+          case 'user_not_member':
+            // Acceptance criterion: 409 user_not_member when the userId is
+            // not already a member of the tenant. Hosts must call the
+            // tenant-users API first.
+            sendError(res, 409, 'user_not_member', result.message);
+            return;
+          case 'no_signing_secret':
+            sendError(res, 409, 'no_signing_secret', result.message);
+            return;
+          default: {
+            const _exhaustive: never = result;
+            void _exhaustive;
+            sendError(res, 500, 'INTERNAL', 'Unable to mint session token');
+            return;
+          }
+        }
+      }
+
+      // Emit metering event for hosts that bill per session.
+      const meteringBus = req.app.locals.meteringBus as
+        | { emit?: (e: unknown) => void }
+        | undefined;
+      try {
+        meteringBus?.emit?.({
+          tenantId,
+          type: 'embed.session.minted',
+          meta: {
+            userId: parsed.data.userId,
+            role: result.role,
+            jtiHash: hashJtiForMetering(result.jti),
+            ttlSeconds:
+              parsed.data.ttlSeconds ?? EMBED_SESSION_TOKEN_DEFAULT_TTL_SECONDS,
+          },
+        });
+      } catch (err) {
+        logger.debug({ err, tenantId }, 'Failed to emit embed.session.minted');
+      }
+
+      // Audit — host-issued credentials are sensitive enough that we leave a
+      // record per mint. The token itself is NEVER logged; only the jti hash
+      // and userId.
+      try {
+        await recordAuditEvent(dataAdapter, {
+          eventType: 'embed.session_token.minted',
+          actorId: req.tenant?.keyId ?? req.user?.uid ?? 'host-api-key',
+          targetId: parsed.data.userId,
+          createdAt: new Date().toISOString(),
+          metadata: {
+            tenantId,
+            jtiHash: hashJtiForMetering(result.jti),
+            role: result.role,
+            expiresAt: result.expiresAt,
+          },
+        });
+      } catch (auditErr) {
+        logger.warn(
+          { err: auditErr, tenantId },
+          'Failed to record embed session token mint audit event'
+        );
+      }
+
+      res.status(201).json({
+        token: result.token,
+        expiresAt: result.expiresAt,
+        audience: EMBED_SESSION_TOKEN_AUDIENCE,
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // ---------------------------------------------------------------------
+  // Embed session exchange (issue #195) — iframe-side redemption.
+  // ---------------------------------------------------------------------
+  // The embedded AuraPix UI calls this with the token it received via the
+  // `aurapix:session` postMessage. We verify the JWT, enforce tenant
+  // binding (token tenant must match the iframe's tenant context), and
+  // record the jti to defeat replay. On success we return the user/role
+  // claims; an enclosing session-issue middleware (Firebase custom token
+  // or session cookie) is wired by `server.ts` so AuraPix can establish
+  // a real session without showing the Firebase login UI.
+  //
+  // Auth: NONE on the request itself — the token IS the credential. Cross
+  // tenant relay is rejected at exchange time because `expectedTenantId`
+  // comes from the URL path, not the token.
+  router.post('/:tenantId/embed/session-exchange', async (req, res, next) => {
+    try {
+      const tenantId = req.params.tenantId;
+      if (!isValidTenantId(tenantId)) {
+        sendError(res, 400, 'INVALID_TENANT_ID', 'tenantId must match [a-zA-Z0-9_-]{1,64}');
+        return;
+      }
+
+      const parsed = EmbedSessionExchangeSchema.safeParse(req.body);
+      if (!parsed.success) {
+        sendError(res, 400, 'INVALID_BODY', 'Invalid embed session exchange payload', {
+          issues: parsed.error.issues,
+        });
+        return;
+      }
+
+      const verification = await verifyAndRedeemEmbedSessionToken(
+        dataAdapter,
+        parsed.data.token,
+        { expectedTenantId: tenantId }
+      );
+
+      if (!verification.ok) {
+        switch (verification.code) {
+          case 'tenant_mismatch':
+            sendError(res, 403, 'tenant_mismatch', verification.message);
+            return;
+          case 'token_expired':
+            sendError(res, 401, 'token_expired', verification.message);
+            return;
+          case 'token_replayed':
+            sendError(res, 401, 'token_replayed', verification.message);
+            return;
+          case 'user_not_member':
+            sendError(res, 409, 'user_not_member', verification.message);
+            return;
+          case 'invalid_token':
+          default:
+            sendError(res, 401, 'invalid_token', verification.message);
+            return;
+        }
+      }
+
+      const { claims } = verification;
+
+      // Optional invoker hook lets `server.ts` swap in a real session
+      // issuer (Firebase custom token, session cookie, etc.) without this
+      // route having to know about Firebase Admin.
+      let sessionIssued: Record<string, unknown> | null = null;
+      if (options.issueEmbedSession) {
+        try {
+          sessionIssued = await options.issueEmbedSession({
+            tenantId: claims.iss,
+            userId: claims.sub,
+            role: claims.role,
+          });
+        } catch (err) {
+          logger.warn(
+            { err, tenantId },
+            'Failed to issue embed session after token exchange'
+          );
+          sendError(res, 500, 'INTERNAL', 'Unable to establish embed session');
+          return;
+        }
+      }
+
+      const meteringBus = req.app.locals.meteringBus as
+        | { emit?: (e: unknown) => void }
+        | undefined;
+      try {
+        meteringBus?.emit?.({
+          tenantId,
+          type: 'embed.session.exchanged',
+          meta: {
+            userId: claims.sub,
+            role: claims.role,
+            jtiHash: hashJtiForMetering(claims.jti),
+            matchedSecret: verification.matchedSecret,
+          },
+        });
+      } catch (err) {
+        logger.debug({ err, tenantId }, 'Failed to emit embed.session.exchanged');
+      }
+
+      res.status(200).json({
+        tenantId: claims.iss,
+        userId: claims.sub,
+        role: claims.role,
+        expiresAt: new Date(claims.exp * 1000).toISOString(),
+        session: sessionIssued,
+      });
+    } catch (error) {
       next(error);
     }
   });

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -529,6 +529,16 @@ app.use(
   embedRouter
 );
 
+// Also mount under `/v1/tenants` for the documented OpenAPI URL
+// (embed session tokens / session-exchange — issue #195). The two
+// mounts share the same router instance so the wiring stays in lockstep.
+app.use(
+  '/v1/tenants',
+  hostApiKeyAuth,
+  optionalAuthMiddleware,
+  embedRouter
+);
+
 app.use(
   '/api/v1/tenants',
   hostApiKeyAuth,

--- a/functions/src/services/host/embedSessionTokenService.ts
+++ b/functions/src/services/host/embedSessionTokenService.ts
@@ -1,0 +1,453 @@
+/**
+ * Embed session token service — issue #195.
+ *
+ * Hosts mint short-lived signed tokens for already-authenticated end users
+ * and pass them to the embedded AuraPix iframe so the user lands inside
+ * AuraPix with the right tenant + role without seeing a Firebase login UI.
+ *
+ * Token format
+ * ------------
+ * A compact JWT-like envelope:
+ *
+ *   base64url(header).base64url(payload).base64url(hmac_sha256(header.payload, secret))
+ *
+ * `header` is the JSON `{"alg":"HS256","typ":"JWT"}`.
+ *
+ * `payload` is the JSON
+ *   {
+ *     "iss": tenantId,         // issuer = tenantId
+ *     "aud": "aurapix:embed",  // audience constant
+ *     "sub": userId,           // subject = end-user id
+ *     "role": "owner|editor|viewer",
+ *     "jti": randomUUID,       // unique id for replay defense
+ *     "iat": <unix seconds>,   // issued at
+ *     "exp": <unix seconds>    // expiry, capped at 300s
+ *   }
+ *
+ * Signing key
+ * -----------
+ * Tokens are signed with the tenant's existing webhook signing secret (see
+ * `tenantWebhookSecretService.ts`, issue #161). Rotation behaviour inherits
+ * #161's dual-secret grace window: tokens minted with the previous secret
+ * remain valid for verification until the grace window expires.
+ *
+ * Replay protection
+ * -----------------
+ * Each successful redemption records the token's `jti` in the
+ * `embedSessionTokenJtis` collection. A second redemption returns
+ * `token_replayed`.
+ *
+ * Dependency surface kept deliberately small: only Node `crypto` is used so
+ * we avoid adding a new runtime dependency for a feature whose JWT shape is
+ * effectively bespoke (HS256, fixed claims).
+ */
+
+import { createHash, createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+import {
+  resolveActiveSigningSecrets,
+  type ActiveSigningSecret,
+} from './tenantWebhookSecretService.js';
+import {
+  isTenantMemberRole,
+  type TenantMemberRole,
+} from '../../models/TenantMember.js';
+import { getMembership } from '../tenant/tenantMembershipService.js';
+import { logger } from '../../utils/logger.js';
+
+/** Fixed audience claim. */
+export const EMBED_SESSION_TOKEN_AUDIENCE = 'aurapix:embed';
+
+/** Maximum TTL the host can request (5 minutes). */
+export const EMBED_SESSION_TOKEN_MAX_TTL_SECONDS = 300;
+
+/** Default TTL when the host does not specify one. */
+export const EMBED_SESSION_TOKEN_DEFAULT_TTL_SECONDS = 120;
+
+/**
+ * Replay tracking collection. Records the `jti` of every redeemed token
+ * along with the timestamp it expires (so periodic cleanup can drop entries
+ * that no longer carry replay risk).
+ */
+export const EMBED_SESSION_TOKEN_JTI_COLLECTION = 'embedSessionTokenJtis';
+
+export interface EmbedSessionTokenJtiRecord {
+  jti: string;
+  tenantId: string;
+  userId: string;
+  redeemedAt: string;
+  /** ISO timestamp the original token would have expired. */
+  expiresAt: string;
+}
+
+export interface EmbedSessionTokenClaims {
+  iss: string;
+  aud: string;
+  sub: string;
+  role: TenantMemberRole;
+  jti: string;
+  iat: number;
+  exp: number;
+}
+
+export interface MintEmbedSessionTokenInput {
+  tenantId: string;
+  userId: string;
+  role?: TenantMemberRole;
+  ttlSeconds?: number;
+}
+
+export interface MintEmbedSessionTokenResult {
+  token: string;
+  expiresAt: string;
+  jti: string;
+  role: TenantMemberRole;
+}
+
+export type MintEmbedSessionTokenError =
+  | { code: 'invalid_input'; message: string }
+  | { code: 'user_not_member'; message: string }
+  | { code: 'no_signing_secret'; message: string };
+
+/** Base64url encoding (no padding). */
+function base64url(input: Buffer | string): string {
+  const buf = typeof input === 'string' ? Buffer.from(input, 'utf8') : input;
+  return buf
+    .toString('base64')
+    .replace(/=+$/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function base64urlDecode(input: string): Buffer {
+  // Restore padding so Buffer.from('base64') parses it correctly.
+  const padded = input + '='.repeat((4 - (input.length % 4)) % 4);
+  return Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+}
+
+function signSegment(segment: string, secret: string): string {
+  return base64url(createHmac('sha256', secret).update(segment).digest());
+}
+
+function clampTtl(ttl: number | undefined): number {
+  if (ttl === undefined || ttl === null) return EMBED_SESSION_TOKEN_DEFAULT_TTL_SECONDS;
+  if (!Number.isFinite(ttl) || ttl <= 0) return EMBED_SESSION_TOKEN_DEFAULT_TTL_SECONDS;
+  return Math.min(Math.floor(ttl), EMBED_SESSION_TOKEN_MAX_TTL_SECONDS);
+}
+
+function buildToken(
+  claims: EmbedSessionTokenClaims,
+  signingSecret: string
+): string {
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify(claims));
+  const signingInput = `${header}.${payload}`;
+  const signature = signSegment(signingInput, signingSecret);
+  return `${signingInput}.${signature}`;
+}
+
+export interface MintEmbedSessionTokenOptions {
+  /** Test hook for time. */
+  now?: () => Date;
+  /** Test hook for jti generation. */
+  generateJti?: () => string;
+}
+
+/**
+ * Mint a fresh embed session token for `(tenantId, userId)`.
+ *
+ * Rejects when the user is not an active member of the tenant — hosts are
+ * expected to provision membership via the tenant-users API (#143) first.
+ * Auto-provisioning is intentionally out of scope per the issue.
+ */
+export async function mintEmbedSessionToken(
+  dataAdapter: DataAdapter,
+  input: MintEmbedSessionTokenInput,
+  options: MintEmbedSessionTokenOptions = {}
+): Promise<MintEmbedSessionTokenResult | MintEmbedSessionTokenError> {
+  const tenantId = (input.tenantId ?? '').toString();
+  const userId = (input.userId ?? '').toString();
+  if (!tenantId || !userId) {
+    return { code: 'invalid_input', message: 'tenantId and userId are required' };
+  }
+  if (input.role !== undefined && input.role !== null && !isTenantMemberRole(input.role)) {
+    return { code: 'invalid_input', message: 'role must be owner | editor | viewer when provided' };
+  }
+
+  const membership = await getMembership(dataAdapter, tenantId, userId);
+  if (!membership) {
+    return {
+      code: 'user_not_member',
+      message: 'User is not a member of the tenant — provision via the tenant-users API first.',
+    };
+  }
+
+  const secrets = await resolveActiveSigningSecrets(dataAdapter, tenantId, {
+    now: options.now,
+  });
+  if (!secrets) {
+    return {
+      code: 'no_signing_secret',
+      message:
+        'Tenant has no webhook signing secret — rotate one via /v1/tenants/{tenantId}/webhook-secret first.',
+    };
+  }
+
+  const now = (options.now ?? (() => new Date()))();
+  const ttlSeconds = clampTtl(input.ttlSeconds);
+  const iat = Math.floor(now.getTime() / 1000);
+  const exp = iat + ttlSeconds;
+  const jti = (options.generateJti ?? randomUUID)();
+  const role: TenantMemberRole = input.role ?? membership.role;
+
+  const claims: EmbedSessionTokenClaims = {
+    iss: tenantId,
+    aud: EMBED_SESSION_TOKEN_AUDIENCE,
+    sub: userId,
+    role,
+    jti,
+    iat,
+    exp,
+  };
+
+  const token = buildToken(claims, secrets.current.secret);
+  const expiresAt = new Date(exp * 1000).toISOString();
+  return { token, expiresAt, jti, role };
+}
+
+export interface VerifyEmbedSessionTokenOptions {
+  /** Expected tenant id — the iframe's tenant context. */
+  expectedTenantId: string;
+  /** Test hook for time. */
+  now?: () => Date;
+  /** Maximum clock skew tolerated, in seconds. Defaults to 30s. */
+  clockSkewSeconds?: number;
+}
+
+export type VerifyEmbedSessionTokenError =
+  | { code: 'invalid_token'; message: string }
+  | { code: 'token_expired'; message: string }
+  | { code: 'tenant_mismatch'; message: string }
+  | { code: 'token_replayed'; message: string }
+  | { code: 'user_not_member'; message: string };
+
+export interface VerifyEmbedSessionTokenSuccess {
+  ok: true;
+  claims: EmbedSessionTokenClaims;
+  /** Which secret matched (current vs previous) — useful for observability. */
+  matchedSecret: 'current' | 'previous';
+}
+
+export type VerifyEmbedSessionTokenResult =
+  | VerifyEmbedSessionTokenSuccess
+  | ({ ok: false } & VerifyEmbedSessionTokenError);
+
+function safeEqualHexlike(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  } catch {
+    return false;
+  }
+}
+
+function parseTokenSegments(
+  token: string
+): { header: string; payload: string; signature: string } | null {
+  if (typeof token !== 'string' || token.length === 0 || token.length > 4096) return null;
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const [header, payload, signature] = parts;
+  if (!header || !payload || !signature) return null;
+  return { header, payload, signature };
+}
+
+function decodeHeader(segment: string): { alg?: string; typ?: string } | null {
+  try {
+    const obj = JSON.parse(base64urlDecode(segment).toString('utf8'));
+    if (typeof obj !== 'object' || obj === null) return null;
+    return obj as { alg?: string; typ?: string };
+  } catch {
+    return null;
+  }
+}
+
+function decodePayload(segment: string): EmbedSessionTokenClaims | null {
+  try {
+    const obj = JSON.parse(base64urlDecode(segment).toString('utf8')) as Record<string, unknown>;
+    if (typeof obj !== 'object' || obj === null) return null;
+    const { iss, aud, sub, role, jti, iat, exp } = obj as Record<string, unknown>;
+    if (
+      typeof iss !== 'string' ||
+      typeof aud !== 'string' ||
+      typeof sub !== 'string' ||
+      typeof role !== 'string' ||
+      !isTenantMemberRole(role) ||
+      typeof jti !== 'string' ||
+      typeof iat !== 'number' ||
+      typeof exp !== 'number' ||
+      !Number.isFinite(iat) ||
+      !Number.isFinite(exp)
+    ) {
+      return null;
+    }
+    return { iss, aud, sub, role, jti, iat: Math.floor(iat), exp: Math.floor(exp) };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify an embed session token: decode, check signature against any active
+ * signing secret (current + grace-window previous), enforce audience,
+ * tenant binding, expiry, then record + check `jti` for replay.
+ *
+ * Returns a discriminated result so callers can map cleanly to HTTP errors.
+ */
+export async function verifyAndRedeemEmbedSessionToken(
+  dataAdapter: DataAdapter,
+  token: string,
+  options: VerifyEmbedSessionTokenOptions
+): Promise<VerifyEmbedSessionTokenResult> {
+  const parts = parseTokenSegments(token);
+  if (!parts) {
+    return { ok: false, code: 'invalid_token', message: 'Token is malformed' };
+  }
+
+  const header = decodeHeader(parts.header);
+  if (!header || header.alg !== 'HS256' || (header.typ && header.typ !== 'JWT')) {
+    return { ok: false, code: 'invalid_token', message: 'Token header is invalid' };
+  }
+
+  const claims = decodePayload(parts.payload);
+  if (!claims) {
+    return { ok: false, code: 'invalid_token', message: 'Token payload is invalid' };
+  }
+
+  if (claims.aud !== EMBED_SESSION_TOKEN_AUDIENCE) {
+    return { ok: false, code: 'invalid_token', message: 'Audience mismatch' };
+  }
+
+  // Tenant binding — the iframe's tenant context MUST match the token's
+  // issuer. Mismatch is rejected at exchange time so cross-tenant tokens
+  // can't be relayed into another tenant's embed.
+  if (claims.iss !== options.expectedTenantId) {
+    return {
+      ok: false,
+      code: 'tenant_mismatch',
+      message: 'Token tenant does not match iframe tenant',
+    };
+  }
+
+  const skew = Math.max(0, Math.floor(options.clockSkewSeconds ?? 30));
+  const now = options.now ? options.now() : new Date();
+  const nowSec = Math.floor(now.getTime() / 1000);
+  if (claims.exp + skew <= nowSec) {
+    return { ok: false, code: 'token_expired', message: 'Token has expired' };
+  }
+  if (claims.iat > nowSec + skew) {
+    return { ok: false, code: 'invalid_token', message: 'Token issued-at is in the future' };
+  }
+
+  // Validate signature against current + (optional) previous secret.
+  const secrets = await resolveActiveSigningSecrets(dataAdapter, claims.iss, {
+    now: options.now,
+  });
+  if (!secrets) {
+    return { ok: false, code: 'invalid_token', message: 'Token signature is invalid' };
+  }
+
+  const signingInput = `${parts.header}.${parts.payload}`;
+  const expectedCurrent = signSegment(signingInput, secrets.current.secret);
+  let matchedSecret: 'current' | 'previous' | null = null;
+  if (safeEqualHexlike(expectedCurrent, parts.signature)) {
+    matchedSecret = 'current';
+  } else if (secrets.previous) {
+    const expectedPrevious = signSegment(signingInput, secrets.previous.secret);
+    if (safeEqualHexlike(expectedPrevious, parts.signature)) {
+      matchedSecret = 'previous';
+    }
+  }
+  if (!matchedSecret) {
+    return { ok: false, code: 'invalid_token', message: 'Token signature is invalid' };
+  }
+
+  // Reconfirm membership at exchange time so revoked users can't keep
+  // redeeming valid-looking tokens. Tokens are short-lived (max 5 minutes)
+  // so the membership lookup is bounded.
+  const membership = await getMembership(dataAdapter, claims.iss, claims.sub);
+  if (!membership) {
+    return {
+      ok: false,
+      code: 'user_not_member',
+      message: 'User is no longer a member of the tenant.',
+    };
+  }
+
+  // Replay defense — `jti` is one-time use within its TTL window. Record
+  // BEFORE handing the session out so two near-simultaneous redemptions of
+  // the same token race deterministically through the data adapter (first
+  // write wins; second redemption sees the existing record).
+  const jtiDocId = `${claims.iss}__${claims.jti}`;
+  try {
+    const existing = await dataAdapter.fetchData<EmbedSessionTokenJtiRecord>(
+      EMBED_SESSION_TOKEN_JTI_COLLECTION,
+      jtiDocId
+    );
+    if (existing) {
+      return { ok: false, code: 'token_replayed', message: 'Token has already been redeemed' };
+    }
+    const record: EmbedSessionTokenJtiRecord = {
+      jti: claims.jti,
+      tenantId: claims.iss,
+      userId: claims.sub,
+      redeemedAt: now.toISOString(),
+      expiresAt: new Date(claims.exp * 1000).toISOString(),
+    };
+    await dataAdapter.storeData<EmbedSessionTokenJtiRecord>(
+      EMBED_SESSION_TOKEN_JTI_COLLECTION,
+      jtiDocId,
+      record
+    );
+  } catch (err) {
+    // If the JTI store is unreachable we fail closed — better to reject a
+    // valid token than allow a replay.
+    logger.warn({ err, tenantId: claims.iss }, 'embed session token jti store unavailable');
+    return { ok: false, code: 'invalid_token', message: 'Token replay check unavailable' };
+  }
+
+  return { ok: true, claims, matchedSecret };
+}
+
+/**
+ * Compute a stable, non-reversible hash of a JTI for metering events.
+ * Returns the first 16 hex chars of SHA-256(jti) — short enough to log,
+ * impossible to invert back to the original UUID.
+ *
+ * Lives here (rather than the route layer) so the metering payload shape
+ * stays consistent across mint + exchange call sites.
+ */
+export function hashJtiForMetering(jti: string): string {
+  return createHash('sha256').update(jti, 'utf8').digest('hex').slice(0, 16);
+}
+
+/**
+ * Helper exported for tests — re-exposes the internal token assembly so
+ * unit tests can synthesize tokens with known fields without re-deriving
+ * the base64url + HMAC logic.
+ *
+ * NOT for use by routes; mint/verify above are the public API.
+ */
+export function _internalBuildTokenForTests(
+  claims: EmbedSessionTokenClaims,
+  signingSecret: string
+): string {
+  return buildToken(claims, signingSecret);
+}
+
+/**
+ * Best-effort export to satisfy tree-shakers — re-export the configured
+ * signing-secret shape so callers can build mock signing flows in tests
+ * without reaching into the host webhook service.
+ */
+export type EmbedSessionTokenSigningSecret = ActiveSigningSecret;

--- a/functions/src/services/metering/eventCatalog.ts
+++ b/functions/src/services/metering/eventCatalog.ts
@@ -45,7 +45,7 @@
  *
  * Use a date string so the value is human-readable in logs.
  */
-export const CATALOG_VERSION = '2026-06-20';
+export const CATALOG_VERSION = '2026-06-29';
 
 /**
  * JSON Schema describing the `meta` payload for a single event type.
@@ -408,6 +408,32 @@ export const EVENT_CATALOG = [
       blockedUri: S_STRING,
       documentUri: S_STRING,
       violatedDirective: S_STRING,
+    }),
+  },
+  {
+    name: 'embed.session.minted',
+    version: 1,
+    billable: false,
+    description:
+      'Host minted an embed session token via POST /v1/tenants/{tenantId}/embed/session-tokens (issue #195). Useful for billing per-session pricing models.',
+    schema: metaSchema({
+      userId: S_STRING,
+      role: S_STRING,
+      jtiHash: S_STRING,
+      ttlSeconds: S_INTEGER,
+    }),
+  },
+  {
+    name: 'embed.session.exchanged',
+    version: 1,
+    billable: false,
+    description:
+      'Embedded iframe successfully redeemed an embed session token — the meaningful "active embedded user" signal that complements `user.active` with embed context (issue #195).',
+    schema: metaSchema({
+      userId: S_STRING,
+      role: S_STRING,
+      jtiHash: S_STRING,
+      matchedSecret: { type: 'string', enum: ['current', 'previous'] },
     }),
   },
   {

--- a/functions/test/routes/embedV1.sessionTokens.test.ts
+++ b/functions/test/routes/embedV1.sessionTokens.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for the host-issued embed session token routes (issue #195):
+ * - POST /v1/tenants/:tenantId/embed/session-tokens (mint)
+ * - POST /v1/tenants/:tenantId/embed/session-exchange (redeem)
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import { createEmbedV1Router } from '../../src/routes/embedV1.js';
+import type { DataAdapter } from '../../src/adapters/data/DataAdapter.js';
+import {
+  TENANT_MEMBERS_COLLECTION,
+  tenantMemberDocId,
+  type TenantMemberRecord,
+} from '../../src/models/TenantMember.js';
+
+interface TestAdapter extends DataAdapter {
+  _store: Record<string, Record<string, unknown>>;
+}
+
+function makeAdapter(): TestAdapter {
+  const store: Record<string, Record<string, unknown>> = {};
+  const bucket = (c: string): Record<string, unknown> => {
+    if (!store[c]) store[c] = {};
+    return store[c];
+  };
+  return {
+    _store: store,
+    async storeData(collection, id, data) {
+      bucket(collection)[id] = data as never;
+    },
+    async fetchData(collection, id) {
+      return (bucket(collection)[id] as never) ?? null;
+    },
+    async queryData() {
+      return [];
+    },
+    async updateData() {},
+    async deleteData(collection, id) {
+      delete bucket(collection)[id];
+    },
+    async exists(collection, id) {
+      return id in bucket(collection);
+    },
+    async listIds() {
+      return [];
+    },
+    async getPhoto() {
+      return null;
+    },
+  } as unknown as TestAdapter;
+}
+
+function seedMembership(
+  adapter: TestAdapter,
+  tenantId: string,
+  userId: string,
+  role: TenantMemberRecord['role'] = 'editor'
+): void {
+  const record: TenantMemberRecord = {
+    userId,
+    tenantId,
+    email: `${userId}@example.com`,
+    role,
+    createdAt: new Date('2026-01-01').toISOString(),
+    lastActiveAt: null,
+    revokedAt: null,
+  };
+  adapter._store[TENANT_MEMBERS_COLLECTION] ??= {};
+  adapter._store[TENANT_MEMBERS_COLLECTION][tenantMemberDocId(tenantId, userId)] =
+    record as never;
+}
+
+function seedSigningSecret(
+  adapter: TestAdapter,
+  tenantId: string,
+  secret = 'whsec_route_test'
+): void {
+  adapter._store['tenantWebhookSecrets'] ??= {};
+  adapter._store['tenantWebhookSecrets'][tenantId] = {
+    tenantId,
+    current: {
+      secret,
+      fingerprint: 'fp',
+      createdAt: new Date().toISOString(),
+    },
+    rotatedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } as never;
+}
+
+async function request(
+  app: express.Express,
+  method: 'GET' | 'POST',
+  path: string,
+  body?: unknown
+): Promise<{ status: number; body: any }> {
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const port = (server.address() as any).port;
+      const init: RequestInit = {
+        method,
+        headers: { 'content-type': 'application/json' },
+      };
+      if (body !== undefined) init.body = JSON.stringify(body);
+      fetch(`http://127.0.0.1:${port}${path}`, init)
+        .then(async (res) => {
+          const text = await res.text();
+          let parsed: any = null;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          server.close();
+          resolve({ status: res.status, body: parsed });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+function makeApp(
+  adapter: DataAdapter,
+  opts: Parameters<typeof createEmbedV1Router>[1] = {},
+  emit?: (e: unknown) => void
+): express.Express {
+  const app = express();
+  app.use(express.json());
+  if (emit) {
+    app.use((req, _res, next) => {
+      (req.app.locals as any).meteringBus = { emit };
+      next();
+    });
+  }
+  app.use('/v1/tenants', createEmbedV1Router(adapter, opts));
+  return app;
+}
+
+describe('POST /v1/tenants/:tenantId/embed/session-tokens', () => {
+  let adapter: TestAdapter;
+  beforeEach(() => {
+    adapter = makeAdapter();
+  });
+
+  it('mints a token for a valid membership and emits embed.session.minted', async () => {
+    seedMembership(adapter, 'acme', 'u_42', 'editor');
+    seedSigningSecret(adapter, 'acme');
+    const emit = vi.fn();
+    const app = makeApp(adapter, { canWriteEmbedConfig: () => true }, emit);
+
+    const res = await request(app, 'POST', '/v1/tenants/acme/embed/session-tokens', {
+      userId: 'u_42',
+      ttlSeconds: 60,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.audience).toBe('aurapix:embed');
+    expect(typeof res.body.token).toBe('string');
+    expect(res.body.token.split('.')).toHaveLength(3);
+    expect(typeof res.body.expiresAt).toBe('string');
+
+    const minted = emit.mock.calls.find(
+      ([e]) => (e as any).type === 'embed.session.minted'
+    );
+    expect(minted).toBeDefined();
+    expect((minted![0] as any).tenantId).toBe('acme');
+    expect((minted![0] as any).meta.userId).toBe('u_42');
+    expect((minted![0] as any).meta.role).toBe('editor');
+    expect(typeof (minted![0] as any).meta.jtiHash).toBe('string');
+  });
+
+  it('rejects with 409 user_not_member when the user is not provisioned', async () => {
+    seedSigningSecret(adapter, 'acme');
+    const app = makeApp(adapter, { canWriteEmbedConfig: () => true });
+    const res = await request(app, 'POST', '/v1/tenants/acme/embed/session-tokens', {
+      userId: 'u_ghost',
+    });
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('user_not_member');
+  });
+
+  it('rejects with 403 when the auth gate denies', async () => {
+    seedMembership(adapter, 'acme', 'u_42');
+    seedSigningSecret(adapter, 'acme');
+    const app = makeApp(adapter, { canWriteEmbedConfig: () => false });
+    const res = await request(app, 'POST', '/v1/tenants/acme/embed/session-tokens', {
+      userId: 'u_42',
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects with 400 on an invalid tenantId', async () => {
+    const app = makeApp(adapter, { canWriteEmbedConfig: () => true });
+    const res = await request(
+      app,
+      'POST',
+      '/v1/tenants/has spaces/embed/session-tokens',
+      { userId: 'u_42' }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects with 400 on missing userId', async () => {
+    seedMembership(adapter, 'acme', 'u_42');
+    seedSigningSecret(adapter, 'acme');
+    const app = makeApp(adapter, { canWriteEmbedConfig: () => true });
+    const res = await request(app, 'POST', '/v1/tenants/acme/embed/session-tokens', {});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_BODY');
+  });
+
+  it('rejects with 400 on invalid role', async () => {
+    seedMembership(adapter, 'acme', 'u_42');
+    seedSigningSecret(adapter, 'acme');
+    const app = makeApp(adapter, { canWriteEmbedConfig: () => true });
+    const res = await request(app, 'POST', '/v1/tenants/acme/embed/session-tokens', {
+      userId: 'u_42',
+      role: 'super-admin',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects with 400 on ttlSeconds above the cap', async () => {
+    seedMembership(adapter, 'acme', 'u_42');
+    seedSigningSecret(adapter, 'acme');
+    const app = makeApp(adapter, { canWriteEmbedConfig: () => true });
+    const res = await request(app, 'POST', '/v1/tenants/acme/embed/session-tokens', {
+      userId: 'u_42',
+      ttlSeconds: 999,
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /v1/tenants/:tenantId/embed/session-exchange', () => {
+  let adapter: TestAdapter;
+  beforeEach(() => {
+    adapter = makeAdapter();
+  });
+
+  async function mint(tenantId = 'acme', userId = 'u_42'): Promise<string> {
+    seedMembership(adapter, tenantId, userId, 'editor');
+    seedSigningSecret(adapter, tenantId);
+    const app = makeApp(adapter, { canWriteEmbedConfig: () => true });
+    const r = await request(app, 'POST', `/v1/tenants/${tenantId}/embed/session-tokens`, {
+      userId,
+    });
+    expect(r.status).toBe(201);
+    return r.body.token;
+  }
+
+  it('exchanges a valid token and emits embed.session.exchanged', async () => {
+    const token = await mint();
+    const emit = vi.fn();
+    const app = makeApp(adapter, {}, emit);
+
+    const res = await request(app, 'POST', '/v1/tenants/acme/embed/session-exchange', {
+      token,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.tenantId).toBe('acme');
+    expect(res.body.userId).toBe('u_42');
+    expect(res.body.role).toBe('editor');
+
+    const exchanged = emit.mock.calls.find(
+      ([e]) => (e as any).type === 'embed.session.exchanged'
+    );
+    expect(exchanged).toBeDefined();
+    expect((exchanged![0] as any).meta.userId).toBe('u_42');
+  });
+
+  it('rejects a replayed token with 401 token_replayed', async () => {
+    const token = await mint();
+    const app = makeApp(adapter);
+    const first = await request(app, 'POST', '/v1/tenants/acme/embed/session-exchange', {
+      token,
+    });
+    expect(first.status).toBe(200);
+    const second = await request(app, 'POST', '/v1/tenants/acme/embed/session-exchange', {
+      token,
+    });
+    expect(second.status).toBe(401);
+    expect(second.body.error.code).toBe('token_replayed');
+  });
+
+  it('rejects a cross-tenant token with 403 tenant_mismatch', async () => {
+    const token = await mint('acme', 'u_42');
+    // Set up another tenant context with a different signing secret.
+    seedMembership(adapter, 'other', 'u_42', 'editor');
+    seedSigningSecret(adapter, 'other', 'whsec_other');
+    const app = makeApp(adapter);
+    const res = await request(app, 'POST', '/v1/tenants/other/embed/session-exchange', {
+      token,
+    });
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('tenant_mismatch');
+  });
+
+  it('rejects a garbage token with 401 invalid_token', async () => {
+    seedSigningSecret(adapter, 'acme');
+    const app = makeApp(adapter);
+    const res = await request(app, 'POST', '/v1/tenants/acme/embed/session-exchange', {
+      token: 'not.a.realtoken',
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('invalid_token');
+  });
+
+  it('rejects a missing body with 400', async () => {
+    const app = makeApp(adapter);
+    const res = await request(app, 'POST', '/v1/tenants/acme/embed/session-exchange', {});
+    expect(res.status).toBe(400);
+  });
+
+  it('invokes issueEmbedSession and echoes its payload', async () => {
+    const token = await mint();
+    const issueEmbedSession = vi.fn(async (input: any) => ({
+      firebaseCustomToken: `ct_${input.userId}`,
+    }));
+    const app = makeApp(adapter, { issueEmbedSession });
+    const res = await request(app, 'POST', '/v1/tenants/acme/embed/session-exchange', {
+      token,
+    });
+    expect(res.status).toBe(200);
+    expect(issueEmbedSession).toHaveBeenCalledWith({
+      tenantId: 'acme',
+      userId: 'u_42',
+      role: 'editor',
+    });
+    expect(res.body.session).toEqual({ firebaseCustomToken: 'ct_u_42' });
+  });
+});

--- a/functions/test/services/host/embedSessionTokenService.test.ts
+++ b/functions/test/services/host/embedSessionTokenService.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  mintEmbedSessionToken,
+  verifyAndRedeemEmbedSessionToken,
+  hashJtiForMetering,
+  _internalBuildTokenForTests,
+  EMBED_SESSION_TOKEN_AUDIENCE,
+  EMBED_SESSION_TOKEN_DEFAULT_TTL_SECONDS,
+  EMBED_SESSION_TOKEN_MAX_TTL_SECONDS,
+  EMBED_SESSION_TOKEN_JTI_COLLECTION,
+  type EmbedSessionTokenClaims,
+  type EmbedSessionTokenJtiRecord,
+} from '../../../src/services/host/embedSessionTokenService.js';
+import type { DataAdapter } from '../../../src/adapters/data/DataAdapter.js';
+import {
+  TENANT_MEMBERS_COLLECTION,
+  tenantMemberDocId,
+  type TenantMemberRecord,
+} from '../../../src/models/TenantMember.js';
+
+interface TestAdapter extends DataAdapter {
+  _store: Record<string, Record<string, unknown>>;
+}
+
+function makeAdapter(): TestAdapter {
+  const store: Record<string, Record<string, unknown>> = {};
+  const get = (c: string): Record<string, unknown> => {
+    if (!store[c]) store[c] = {};
+    return store[c];
+  };
+  return {
+    _store: store,
+    async storeData(collection, id, data) {
+      get(collection)[id] = data as never;
+    },
+    async fetchData(collection, id) {
+      return (get(collection)[id] as never) ?? null;
+    },
+    async queryData() {
+      return [];
+    },
+    async updateData() {},
+    async deleteData(collection, id) {
+      delete get(collection)[id];
+    },
+    async exists(collection, id) {
+      return id in get(collection);
+    },
+    async listIds() {
+      return [];
+    },
+    async getPhoto() {
+      return null;
+    },
+  } as unknown as TestAdapter;
+}
+
+function seedMembership(
+  adapter: TestAdapter,
+  tenantId: string,
+  userId: string,
+  role: TenantMemberRecord['role'] = 'editor'
+): void {
+  const record: TenantMemberRecord = {
+    userId,
+    tenantId,
+    email: `${userId}@example.com`,
+    role,
+    createdAt: new Date('2026-01-01').toISOString(),
+    lastActiveAt: null,
+    revokedAt: null,
+  };
+  adapter._store[TENANT_MEMBERS_COLLECTION] ??= {};
+  adapter._store[TENANT_MEMBERS_COLLECTION][tenantMemberDocId(tenantId, userId)] =
+    record as never;
+}
+
+function seedSigningSecret(
+  adapter: TestAdapter,
+  tenantId: string,
+  secret = 'whsec_test_current'
+): void {
+  adapter._store['tenantWebhookSecrets'] ??= {};
+  adapter._store['tenantWebhookSecrets'][tenantId] = {
+    tenantId,
+    current: {
+      secret,
+      fingerprint: 'fp_current',
+      createdAt: new Date('2026-01-01').toISOString(),
+    },
+    rotatedAt: new Date('2026-01-01').toISOString(),
+    updatedAt: new Date('2026-01-01').toISOString(),
+  } as never;
+}
+
+function seedRotatedSecret(
+  adapter: TestAdapter,
+  tenantId: string,
+  currentSecret: string,
+  previousSecret: string,
+  graceMs: number
+): void {
+  adapter._store['tenantWebhookSecrets'] ??= {};
+  adapter._store['tenantWebhookSecrets'][tenantId] = {
+    tenantId,
+    current: {
+      secret: currentSecret,
+      fingerprint: 'fp_new',
+      createdAt: new Date().toISOString(),
+    },
+    previous: {
+      secret: previousSecret,
+      fingerprint: 'fp_old',
+      createdAt: new Date(Date.now() - graceMs).toISOString(),
+    },
+    previousExpiresAt: new Date(Date.now() + graceMs).toISOString(),
+    rotatedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } as never;
+}
+
+describe('embedSessionTokenService — constants', () => {
+  it('matches the documented audience and TTL caps', () => {
+    expect(EMBED_SESSION_TOKEN_AUDIENCE).toBe('aurapix:embed');
+    expect(EMBED_SESSION_TOKEN_MAX_TTL_SECONDS).toBe(300);
+    expect(EMBED_SESSION_TOKEN_DEFAULT_TTL_SECONDS).toBe(120);
+  });
+});
+
+describe('mintEmbedSessionToken', () => {
+  let adapter: TestAdapter;
+  beforeEach(() => {
+    adapter = makeAdapter();
+  });
+
+  it('mints a 3-segment JWT with required claims', async () => {
+    seedMembership(adapter, 'acme', 'u_1', 'editor');
+    seedSigningSecret(adapter, 'acme');
+
+    const result = await mintEmbedSessionToken(adapter, {
+      tenantId: 'acme',
+      userId: 'u_1',
+    });
+    if ('code' in result) throw new Error(`expected success: ${result.code}`);
+
+    expect(result.role).toBe('editor');
+    expect(result.token.split('.')).toHaveLength(3);
+    expect(typeof result.jti).toBe('string');
+    expect(result.expiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    // Decode payload and confirm shape.
+    const [, payload] = result.token.split('.');
+    const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
+    const claims = JSON.parse(
+      Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString(
+        'utf8'
+      )
+    );
+    expect(claims.iss).toBe('acme');
+    expect(claims.aud).toBe('aurapix:embed');
+    expect(claims.sub).toBe('u_1');
+    expect(claims.role).toBe('editor');
+    expect(typeof claims.jti).toBe('string');
+    expect(claims.exp - claims.iat).toBe(EMBED_SESSION_TOKEN_DEFAULT_TTL_SECONDS);
+  });
+
+  it('rejects when the user is not a tenant member', async () => {
+    // No membership seeded.
+    seedSigningSecret(adapter, 'acme');
+    const result = await mintEmbedSessionToken(adapter, {
+      tenantId: 'acme',
+      userId: 'u_ghost',
+    });
+    expect('code' in result && result.code).toBe('user_not_member');
+  });
+
+  it('rejects when the tenant has no signing secret', async () => {
+    seedMembership(adapter, 'acme', 'u_1', 'editor');
+    const result = await mintEmbedSessionToken(adapter, {
+      tenantId: 'acme',
+      userId: 'u_1',
+    });
+    expect('code' in result && result.code).toBe('no_signing_secret');
+  });
+
+  it('rejects invalid role values', async () => {
+    seedMembership(adapter, 'acme', 'u_1', 'editor');
+    seedSigningSecret(adapter, 'acme');
+    const result = await mintEmbedSessionToken(adapter, {
+      tenantId: 'acme',
+      userId: 'u_1',
+      role: 'super-admin' as never,
+    });
+    expect('code' in result && result.code).toBe('invalid_input');
+  });
+
+  it('clamps ttlSeconds to the 300s cap', async () => {
+    seedMembership(adapter, 'acme', 'u_1');
+    seedSigningSecret(adapter, 'acme');
+    const result = await mintEmbedSessionToken(adapter, {
+      tenantId: 'acme',
+      userId: 'u_1',
+      ttlSeconds: 99_999,
+    });
+    if ('code' in result) throw new Error('expected success');
+    const payload = result.token.split('.')[1];
+    const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
+    const claims = JSON.parse(
+      Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString(
+        'utf8'
+      )
+    );
+    expect(claims.exp - claims.iat).toBe(EMBED_SESSION_TOKEN_MAX_TTL_SECONDS);
+  });
+
+  it('honors an explicit role override', async () => {
+    seedMembership(adapter, 'acme', 'u_1', 'viewer');
+    seedSigningSecret(adapter, 'acme');
+    const result = await mintEmbedSessionToken(adapter, {
+      tenantId: 'acme',
+      userId: 'u_1',
+      role: 'editor',
+    });
+    if ('code' in result) throw new Error('expected success');
+    expect(result.role).toBe('editor');
+  });
+});
+
+describe('verifyAndRedeemEmbedSessionToken', () => {
+  let adapter: TestAdapter;
+  beforeEach(() => {
+    adapter = makeAdapter();
+    seedMembership(adapter, 'acme', 'u_1', 'editor');
+    seedSigningSecret(adapter, 'acme');
+  });
+
+  it('accepts a freshly minted token', async () => {
+    const minted = await mintEmbedSessionToken(adapter, {
+      tenantId: 'acme',
+      userId: 'u_1',
+    });
+    if ('code' in minted) throw new Error('mint failed');
+
+    const verified = await verifyAndRedeemEmbedSessionToken(adapter, minted.token, {
+      expectedTenantId: 'acme',
+    });
+    expect(verified.ok).toBe(true);
+    if (verified.ok) {
+      expect(verified.claims.sub).toBe('u_1');
+      expect(verified.claims.role).toBe('editor');
+      expect(verified.matchedSecret).toBe('current');
+    }
+  });
+
+  it('rejects a second redemption of the same token (replay)', async () => {
+    const minted = await mintEmbedSessionToken(adapter, {
+      tenantId: 'acme',
+      userId: 'u_1',
+    });
+    if ('code' in minted) throw new Error('mint failed');
+
+    const first = await verifyAndRedeemEmbedSessionToken(adapter, minted.token, {
+      expectedTenantId: 'acme',
+    });
+    expect(first.ok).toBe(true);
+    const second = await verifyAndRedeemEmbedSessionToken(adapter, minted.token, {
+      expectedTenantId: 'acme',
+    });
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.code).toBe('token_replayed');
+  });
+
+  it('rejects cross-tenant tokens (iss != expectedTenantId)', async () => {
+    const minted = await mintEmbedSessionToken(adapter, {
+      tenantId: 'acme',
+      userId: 'u_1',
+    });
+    if ('code' in minted) throw new Error('mint failed');
+
+    seedMembership(adapter, 'other', 'u_1', 'editor');
+    seedSigningSecret(adapter, 'other', 'other_secret');
+
+    const verified = await verifyAndRedeemEmbedSessionToken(adapter, minted.token, {
+      expectedTenantId: 'other',
+    });
+    expect(verified.ok).toBe(false);
+    if (!verified.ok) expect(verified.code).toBe('tenant_mismatch');
+  });
+
+  it('rejects an expired token', async () => {
+    const past = new Date('2024-01-01T00:00:00Z');
+    const minted = await mintEmbedSessionToken(
+      adapter,
+      { tenantId: 'acme', userId: 'u_1', ttlSeconds: 30 },
+      { now: () => past }
+    );
+    if ('code' in minted) throw new Error('mint failed');
+
+    const verified = await verifyAndRedeemEmbedSessionToken(adapter, minted.token, {
+      expectedTenantId: 'acme',
+    });
+    expect(verified.ok).toBe(false);
+    if (!verified.ok) expect(verified.code).toBe('token_expired');
+  });
+
+  it('rejects a tampered signature', async () => {
+    const minted = await mintEmbedSessionToken(adapter, {
+      tenantId: 'acme',
+      userId: 'u_1',
+    });
+    if ('code' in minted) throw new Error('mint failed');
+    const [h, p] = minted.token.split('.');
+    const tampered = `${h}.${p}.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`;
+    const verified = await verifyAndRedeemEmbedSessionToken(adapter, tampered, {
+      expectedTenantId: 'acme',
+    });
+    expect(verified.ok).toBe(false);
+    if (!verified.ok) expect(verified.code).toBe('invalid_token');
+  });
+
+  it('rejects a token signed with the wrong secret', async () => {
+    // Hand-craft a token using a different secret.
+    const claims: EmbedSessionTokenClaims = {
+      iss: 'acme',
+      aud: EMBED_SESSION_TOKEN_AUDIENCE,
+      sub: 'u_1',
+      role: 'editor',
+      jti: 'jti-1',
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 60,
+    };
+    const bogus = _internalBuildTokenForTests(claims, 'whsec_not_the_one');
+    const verified = await verifyAndRedeemEmbedSessionToken(adapter, bogus, {
+      expectedTenantId: 'acme',
+    });
+    expect(verified.ok).toBe(false);
+    if (!verified.ok) expect(verified.code).toBe('invalid_token');
+  });
+
+  it('accepts a token signed with the previous secret during the grace window', async () => {
+    seedRotatedSecret(adapter, 'acme', 'whsec_new', 'whsec_old', 60_000);
+
+    const claims: EmbedSessionTokenClaims = {
+      iss: 'acme',
+      aud: EMBED_SESSION_TOKEN_AUDIENCE,
+      sub: 'u_1',
+      role: 'editor',
+      jti: 'jti-rot',
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 60,
+    };
+    const token = _internalBuildTokenForTests(claims, 'whsec_old');
+    const verified = await verifyAndRedeemEmbedSessionToken(adapter, token, {
+      expectedTenantId: 'acme',
+    });
+    expect(verified.ok).toBe(true);
+    if (verified.ok) expect(verified.matchedSecret).toBe('previous');
+  });
+
+  it('rejects when the user has since lost membership', async () => {
+    const minted = await mintEmbedSessionToken(adapter, {
+      tenantId: 'acme',
+      userId: 'u_1',
+    });
+    if ('code' in minted) throw new Error('mint failed');
+    // Wipe the membership before exchange.
+    delete (adapter._store[TENANT_MEMBERS_COLLECTION] ??= {})[
+      tenantMemberDocId('acme', 'u_1')
+    ];
+    const verified = await verifyAndRedeemEmbedSessionToken(adapter, minted.token, {
+      expectedTenantId: 'acme',
+    });
+    expect(verified.ok).toBe(false);
+    if (!verified.ok) expect(verified.code).toBe('user_not_member');
+  });
+
+  it('rejects garbage strings without crashing', async () => {
+    for (const garbage of ['', 'abc', 'a.b', 'a.b.c.d', '.'.repeat(10_000)]) {
+      const verified = await verifyAndRedeemEmbedSessionToken(adapter, garbage, {
+        expectedTenantId: 'acme',
+      });
+      expect(verified.ok).toBe(false);
+    }
+  });
+
+  it('persists a jti record on redemption', async () => {
+    const minted = await mintEmbedSessionToken(adapter, {
+      tenantId: 'acme',
+      userId: 'u_1',
+    });
+    if ('code' in minted) throw new Error('mint failed');
+    await verifyAndRedeemEmbedSessionToken(adapter, minted.token, {
+      expectedTenantId: 'acme',
+    });
+    const jtiBucket = adapter._store[EMBED_SESSION_TOKEN_JTI_COLLECTION] ?? {};
+    const records = Object.values(jtiBucket) as EmbedSessionTokenJtiRecord[];
+    expect(records).toHaveLength(1);
+    expect(records[0].tenantId).toBe('acme');
+    expect(records[0].userId).toBe('u_1');
+  });
+});
+
+describe('hashJtiForMetering', () => {
+  it('returns 16 hex characters and is stable', () => {
+    const a = hashJtiForMetering('jti-a');
+    const b = hashJtiForMetering('jti-a');
+    const c = hashJtiForMetering('jti-b');
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+});

--- a/src/embed/contract.ts
+++ b/src/embed/contract.ts
@@ -43,6 +43,24 @@ export interface AuraPixNavigateMessage {
   path: string;
 }
 
+/**
+ * Host → embedded: forward a host-issued embed session token (issue #195).
+ *
+ * Sent by the host SDK as the first `postMessage` after the embedded UI
+ * announces `aurapix:ready`. The embedded UI POSTs the token to
+ * `/v1/tenants/{tenantId}/embed/session-exchange` to mint a server-side
+ * session without showing the Firebase login UI.
+ */
+export interface AuraPixSessionMessage {
+  type: 'aurapix:session';
+  /**
+   * Compact JWT minted by the host backend via
+   * `POST /v1/tenants/{tenantId}/embed/session-tokens`. Single use,
+   * short-lived (TTL ≤ 300s), bound to a specific tenant.
+   */
+  token: string;
+}
+
 export type AuraPixOutboundMessage =
   | AuraPixReadyMessage
   | AuraPixResizeMessage
@@ -50,7 +68,8 @@ export type AuraPixOutboundMessage =
 
 export type AuraPixInboundMessage =
   | AuraPixSetThemeMessage
-  | AuraPixNavigateMessage;
+  | AuraPixNavigateMessage
+  | AuraPixSessionMessage;
 
 export type AuraPixMessage = AuraPixOutboundMessage | AuraPixInboundMessage;
 
@@ -62,6 +81,7 @@ export const AURAPIX_MESSAGE_TYPES = {
   event: 'aurapix:event',
   setTheme: 'aurapix:set-theme',
   navigate: 'aurapix:navigate',
+  session: 'aurapix:session',
 } as const;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -120,5 +140,24 @@ export function isAuraPixNavigate(
     value.type === AURAPIX_MESSAGE_TYPES.navigate &&
     typeof value.path === 'string' &&
     value.path.startsWith('/')
+  );
+}
+
+/**
+ * Type guard for the host-issued embed session token forwarded over
+ * postMessage (issue #195). Validates structure only — the token itself
+ * is verified server-side at /v1/tenants/{tenantId}/embed/session-exchange.
+ */
+export function isAuraPixSession(
+  value: unknown
+): value is AuraPixSessionMessage {
+  return (
+    isPlainObject(value) &&
+    value.type === AURAPIX_MESSAGE_TYPES.session &&
+    typeof value.token === 'string' &&
+    value.token.length > 0 &&
+    // Compact JWTs are header.payload.signature — reject obvious garbage
+    // early so the embedded UI doesn't waste a network round-trip.
+    value.token.split('.').length === 3
   );
 }

--- a/src/embed/embedded.ts
+++ b/src/embed/embedded.ts
@@ -78,7 +78,8 @@ export function createEmbedded(opts: EmbeddedEmitterOptions): EmbeddedHandle {
     const t = event.data.type;
     if (
       t !== AURAPIX_MESSAGE_TYPES.setTheme &&
-      t !== AURAPIX_MESSAGE_TYPES.navigate
+      t !== AURAPIX_MESSAGE_TYPES.navigate &&
+      t !== AURAPIX_MESSAGE_TYPES.session
     ) {
       return;
     }

--- a/src/embed/host-sdk.test.ts
+++ b/src/embed/host-sdk.test.ts
@@ -5,6 +5,7 @@ import {
   isAuraPixReady,
   isAuraPixResize,
   isAuraPixEvent,
+  isAuraPixSession,
   AURAPIX_MESSAGE_TYPES,
   type AuraPixOutboundMessage,
   type AuraPixInboundMessage,
@@ -301,6 +302,127 @@ describe('createEmbedded', () => {
 
     expect(seen).toHaveLength(1);
     expect(seen[0]).toMatchObject({ type: 'aurapix:set-theme', theme: 'dark' });
+    handle.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #195: host-issued embed session token forwarding.
+// ---------------------------------------------------------------------------
+
+describe('isAuraPixSession guard', () => {
+  it('accepts a well-formed compact JWT', () => {
+    expect(
+      isAuraPixSession({ type: 'aurapix:session', token: 'aaa.bbb.ccc' })
+    ).toBe(true);
+  });
+
+  it('rejects non-JWT-shaped tokens and wrong-type messages', () => {
+    expect(isAuraPixSession({ type: 'aurapix:session', token: '' })).toBe(false);
+    expect(isAuraPixSession({ type: 'aurapix:session', token: 'noDots' })).toBe(
+      false
+    );
+    expect(
+      isAuraPixSession({ type: 'aurapix:session', token: 'a.b.c.d' })
+    ).toBe(false);
+    expect(isAuraPixSession({ type: 'aurapix:ready', token: 'a.b.c' })).toBe(
+      false
+    );
+    expect(isAuraPixSession(null)).toBe(false);
+  });
+});
+
+describe('createEmbedHost — sessionToken (issue #195)', () => {
+  function makeFakeIframe(post: ReturnType<typeof vi.fn>): HTMLIFrameElement {
+    const iframe = document.createElement('iframe');
+    const fakeWin = { postMessage: post, close: () => {} } as unknown as Window;
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: fakeWin,
+      configurable: true,
+    });
+    document.body.appendChild(iframe);
+    return iframe;
+  }
+
+  it('forwards the queued sessionToken on aurapix:ready', () => {
+    const post = vi.fn();
+    const iframe = makeFakeIframe(post);
+    const handle = createEmbedHost({
+      iframe,
+      targetOrigin: 'https://app.aurapix.com',
+      sessionToken: 'aaa.bbb.ccc',
+    });
+
+    // Simulate aurapix:ready from the iframe.
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'aurapix:ready', tenantId: 'acme', version: '1.0.0' },
+        origin: 'https://app.aurapix.com',
+        source: iframe.contentWindow as unknown as Window,
+      })
+    );
+
+    expect(post).toHaveBeenCalledWith(
+      { type: AURAPIX_MESSAGE_TYPES.session, token: 'aaa.bbb.ccc' },
+      'https://app.aurapix.com'
+    );
+
+    handle.dispose();
+  });
+
+  it('does not forward the token if ready never arrives', () => {
+    const post = vi.fn();
+    const iframe = makeFakeIframe(post);
+    const handle = createEmbedHost({
+      iframe,
+      targetOrigin: 'https://app.aurapix.com',
+      sessionToken: 'aaa.bbb.ccc',
+    });
+    expect(post).not.toHaveBeenCalled();
+    handle.dispose();
+  });
+
+  it('sendSessionToken queues before ready and sends immediately after', () => {
+    const post = vi.fn();
+    const iframe = makeFakeIframe(post);
+    const handle = createEmbedHost({
+      iframe,
+      targetOrigin: 'https://app.aurapix.com',
+    });
+
+    handle.sendSessionToken('xxx.yyy.zzz');
+    expect(post).not.toHaveBeenCalled();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'aurapix:ready', tenantId: 'acme', version: '1.0.0' },
+        origin: 'https://app.aurapix.com',
+        source: iframe.contentWindow as unknown as Window,
+      })
+    );
+    expect(post).toHaveBeenCalledWith(
+      { type: AURAPIX_MESSAGE_TYPES.session, token: 'xxx.yyy.zzz' },
+      'https://app.aurapix.com'
+    );
+
+    // After ready, calls send immediately.
+    post.mockClear();
+    handle.sendSessionToken('ddd.eee.fff');
+    expect(post).toHaveBeenCalledWith(
+      { type: AURAPIX_MESSAGE_TYPES.session, token: 'ddd.eee.fff' },
+      'https://app.aurapix.com'
+    );
+
+    handle.dispose();
+  });
+
+  it('sendSessionToken rejects empty tokens', () => {
+    const iframe = makeFakeIframe(vi.fn());
+    const handle = createEmbedHost({
+      iframe,
+      targetOrigin: 'https://app.aurapix.com',
+    });
+    expect(() => handle.sendSessionToken('')).toThrow();
     handle.dispose();
   });
 });

--- a/src/embed/host-sdk.ts
+++ b/src/embed/host-sdk.ts
@@ -19,6 +19,18 @@ export interface CreateEmbedHostOptions {
   targetOrigin: string;
   /** `window` reference — defaults to the global `window`. */
   window?: Window;
+  /**
+   * Optional host-issued embed session token (issue #195). When set, the
+   * host SDK forwards it as the first `aurapix:session` postMessage as
+   * soon as the embedded UI announces `aurapix:ready`. The embedded UI
+   * exchanges the token for a server-side session and the user lands
+   * inside AuraPix without seeing the Firebase login UI.
+   *
+   * Mint a token via `POST /v1/tenants/{tenantId}/embed/session-tokens`
+   * (host API key, `tenants.write` scope). Tokens are single-use and
+   * short-lived (TTL ≤ 300s).
+   */
+  sessionToken?: string;
 }
 
 export type EmbedHostListener = (
@@ -30,6 +42,12 @@ export interface EmbedHostHandle {
   on(listener: EmbedHostListener): () => void;
   setTheme(theme: AuraPixSetThemeMessage['theme']): void;
   navigate(path: string): void;
+  /**
+   * Send (or replace) the host-issued embed session token (issue #195).
+   * Callers can also pass it via `createEmbedHost({ sessionToken })` and
+   * the SDK will auto-forward as soon as `aurapix:ready` arrives.
+   */
+  sendSessionToken(token: string): void;
   dispose(): void;
 }
 
@@ -60,11 +78,28 @@ export function createEmbedHost(opts: CreateEmbedHostOptions): EmbedHostHandle {
 
   const listeners = new Set<EmbedHostListener>();
   let disposed = false;
+  // Issue #195: queued session token — sent after `aurapix:ready` arrives
+  // so the embedded UI is guaranteed to have its postMessage listener
+  // wired up before we hand it the credential. We also drop the token
+  // from memory after sending so it isn't trivially exfiltrable from a
+  // long-lived host page.
+  let pendingSessionToken: string | null =
+    typeof opts.sessionToken === 'string' && opts.sessionToken.length > 0
+      ? opts.sessionToken
+      : null;
+  let readySeen = false;
 
   const send = (message: AuraPixInboundMessage): void => {
     if (disposed) return;
     const target = opts.iframe.contentWindow;
     if (target) target.postMessage(message, parsedOrigin);
+  };
+
+  const flushSessionToken = (): void => {
+    if (!pendingSessionToken) return;
+    const token = pendingSessionToken;
+    pendingSessionToken = null;
+    send({ type: AURAPIX_MESSAGE_TYPES.session, token });
   };
 
   const onMessage = (event: MessageEvent): void => {
@@ -79,6 +114,13 @@ export function createEmbedHost(opts: CreateEmbedHostOptions): EmbedHostHandle {
       t !== AURAPIX_MESSAGE_TYPES.event
     ) {
       return;
+    }
+    // Issue #195: send the queued session token as soon as the embedded
+    // UI announces it's ready. This guarantees the embedded message
+    // handler is mounted before we hand it the credential.
+    if (t === AURAPIX_MESSAGE_TYPES.ready && !readySeen) {
+      readySeen = true;
+      flushSessionToken();
     }
     for (const l of listeners) {
       try {
@@ -104,6 +146,18 @@ export function createEmbedHost(opts: CreateEmbedHostOptions): EmbedHostHandle {
         throw new Error('navigate: path must start with "/"');
       }
       send({ type: AURAPIX_MESSAGE_TYPES.navigate, path });
+    },
+    sendSessionToken(token) {
+      if (typeof token !== 'string' || token.length === 0) {
+        throw new Error('sendSessionToken: token must be a non-empty string');
+      }
+      // If `aurapix:ready` has already arrived, send immediately;
+      // otherwise queue so the SDK can flush on ready.
+      if (readySeen) {
+        send({ type: AURAPIX_MESSAGE_TYPES.session, token });
+      } else {
+        pendingSessionToken = token;
+      }
     },
     dispose() {
       if (disposed) return;


### PR DESCRIPTION
## Summary

Adds the host-issued embed session-token handshake described in #195. Host applications can now mint a short-lived signed credential on their backend (using the tenant's existing webhook signing secret) and pass it to the embedded AuraPix iframe via the documented `aurapix:session` postMessage. AuraPix exchanges the token for a server-side session and the user lands logged in — no Firebase login prompt.

The flow inherits the per-tenant webhook-secret rotation grace window (#161), is still gated by the embed allowed-origins config (#163), and emits per-session metering events.

## Changes

**Backend service**
- `functions/src/services/host/embedSessionTokenService.ts` (new) — `mintEmbedSessionToken` and `verifyAndRedeemEmbedSessionToken`. Compact HS256 JWT with claims `iss=tenantId`, `aud='aurapix:embed'`, `sub=userId`, `role`, `jti`, `iat`, `exp`. TTL capped at 300s (default 120s). Replay defense via `embedSessionTokenJtis` collection (one-time-use). Membership is re-checked at exchange time.

**Routes**
- `POST /v1/tenants/:tenantId/embed/session-tokens` — host-API-key gated, requires `tenants.write` scope. Body `{ userId, role?, ttlSeconds? }`. Returns `{ token, expiresAt, audience }`. Emits `embed.session.minted`.
- `POST /v1/tenants/:tenantId/embed/session-exchange` — token IS the credential, no API key required. Validates signature, audience, expiry, tenant binding (cross-tenant returns `403 tenant_mismatch`), and one-time-use (replay returns `401 token_replayed`). Optional `issueEmbedSession` hook lets a deployment return a Firebase custom token. Emits `embed.session.exchanged`.
- `functions/src/server.ts` now mounts `embedRouter` under `/v1/tenants` (canonical spec URL) in addition to the legacy `/api/v1/tenants` prefix.

**Metering**
- `functions/src/services/metering/eventCatalog.ts` — bumps `CATALOG_VERSION` to `2026-06-29` and adds `embed.session.minted` and `embed.session.exchanged` to the catalog (so they flow through the existing host webhook fanout and `GET /v1/host/webhook-events`).

**Embed SDK (frontend)**
- `src/embed/contract.ts` — new `AuraPixSessionMessage` type + `isAuraPixSession` guard.
- `src/embed/embedded.ts` — accepts the new message type in its allowlist.
- `src/embed/host-sdk.ts` — `createEmbedHost` takes an optional `sessionToken`; queued and forwarded as the first `postMessage` after `aurapix:ready`. Also exposes `handle.sendSessionToken(token)`.

**Docs / spec**
- `contracts/openapi/embed.openapi.json` — bump `0.1.0 → 0.2.0`, document both endpoints + four request/response schemas.
- `docs/features/embed-handshake.md` — new "Host-issued session tokens (SSO)" section, handshake table updated, acceptance-criteria rows added.
- `docs/features/auth-and-user-management.md` — cross-links the new flow.

## Testing

All new tests pass.

- `functions/test/services/host/embedSessionTokenService.test.ts` (18 tests): mint shape & claims, membership gate, missing signing secret, role override, ttl cap, fresh verify, expired token, tampered signature, wrong-secret token, dual-secret grace window, replay defense, cross-tenant rejection, revoked-after-mint, garbage input.
- `functions/test/routes/embedV1.sessionTokens.test.ts` (13 tests): mint + `embed.session.minted`, scope/role/ttl validation, exchange + `embed.session.exchanged`, replay → 401 `token_replayed`, cross-tenant → 403 `tenant_mismatch`, garbage → 401 `invalid_token`, `issueEmbedSession` integration.
- `src/embed/host-sdk.test.ts`: 4 new tests for `isAuraPixSession` and the host-SDK token queue/forward behavior.

Verified the 12 pre-existing failures in `tenantUsersV1.test.ts`/`photosV1.test.ts` and the 3 emulator-only failures in `FirebaseUploadService.emulator.test.ts` exist on `main` and are unrelated.

## Acceptance criteria mapping

| Criterion | Implementation |
| --- | --- |
| `POST /v1/tenants/{tenantId}/embed/session-tokens` documented in OpenAPI and rejects without `tenants.write` scope | `embedV1.ts` (gated by `canWriteEmbedConfig` / `tenants.write`); spec in `embed.openapi.json` |
| JWT signed with tenant webhook secret, `exp ≤ 300s`, includes `aud`, `iss`, `sub`, `role`, `jti` | `embedSessionTokenService.ts#mintEmbedSessionToken` |
| Replay (same `jti` redeemed twice) returns `401 token_replayed` | `verifyAndRedeemEmbedSessionToken` + `embedSessionTokenJtis` collection |
| Embed handshake accepts `aurapix:session` postMessage and establishes a session without showing the Firebase login UI | `host-sdk.ts` queue + `issueEmbedSession` hook contract |
| Cross-tenant token rejected | `verifyAndRedeemEmbedSessionToken` `iss` vs `expectedTenantId` |
| `embed.session.minted` and `embed.session.exchanged` listed in the public webhook event catalog | `eventCatalog.ts` + bumped `CATALOG_VERSION` |
| Docs updated | `embed-handshake.md`, `auth-and-user-management.md` |

## Caveats

- The exchange endpoint returns a `session` payload only when the deployment wires the optional `issueEmbedSession` callback (e.g. to mint a Firebase custom token). The handshake itself is decoupled from that — the iframe can also rely on a future cookie-based session if a deployment prefers.
- `tenants:write` in the issue text is translated to the codebase's dot-notation scope `tenants.write` (matches the existing tenant-users API).

Fixes rwrife/AuraPix#195