### PR TITLE
fix: storage-quota threshold webhook events (#196)

### DIFF
--- a/docs/features/metering-events.md
+++ b/docs/features/metering-events.md
@@ -26,7 +26,7 @@ discarded; there is no outbound traffic.
 > ⚠️ This table is auto-generated from `functions/src/services/metering/eventCatalog.ts`.
 > Do not hand-edit; run `node scripts/generate-event-catalog-docs.mjs` after changing the registry.
 >
-> **Catalog version:** `2026-06-20` — the same string is stamped on every outbound webhook envelope and returned by `GET /v1/host/webhook-events`.
+> **Catalog version:** `2026-06-30` — the same string is stamped on every outbound webhook envelope and returned by `GET /v1/host/webhook-events`.
 
 | `type` | Version | Billable | Description |
 | --- | --- | --- | --- |
@@ -40,6 +40,8 @@ discarded; there is no outbound traffic.
 | `user.revoked` | 1 | — | A tenant membership was removed. |
 | `quota.exceeded` | 1 | — | In-process storage quota check rejected an upload with HTTP 413. |
 | `quota.warning` | 1 | — | Tenant storage usage crossed a configured threshold (e.g. 80%, 95%). Once per threshold per UTC day. |
+| `tenant.storage.threshold_crossed` | 1 | — | Per-tenant storage usage crossed a configured threshold (issue #196). Hysteresis prevents re-firing until usage drops 5% below and crosses up again. Hosts drive upsell / hard-cap flows from this event. |
+| `tenant.storage.threshold_cleared` | 1 | — | Per-tenant storage usage dropped at least 5% below a previously-crossed threshold (issue #196). Emitted exactly once per crossing direction; pairs with `tenant.storage.threshold_crossed`. |
 | `share.viewed` | 1 | ✅ | A share token passed auth and a resource was actually delivered. |
 | `plugin.ran` | 1 | ✅ | A plugin/edit operation executed (success or failure). One event per operation. |
 | `plugin.enabled` | 1 | — | A tenant toggled a plugin to enabled. |
@@ -56,6 +58,8 @@ discarded; there is no outbound traffic.
 | `embed.session_started` | 1 | — | An allowed parent origin framed an embed-eligible response. Debounced per `(tenantId, origin)`. |
 | `embed.session_ended` | 1 | — | The embed SDK reported a session end via the beacon endpoint or page unload. |
 | `embed.origin_blocked` | 1 | — | A browser-reported `frame-ancestors` CSP violation. Helps hosts find misconfigured deployments. |
+| `embed.session.minted` | 1 | — | Host minted an embed session token via POST /v1/tenants/{tenantId}/embed/session-tokens (issue #195). Useful for billing per-session pricing models. |
+| `embed.session.exchanged` | 1 | — | Embedded iframe successfully redeemed an embed session token — the meaningful "active embedded user" signal that complements `user.active` with embed context (issue #195). |
 | `idempotency.replayed` | 1 | — | Idempotency-Key middleware served a cached response. Debug-tier; NOT billable. |
 | `webhook.secret_rotated` | 1 | — | A tenant rotated its webhook signing secret. |
 | `smart_album.created` | 1 | — | A smart album definition was created. |

--- a/docs/features/usage-and-billing.md
+++ b/docs/features/usage-and-billing.md
@@ -207,6 +207,105 @@ After each tenant's daily snapshot, the system emits one
 Hosts can subscribe to this event to push-trigger their billing job
 instead of polling the read endpoint.
 
+## Push trigger: storage threshold webhooks (issue #196)
+
+Hosts that resell AuraPix should not need to poll `GET /v1/tenants/:id/usage`
+to know when one of their customer tenants is approaching its plan
+limit. AuraPix pushes two webhook events on the existing host webhook
+pipeline whenever a tenant's storage usage **crosses** or **clears** a
+configured threshold:
+
+| Event                                | Fires when                                                                                |
+| ------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `tenant.storage.threshold_crossed`   | Used bytes / quota bytes ≥ threshold for the first time since the last `_cleared`.       |
+| `tenant.storage.threshold_cleared`   | Used bytes / quota bytes ≤ (threshold − 5%) after a `_crossed` event was previously fired. |
+
+Payload (both events; only the trailing timestamp field differs):
+
+```json
+{
+  "type": "tenant.storage.threshold_crossed",
+  "tenantId": "tenant-A",
+  "meta": {
+    "tenantId": "tenant-A",
+    "threshold": 0.8,
+    "usedBytes": 8589934592,
+    "quotaBytes": 10737418240,
+    "crossedAt": "2026-06-30T12:00:00.000Z"
+  }
+}
+```
+
+### Hysteresis (no flapping)
+
+A threshold fires `_crossed` **at most once per crossing direction**. After
+`_crossed` is emitted, the threshold is considered "armed for clear";
+`_cleared` only fires once usage has dropped by at least **5% of quota**
+below the threshold and then crosses up again. This guarantees a tenant
+that hovers around 80% does not generate a flood of webhook events.
+
+State is persisted on the tenant doc (`storageThresholdState`) so a
+restart never re-fires events for thresholds that were already crossed.
+
+### Evaluation cadence
+
+Evaluation is **piggy-backed** on existing hot paths — there is no new
+scheduler:
+
+| Trigger                 | What it can fire           |
+| ----------------------- | -------------------------- |
+| Successful upload       | `_crossed` (usage went up) |
+| Trash purge job         | `_cleared` (usage went down) |
+
+### Default thresholds
+
+When a tenant has no per-tenant override, the system applies:
+
+```json
+[0.5, 0.8, 0.95, 1.0]
+```
+
+Values above `1.0` (up to `1.5`) are permitted on a per-tenant basis so
+hosts can wire **overage** alerts (e.g. `1.05` = 5% over quota).
+
+### Configure per-tenant thresholds
+
+Manage the override via the per-tenant config API. Requires a host API
+key with the `tenants.write` scope (read uses `tenants.read`); also
+accessible to the tenant owner via the `/api/v1/...` prefix.
+
+```
+GET    /v1/tenants/{tenantId}/storage/thresholds
+PUT    /v1/tenants/{tenantId}/storage/thresholds   body: { "thresholds": [0.5, 0.8, 0.95, 1.05] }
+DELETE /v1/tenants/{tenantId}/storage/thresholds   (revert to defaults)
+```
+
+Response shape:
+
+```json
+{
+  "tenantId": "tenant-A",
+  "thresholds": [0.5, 0.8, 0.95, 1.05],
+  "defaults": [0.5, 0.8, 0.95, 1.0],
+  "override": [0.5, 0.8, 0.95, 1.05],
+  "source": "tenant",
+  "updatedAt": "2026-06-30T12:00:00.000Z"
+}
+```
+
+Validation rules:
+
+- 1–8 entries.
+- Each entry must be a finite number in the open interval `(0, 1.5]`.
+- Duplicates (after 3-decimal normalization) are deduped silently.
+- Output is always sorted ascending.
+
+### Discovery
+
+Both events appear in the public catalog at
+`GET /v1/host/webhook-events` (#176) so hosts can discover them
+programmatically; their schemas live in `services/metering/eventCatalog.ts`.
+
 ## Caveats & dependencies
 
 - The `tenantId` model and host API key scopes (`usage.read`) are tracked

--- a/functions/src/handlers/images/upload.ts
+++ b/functions/src/handlers/images/upload.ts
@@ -26,6 +26,7 @@ import {
 } from '../../services/metering/index.js';
 import { readCurrentUsageBytes } from '../../services/metering/currentUsage.js';
 import { getTenantRecord } from '../../services/tenant/tenantRecordService.js';
+import { evaluateStorageThresholds } from '../../services/tenant/storageThresholdEvaluator.js';
 import { wouldExceedQuota } from '../../models/TenantRecord.js';
 import type { DailyDocStore } from '../../services/metering/UsageRollupConsumer.js';
 
@@ -364,6 +365,30 @@ export async function handleUpload(
         ...(metadata.height ? { heightPx: metadata.height } : {}),
       },
     });
+
+    // Issue #196: piggy-back per-tenant storage-threshold evaluation on
+    // the upload path. Uses the post-upload usage estimate (pre-snapshot
+    // we approximate by adding the new bytes to the in-memory reading we
+    // just took). Best-effort — the evaluator swallows all errors so it
+    // can never break an upload.
+    if (
+      usageDailyStore &&
+      tenantRecord.quotaBytes !== null &&
+      tenantRecord.quotaBytes > 0
+    ) {
+      const postUploadUsageBytes =
+        (await readCurrentUsageBytes(usageDailyStore, tenantId)) +
+        metadata.sizeBytes;
+      // Don't await beyond a single tick — we want this off the
+      // critical response path. `evaluateStorageThresholds` already
+      // catches all errors internally.
+      void evaluateStorageThresholds({
+        dataAdapter,
+        tenantId,
+        usedBytes: postUploadUsageBytes,
+        tenantRecord,
+      });
+    }
 
     // Return response immediately
     res.status(202).json({

--- a/functions/src/jobs/purgeTrash.ts
+++ b/functions/src/jobs/purgeTrash.ts
@@ -17,6 +17,15 @@
  *   - Reuses the existing storage-cleanup path on the storage adapter.
  *   - Emits `photo.purged` exactly once per photo (host webhook).
  *   - Decrements the daily `storageBytesDelta` rollup via the usage bus.
+ *
+ * Threshold clearing (issue #196):
+ *   - When a `usageStore` is provided, evaluates per-tenant storage
+ *     thresholds after each tenant's purge completes so
+ *     `tenant.storage.threshold_cleared` events fire when bytes
+ *     reclaimed bring usage back below a previously-crossed threshold
+ *     (after hysteresis). When no `usageStore` is wired, this step is
+ *     skipped silently and the next upload's piggy-backed evaluation
+ *     will catch up.
  */
 
 import type { DataAdapter } from '../adapters/data/DataAdapter.js';
@@ -24,6 +33,9 @@ import type { StorageAdapter } from '../adapters/storage/StorageAdapter.js';
 import { PhotosService } from '../domain/photos/PhotosService.js';
 import type { UsageMeteringBus } from '../services/metering/UsageMeteringBus.js';
 import { resolveTenantTrashRetentionDays } from '../services/host/tenantFeaturesConfigService.js';
+import { evaluateStorageThresholds } from '../services/tenant/storageThresholdEvaluator.js';
+import { readCurrentUsageBytes } from '../services/metering/currentUsage.js';
+import type { DailyDocStore } from '../services/metering/UsageRollupConsumer.js';
 import { logger } from '../utils/logger.js';
 
 export const DEFAULT_TRASH_RETENTION_DAYS = 30;
@@ -48,6 +60,14 @@ export interface PurgeTrashJobOptions {
   dataAdapter: DataAdapter;
   storageAdapter?: StorageAdapter;
   usageBus?: UsageMeteringBus;
+  /**
+   * Optional usage store used by the issue #196 threshold evaluator to
+   * compute fresh post-purge `usedBytes` per tenant. Without it the
+   * `tenant.storage.threshold_cleared` event cannot fire from this job;
+   * the next upload for that tenant will still trip the evaluator and
+   * emit the cleared event then.
+   */
+  usageStore?: DailyDocStore;
   /**
    * Deployment-wide default retention. Per-tenant overrides on the
    * features-config doc take precedence; pass this when you want to
@@ -105,6 +125,33 @@ export async function runPurgeTrashJob(
     { retentionDays, totalPurged, tenants: results.length },
     'purgeTrash job complete'
   );
+
+  // Issue #196: after each tenant's purge, re-evaluate storage
+  // thresholds so `tenant.storage.threshold_cleared` events fire when
+  // the reclaimed bytes bring usage back below a previously-crossed
+  // threshold (after hysteresis). Skipped silently when no usage store
+  // is wired — the next upload's piggy-backed evaluation will catch up.
+  if (opts.usageStore) {
+    for (const r of results) {
+      if (r.photoIds.length === 0) continue;
+      try {
+        const usedBytes = await readCurrentUsageBytes(
+          opts.usageStore,
+          String(r.tenantId)
+        );
+        await evaluateStorageThresholds({
+          dataAdapter: opts.dataAdapter,
+          tenantId: r.tenantId,
+          usedBytes,
+        });
+      } catch (err) {
+        logger.warn(
+          { err, tenantId: r.tenantId },
+          'purgeTrash: threshold re-evaluation failed; continuing'
+        );
+      }
+    }
+  }
 
   return {
     retentionDays,

--- a/functions/src/models/TenantRecord.ts
+++ b/functions/src/models/TenantRecord.ts
@@ -22,6 +22,60 @@ import type { TenantId } from '../domain/tenant/Tenant.js';
 
 export const TENANTS_COLLECTION = 'tenants';
 
+/**
+ * Default storage-usage thresholds (issue #196). Each value is a
+ * fraction of `quotaBytes`; a value > 1.0 is permitted for overage
+ * alerting (e.g. host wants to know when a tenant is 5% over).
+ *
+ * These defaults apply when a tenant has no explicit override on its
+ * record. Order matches the public docs and the
+ * `tenant.storage.threshold_crossed` event ordering.
+ */
+export const DEFAULT_STORAGE_THRESHOLDS: readonly number[] = [
+  0.5,
+  0.8,
+  0.95,
+  1.0,
+];
+
+/** Max number of per-tenant thresholds accepted by the admin API. */
+export const STORAGE_THRESHOLDS_MAX_COUNT = 8;
+/** Max allowed threshold value (overage alerting). */
+export const STORAGE_THRESHOLD_MAX = 1.5;
+/** Min allowed threshold value (exclusive lower bound). */
+export const STORAGE_THRESHOLD_MIN_EXCLUSIVE = 0;
+/**
+ * Hysteresis band (fraction of quota) — a threshold does not re-fire
+ * `crossed` until usage has dropped by at least this much below it and
+ * then crossed up again. Keeps webhook traffic quiet when usage hovers
+ * right around a threshold.
+ */
+export const STORAGE_THRESHOLD_HYSTERESIS = 0.05;
+
+/**
+ * Per-threshold crossing state (issue #196).
+ *
+ * Stored on the tenant doc so the evaluator can decide whether the
+ * tenant has crossed a given threshold for the first time, is still in
+ * the crossed band (no event), or has cleared (after hysteresis).
+ *
+ * `crossed` is the source of truth for whether `_crossed` has already
+ * fired since the last `_cleared` (or since the tenant was created).
+ * `lastCrossedAt` / `lastClearedAt` are observability fields.
+ */
+export interface StorageThresholdState {
+  /**
+   * Currently in the "crossed" half of the hysteresis loop. While true,
+   * `_crossed` will NOT fire again for this threshold; it can only flip
+   * back to false after a `_cleared` event.
+   */
+  crossed: boolean;
+  /** ISO-8601 timestamp of the most recent `_crossed` emission. */
+  lastCrossedAt?: string;
+  /** ISO-8601 timestamp of the most recent `_cleared` emission. */
+  lastClearedAt?: string;
+}
+
 export interface TenantRecord {
   /** Document id (same as the resolved `TenantId`). */
   id: TenantId;
@@ -32,9 +86,35 @@ export interface TenantRecord {
    * itself omits a value.
    */
   quotaBytes: number | null;
+  /**
+   * Per-tenant storage thresholds (issue #196). `null` / `undefined`
+   * means "use {@link DEFAULT_STORAGE_THRESHOLDS}". Each value is a
+   * fraction of `quotaBytes` in the open interval
+   * `(0, STORAGE_THRESHOLD_MAX]`. Max length is
+   * {@link STORAGE_THRESHOLDS_MAX_COUNT}. Order is not significant; the
+   * evaluator always sorts ascending.
+   */
+  storageThresholds?: number[] | null;
+  /**
+   * Per-threshold crossing state (issue #196). Keyed by the threshold's
+   * fixed-precision string form (see `thresholdStateKey()`). Missing
+   * entries are treated as `{ crossed: false }`.
+   */
+  storageThresholdState?: Record<string, StorageThresholdState>;
   /** ISO-8601 timestamps. */
   createdAt: string;
   updatedAt: string;
+}
+
+/**
+ * Canonical map key for a threshold value. Using a fixed-precision
+ * string avoids float-equality footguns when persisting / looking up
+ * `storageThresholdState` entries across reloads.
+ *
+ * Example: `0.8` → `"0.800"`; `1` → `"1.000"`.
+ */
+export function thresholdStateKey(threshold: number): string {
+  return threshold.toFixed(3);
 }
 
 /**

--- a/functions/src/routes/tenantStorageThresholdsV1.test.ts
+++ b/functions/src/routes/tenantStorageThresholdsV1.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Unit tests for the per-tenant storage thresholds router (issue #196).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import type { Express } from 'express';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { createTenantStorageThresholdsRouter } from './tenantStorageThresholdsV1.js';
+import {
+  DEFAULT_STORAGE_THRESHOLDS,
+  TENANTS_COLLECTION,
+  type TenantRecord,
+} from '../models/TenantRecord.js';
+
+interface FakeTenant {
+  id: string;
+  scopes: string[];
+  keyId?: string;
+}
+
+function makeApp(
+  data: DataAdapter,
+  inject: (req: express.Request) => void = () => {}
+): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    inject(req);
+    next();
+  });
+  const router = createTenantStorageThresholdsRouter({ dataAdapter: data });
+  app.use('/v1/tenants', router);
+  app.use(errorHandler);
+  return app;
+}
+
+function makeMemoryAdapter(seed: Record<string, unknown> = {}): {
+  data: DataAdapter;
+  store: Map<string, Map<string, unknown>>;
+} {
+  const store = new Map<string, Map<string, unknown>>();
+  for (const [key, value] of Object.entries(seed)) {
+    const [collection, id] = key.split('::');
+    if (!collection || !id) continue;
+    if (!store.has(collection)) store.set(collection, new Map());
+    store.get(collection)!.set(id, value);
+  }
+  const get = (collection: string) => {
+    let inner = store.get(collection);
+    if (!inner) {
+      inner = new Map();
+      store.set(collection, inner);
+    }
+    return inner;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: any = {
+    storeData: vi.fn(async (collection: string, id: string, value: unknown) => {
+      get(collection).set(id, value);
+    }),
+    fetchData: vi.fn(async (collection: string, id: string) => {
+      return get(collection).get(id) ?? null;
+    }),
+    queryData: vi.fn(async () => []),
+    updateData: vi.fn(async () => {}),
+    deleteData: vi.fn(async () => {}),
+    exists: vi.fn(async () => false),
+    listIds: vi.fn(async () => []),
+    getPhoto: vi.fn(async () => null),
+  };
+  return { data: data as DataAdapter, store };
+}
+
+async function request(
+  app: Express,
+  method: 'get' | 'put' | 'delete' | 'post',
+  path: string,
+  body?: unknown
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<{ status: number; body: any }> {
+  const { createServer } = await import('node:http');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const server = createServer(app as unknown as (req: any, res: any) => void);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const addr = server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method: method.toUpperCase(),
+      headers: { 'content-type': 'application/json' },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let parsed: any;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    return { status: res.status, body: parsed };
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe('createTenantStorageThresholdsRouter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('GET /:tenantId/storage/thresholds', () => {
+    it('401 when no auth context is present', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data);
+      const { status } = await request(
+        app,
+        'get',
+        '/v1/tenants/tenant-a/storage/thresholds'
+      );
+      expect(status).toBe(401);
+    });
+
+    it('403 when host API key targets a different tenant', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-other',
+          scopes: ['tenants.read'],
+        } satisfies FakeTenant;
+      });
+      const { status } = await request(
+        app,
+        'get',
+        '/v1/tenants/tenant-a/storage/thresholds'
+      );
+      expect(status).toBe(403);
+    });
+
+    it('returns defaults when no override is set', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['tenants.read', 'tenants.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'get',
+        '/v1/tenants/tenant-a/storage/thresholds'
+      );
+      expect(status).toBe(200);
+      expect(body.tenantId).toBe('tenant-a');
+      expect(body.thresholds).toEqual([...DEFAULT_STORAGE_THRESHOLDS]);
+      expect(body.source).toBe('deployment');
+      expect(body.override).toBeNull();
+    });
+
+    it('returns the tenant override when present', async () => {
+      const seed: TenantRecord = {
+        id: 'tenant-a',
+        quotaBytes: 1000,
+        storageThresholds: [0.5, 0.95],
+        createdAt: '2026-06-30T00:00:00.000Z',
+        updatedAt: '2026-06-30T00:00:00.000Z',
+      };
+      const { data } = makeMemoryAdapter({
+        [`${TENANTS_COLLECTION}::tenant-a`]: seed,
+      });
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['tenants.read'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'get',
+        '/v1/tenants/tenant-a/storage/thresholds'
+      );
+      expect(status).toBe(200);
+      expect(body.thresholds).toEqual([0.5, 0.95]);
+      expect(body.source).toBe('tenant');
+    });
+  });
+
+  describe('PUT /:tenantId/storage/thresholds', () => {
+    it('401 when no auth context is present', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data);
+      const { status } = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/storage/thresholds',
+        { thresholds: [0.5] }
+      );
+      expect(status).toBe(401);
+    });
+
+    it('403 without tenants.write scope', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['tenants.read'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/storage/thresholds',
+        { thresholds: [0.5] }
+      );
+      expect(status).toBe(403);
+      expect(body.missing).toEqual(['tenants.write']);
+    });
+
+    it('400 when thresholds field is missing', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['tenants.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/storage/thresholds',
+        {}
+      );
+      expect(status).toBe(400);
+      expect(body.error.code).toBe('INVALID_BODY');
+    });
+
+    it('400 when thresholds is null (use DELETE instead)', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['tenants.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/storage/thresholds',
+        { thresholds: null }
+      );
+      expect(status).toBe(400);
+      expect(body.error.message).toMatch(/DELETE/);
+    });
+
+    it('400 when an entry is out of range', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['tenants.write'],
+        } satisfies FakeTenant;
+      });
+      const r1 = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/storage/thresholds',
+        { thresholds: [0.5, 2.0] }
+      );
+      expect(r1.status).toBe(400);
+
+      const r2 = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/storage/thresholds',
+        { thresholds: [0, 0.5] }
+      );
+      expect(r2.status).toBe(400);
+
+      const r3 = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/storage/thresholds',
+        { thresholds: [-0.1, 0.5] }
+      );
+      expect(r3.status).toBe(400);
+    });
+
+    it('400 when more than 8 entries are submitted', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['tenants.write'],
+        } satisfies FakeTenant;
+      });
+      const { status } = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/storage/thresholds',
+        { thresholds: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9] }
+      );
+      expect(status).toBe(400);
+    });
+
+    it('writes a valid override and returns the normalized list', async () => {
+      const { data, store } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['tenants.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/storage/thresholds',
+        { thresholds: [0.8, 0.5, 0.95, 1.2] }
+      );
+      expect(status).toBe(200);
+      expect(body.override).toEqual([0.5, 0.8, 0.95, 1.2]);
+      expect(body.thresholds).toEqual([0.5, 0.8, 0.95, 1.2]);
+      expect(body.source).toBe('tenant');
+
+      // Persisted to the tenant record.
+      const persisted = store
+        .get(TENANTS_COLLECTION)
+        ?.get('tenant-a') as TenantRecord | undefined;
+      expect(persisted?.storageThresholds).toEqual([0.5, 0.8, 0.95, 1.2]);
+    });
+
+    it('allows values above 1.0 (overage alerting)', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['tenants.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'put',
+        '/v1/tenants/tenant-a/storage/thresholds',
+        { thresholds: [1.0, 1.1, 1.5] }
+      );
+      expect(status).toBe(200);
+      expect(body.override).toEqual([1.0, 1.1, 1.5]);
+    });
+  });
+
+  describe('DELETE /:tenantId/storage/thresholds', () => {
+    it('reverts to defaults', async () => {
+      const seed: TenantRecord = {
+        id: 'tenant-a',
+        quotaBytes: 1000,
+        storageThresholds: [0.5],
+        createdAt: '2026-06-30T00:00:00.000Z',
+        updatedAt: '2026-06-30T00:00:00.000Z',
+      };
+      const { data, store } = makeMemoryAdapter({
+        [`${TENANTS_COLLECTION}::tenant-a`]: seed,
+      });
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['tenants.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'delete',
+        '/v1/tenants/tenant-a/storage/thresholds'
+      );
+      expect(status).toBe(200);
+      expect(body.override).toBeNull();
+      expect(body.thresholds).toEqual([...DEFAULT_STORAGE_THRESHOLDS]);
+
+      const persisted = store
+        .get(TENANTS_COLLECTION)
+        ?.get('tenant-a') as TenantRecord | undefined;
+      expect(persisted?.storageThresholds).toBeNull();
+    });
+  });
+});

--- a/functions/src/routes/tenantStorageThresholdsV1.ts
+++ b/functions/src/routes/tenantStorageThresholdsV1.ts
@@ -1,0 +1,235 @@
+/**
+ * Per-tenant storage threshold config endpoints (issue #196).
+ *
+ * Mounted at `/v1/tenants/:tenantId/storage/thresholds` (and the legacy
+ * `/api/v1/tenants/...` alias). Both endpoints are host-API-key only
+ * with the `tenants.write` scope (read uses `tenants.read`) and are
+ * scoped to the calling tenant (cross-tenant calls return 403).
+ *
+ *   GET /:tenantId/storage/thresholds  \u2192 { tenantId, thresholds,
+ *                                          defaults, source, updatedAt }
+ *   PUT /:tenantId/storage/thresholds  \u2192 body { thresholds: number[] }
+ *                                          replaces the override; `null`
+ *                                          may NOT be passed via PUT \u2014
+ *                                          use DELETE for that.
+ *   DELETE /:tenantId/storage/thresholds \u2192 clears the override and reverts
+ *                                          to the deployment defaults.
+ *
+ * Validation rules (issue #196 acceptance criteria):
+ *   - Each entry must be a finite number in `(0, 1.5]`. Values > 1.0
+ *     are allowed deliberately so hosts can alert on overage.
+ *   - Max 8 entries.
+ *   - Duplicates (after 3-decimal normalization) are deduped silently.
+ *
+ * See:
+ *   - models/TenantRecord.ts                        \u2014 storage shape +
+ *                                                     constants
+ *   - services/tenant/tenantRecordService.ts        \u2014 validator + writer
+ *   - services/tenant/storageThresholdEvaluator.ts  \u2014 the evaluator that
+ *                                                     consumes the
+ *                                                     persisted config
+ */
+
+import { randomUUID } from 'node:crypto';
+import { Router } from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import { requireUserOrTenantScopes } from '../middleware/hostApiKeyAuth.js';
+import {
+  DEFAULT_STORAGE_THRESHOLDS,
+  STORAGE_THRESHOLDS_MAX_COUNT,
+  STORAGE_THRESHOLD_MAX,
+  STORAGE_THRESHOLD_MIN_EXCLUSIVE,
+} from '../models/TenantRecord.js';
+import {
+  getTenantRecord,
+  patchTenantRecord,
+  validateStorageThresholdsInput,
+} from '../services/tenant/tenantRecordService.js';
+import { isValidTenantId } from '../domain/tenant/Tenant.js';
+import { logger } from '../utils/logger.js';
+
+interface ApiErrorPayload {
+  error: {
+    code: string;
+    message: string;
+    requestId: string;
+    details: Record<string, unknown> | null;
+  };
+}
+
+function sendError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> | null = null
+): void {
+  const body: ApiErrorPayload = {
+    error: { code, message, requestId: randomUUID(), details },
+  };
+  res.status(status).json(body);
+}
+
+interface ResponseBody {
+  tenantId: string;
+  thresholds: number[];
+  defaults: readonly number[];
+  override: number[] | null;
+  source: 'tenant' | 'deployment';
+  updatedAt: string | null;
+}
+
+function buildResponse(
+  tenantId: string,
+  override: number[] | null,
+  updatedAt: string | null
+): ResponseBody {
+  const effective =
+    override && override.length > 0 ? override : [...DEFAULT_STORAGE_THRESHOLDS];
+  return {
+    tenantId,
+    thresholds: effective,
+    defaults: DEFAULT_STORAGE_THRESHOLDS,
+    override,
+    source: override && override.length > 0 ? 'tenant' : 'deployment',
+    updatedAt,
+  };
+}
+
+export interface TenantStorageThresholdsRouterDeps {
+  dataAdapter: DataAdapter;
+}
+
+export function createTenantStorageThresholdsRouter(
+  deps: TenantStorageThresholdsRouterDeps
+): Router {
+  const router = Router({ mergeParams: true });
+
+  // GET /:tenantId/storage/thresholds
+  router.get(
+    '/:tenantId/storage/thresholds',
+    requireUserOrTenantScopes({
+      scopes: ['tenants.read'],
+      tenantIdFromReq: (req) => (req.params.tenantId as string) || undefined,
+    }),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId ?? '');
+        if (!isValidTenantId(tenantId)) {
+          sendError(res, 400, 'INVALID_TENANT_ID', 'Invalid tenantId');
+          return;
+        }
+        const record = await getTenantRecord(deps.dataAdapter, tenantId);
+        const override =
+          record.storageThresholds && record.storageThresholds.length > 0
+            ? record.storageThresholds
+            : null;
+        res
+          .status(200)
+          .json(buildResponse(tenantId, override, record.updatedAt));
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  // PUT /:tenantId/storage/thresholds
+  router.put(
+    '/:tenantId/storage/thresholds',
+    requireUserOrTenantScopes({
+      scopes: ['tenants.write'],
+      tenantIdFromReq: (req) => (req.params.tenantId as string) || undefined,
+    }),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId ?? '');
+        if (!isValidTenantId(tenantId)) {
+          sendError(res, 400, 'INVALID_TENANT_ID', 'Invalid tenantId');
+          return;
+        }
+        const body = (req.body || {}) as { thresholds?: unknown };
+        if (!('thresholds' in body)) {
+          sendError(
+            res,
+            400,
+            'INVALID_BODY',
+            'Request body must include `thresholds`',
+            {
+              constraints: {
+                maxCount: STORAGE_THRESHOLDS_MAX_COUNT,
+                minExclusive: STORAGE_THRESHOLD_MIN_EXCLUSIVE,
+                max: STORAGE_THRESHOLD_MAX,
+              },
+            }
+          );
+          return;
+        }
+        let normalized: number[] | null;
+        try {
+          normalized = validateStorageThresholdsInput(body.thresholds);
+        } catch (err) {
+          sendError(
+            res,
+            400,
+            'INVALID_BODY',
+            err instanceof Error ? err.message : 'Invalid thresholds payload',
+            {
+              constraints: {
+                maxCount: STORAGE_THRESHOLDS_MAX_COUNT,
+                minExclusive: STORAGE_THRESHOLD_MIN_EXCLUSIVE,
+                max: STORAGE_THRESHOLD_MAX,
+              },
+            }
+          );
+          return;
+        }
+        // PUT requires a concrete array. Use DELETE to clear.
+        if (normalized === null) {
+          sendError(
+            res,
+            400,
+            'INVALID_BODY',
+            'PUT requires a non-null `thresholds` array; use DELETE to clear the override'
+          );
+          return;
+        }
+        const updated = await patchTenantRecord(deps.dataAdapter, tenantId, {
+          storageThresholds: normalized,
+        });
+        res
+          .status(200)
+          .json(buildResponse(tenantId, normalized, updated.updatedAt));
+      } catch (err) {
+        logger.error({ err }, 'PUT /storage/thresholds failed');
+        next(err);
+      }
+    }
+  );
+
+  // DELETE /:tenantId/storage/thresholds \u2014 revert to defaults.
+  router.delete(
+    '/:tenantId/storage/thresholds',
+    requireUserOrTenantScopes({
+      scopes: ['tenants.write'],
+      tenantIdFromReq: (req) => (req.params.tenantId as string) || undefined,
+    }),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId ?? '');
+        if (!isValidTenantId(tenantId)) {
+          sendError(res, 400, 'INVALID_TENANT_ID', 'Invalid tenantId');
+          return;
+        }
+        const updated = await patchTenantRecord(deps.dataAdapter, tenantId, {
+          storageThresholds: null,
+        });
+        res.status(200).json(buildResponse(tenantId, null, updated.updatedAt));
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  return router;
+}

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -117,6 +117,7 @@ import { createTenantWebhookSecretsRouter } from './routes/tenantWebhookSecretsV
 import { createTenantPluginsRouter } from './routes/tenantPluginsV1.js';
 import { createTenantFeaturesRouter } from './routes/tenantFeaturesV1.js';
 import { createTenantTrashConfigRouter } from './routes/tenantTrashConfigV1.js';
+import { createTenantStorageThresholdsRouter } from './routes/tenantStorageThresholdsV1.js';
 import { createHostWebhookEventsRouter } from './routes/hostWebhookEventsV1.js';
 import { createRequireFeature } from './middleware/requireFeature.js';
 import { createPhotosV1Router, createLibraryTagsRouter } from './routes/photosV1.js';
@@ -583,6 +584,26 @@ app.use(
   '/api/v1/tenants',
   hostApiKeyAuth,
   tenantTrashConfigRouter
+);
+
+// Per-tenant storage threshold config (issue #196). Drives
+// `tenant.storage.threshold_crossed` / `_cleared` webhook events.
+// Host-API-key-only (`tenants.write` for mutations, `tenants.read` for
+// GET); also accessible to tenant owners via Bearer auth on the
+// `/api/v1/tenants` prefix. Mounted on both prefixes for parity with
+// the trash config router.
+const tenantStorageThresholdsRouter = createTenantStorageThresholdsRouter({
+  dataAdapter,
+});
+app.use(
+  '/v1/tenants',
+  hostApiKeyAuth,
+  tenantStorageThresholdsRouter
+);
+app.use(
+  '/api/v1/tenants',
+  hostApiKeyAuth,
+  tenantStorageThresholdsRouter
 );
 
 // Public webhook event catalog (issue #176). Global — not per-tenant —

--- a/functions/src/services/metering/eventCatalog.ts
+++ b/functions/src/services/metering/eventCatalog.ts
@@ -45,7 +45,7 @@
  *
  * Use a date string so the value is human-readable in logs.
  */
-export const CATALOG_VERSION = '2026-06-29';
+export const CATALOG_VERSION = '2026-06-30';
 
 /**
  * JSON Schema describing the `meta` payload for a single event type.
@@ -224,6 +224,40 @@ export const EVENT_CATALOG = [
       usageBytes: S_NUMBER,
       date: S_STRING,
     }),
+  },
+  {
+    name: 'tenant.storage.threshold_crossed',
+    version: 1,
+    billable: false,
+    description:
+      'Per-tenant storage usage crossed a configured threshold (issue #196). Hysteresis prevents re-firing until usage drops 5% below and crosses up again. Hosts drive upsell / hard-cap flows from this event.',
+    schema: metaSchema(
+      {
+        tenantId: S_STRING,
+        threshold: S_NUMBER,
+        usedBytes: S_NUMBER,
+        quotaBytes: S_NUMBER,
+        crossedAt: S_ISO_DATE,
+      },
+      ['tenantId', 'threshold', 'usedBytes', 'quotaBytes', 'crossedAt']
+    ),
+  },
+  {
+    name: 'tenant.storage.threshold_cleared',
+    version: 1,
+    billable: false,
+    description:
+      'Per-tenant storage usage dropped at least 5% below a previously-crossed threshold (issue #196). Emitted exactly once per crossing direction; pairs with `tenant.storage.threshold_crossed`.',
+    schema: metaSchema(
+      {
+        tenantId: S_STRING,
+        threshold: S_NUMBER,
+        usedBytes: S_NUMBER,
+        quotaBytes: S_NUMBER,
+        clearedAt: S_ISO_DATE,
+      },
+      ['tenantId', 'threshold', 'usedBytes', 'quotaBytes', 'clearedAt']
+    ),
   },
   {
     name: 'share.viewed',

--- a/functions/src/services/tenant/storageThresholdEvaluator.test.ts
+++ b/functions/src/services/tenant/storageThresholdEvaluator.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Unit tests for the per-tenant storage threshold evaluator (issue #196).
+ *
+ * Covers:
+ *   - First crossing emits `tenant.storage.threshold_crossed` once.
+ *   - No double-fire on subsequent evaluations while still crossed.
+ *   - Clearing (with 5% hysteresis) emits `tenant.storage.threshold_cleared`.
+ *   - Re-crossing after clear emits `_crossed` again.
+ *   - Default thresholds apply when no per-tenant override is set.
+ *   - Custom thresholds override defaults.
+ *   - quotaBytes null / 0 short-circuits silently.
+ *   - State is persisted across calls (so re-init doesn't re-fire).
+ *
+ * Note: AuraPix already has a number of pre-existing TS warnings in
+ * test files (vi.fn() generic vs DataAdapter index signature). We keep
+ * a tiny private adapter helper here that uses `any`-style typing only
+ * inside the test scope, never in production code.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MeteringBus,
+  type MeteringSink,
+  type NormalizedMeteringEvent,
+} from '../metering/MeteringBus.js';
+import { setMeteringBus } from '../metering/index.js';
+import {
+  computeTransitions,
+  evaluateStorageThresholds,
+  resolveThresholds,
+} from './storageThresholdEvaluator.js';
+import {
+  DEFAULT_STORAGE_THRESHOLDS,
+  STORAGE_THRESHOLD_HYSTERESIS,
+  TENANTS_COLLECTION,
+  thresholdStateKey,
+  type TenantRecord,
+} from '../../models/TenantRecord.js';
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+
+class CapturingSink implements MeteringSink {
+  events: NormalizedMeteringEvent[] = [];
+  async deliver(events: NormalizedMeteringEvent[]): Promise<void> {
+    this.events.push(...events);
+  }
+}
+
+function makeAdapter(seed: Record<string, unknown> = {}): DataAdapter {
+  const docs = new Map<string, unknown>(Object.entries(seed));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const adapter: any = {
+    storeData: vi.fn(async (collection: string, id: string, data: unknown) => {
+      docs.set(`${collection}::${id}`, data);
+    }),
+    fetchData: vi.fn(async (collection: string, id: string) => {
+      return docs.get(`${collection}::${id}`) ?? null;
+    }),
+    queryData: vi.fn(async () => []),
+    updateData: vi.fn(),
+    deleteData: vi.fn(),
+    exists: vi.fn(async () => false),
+    listIds: vi.fn(async () => []),
+    getPhoto: vi.fn(async () => null),
+  };
+  // Expose the docs map for assertions.
+  adapter.__docs = docs;
+  return adapter as DataAdapter;
+}
+
+function makeRecord(overrides: Partial<TenantRecord> = {}): TenantRecord {
+  return {
+    id: 't1',
+    quotaBytes: 1000,
+    createdAt: '2026-06-30T00:00:00.000Z',
+    updatedAt: '2026-06-30T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('storageThresholdEvaluator', () => {
+  let sink: CapturingSink;
+
+  beforeEach(() => {
+    sink = new CapturingSink();
+    setMeteringBus(
+      new MeteringBus({ sink, flushIntervalMs: 1000, maxBatchSize: 100 })
+    );
+  });
+
+  afterEach(() => {
+    setMeteringBus(null);
+    vi.restoreAllMocks();
+  });
+
+  describe('resolveThresholds()', () => {
+    it('returns defaults when no override is set', () => {
+      expect(resolveThresholds(makeRecord())).toEqual([
+        ...DEFAULT_STORAGE_THRESHOLDS,
+      ]);
+    });
+
+    it('returns defaults when override is empty', () => {
+      expect(
+        resolveThresholds(makeRecord({ storageThresholds: [] }))
+      ).toEqual([...DEFAULT_STORAGE_THRESHOLDS]);
+    });
+
+    it('uses tenant override when present, sorted and deduped', () => {
+      expect(
+        resolveThresholds(
+          makeRecord({ storageThresholds: [0.9, 0.5, 0.9001, 1.2] })
+        )
+      ).toEqual([0.5, 0.9, 1.2]);
+    });
+  });
+
+  describe('computeTransitions()', () => {
+    const now = new Date('2026-06-30T12:00:00.000Z');
+
+    it('first crossing emits one crossed transition', () => {
+      const { nextState, transitions } = computeTransitions({
+        thresholds: [0.5, 0.8, 0.95, 1.0],
+        usedBytes: 850,
+        quotaBytes: 1000,
+        previousState: {},
+        now,
+      });
+      expect(transitions).toEqual([
+        { threshold: 0.5, direction: 'crossed' },
+        { threshold: 0.8, direction: 'crossed' },
+      ]);
+      expect(nextState[thresholdStateKey(0.5)]?.crossed).toBe(true);
+      expect(nextState[thresholdStateKey(0.8)]?.crossed).toBe(true);
+      expect(nextState[thresholdStateKey(0.95)]?.crossed).toBe(false);
+    });
+
+    it('does not double-fire while still in the crossed band', () => {
+      const prior = {
+        [thresholdStateKey(0.8)]: {
+          crossed: true,
+          lastCrossedAt: '2026-06-29T00:00:00.000Z',
+        },
+      };
+      const { transitions } = computeTransitions({
+        thresholds: [0.8],
+        usedBytes: 900,
+        quotaBytes: 1000,
+        previousState: prior,
+        now,
+      });
+      expect(transitions).toEqual([]);
+    });
+
+    it('clears only after hysteresis band is satisfied', () => {
+      const prior = {
+        [thresholdStateKey(0.8)]: {
+          crossed: true,
+          lastCrossedAt: '2026-06-29T00:00:00.000Z',
+        },
+      };
+      // 0.8 - 0.05 = 0.75 \u2192 760 / 1000 = 0.76 should NOT clear yet.
+      const stillHigh = computeTransitions({
+        thresholds: [0.8],
+        usedBytes: 760,
+        quotaBytes: 1000,
+        previousState: prior,
+        now,
+      });
+      expect(stillHigh.transitions).toEqual([]);
+
+      // 750 / 1000 = 0.75 == 0.8 - 0.05 \u2192 boundary should clear.
+      const justClears = computeTransitions({
+        thresholds: [0.8],
+        usedBytes: 750,
+        quotaBytes: 1000,
+        previousState: prior,
+        now,
+      });
+      expect(justClears.transitions).toEqual([
+        { threshold: 0.8, direction: 'cleared' },
+      ]);
+      expect(justClears.nextState[thresholdStateKey(0.8)]?.crossed).toBe(false);
+    });
+
+    it('re-crosses after a clear emits crossed again', () => {
+      // Phase 1: cross.
+      const phase1 = computeTransitions({
+        thresholds: [0.8],
+        usedBytes: 850,
+        quotaBytes: 1000,
+        previousState: {},
+        now,
+      });
+      expect(phase1.transitions).toEqual([
+        { threshold: 0.8, direction: 'crossed' },
+      ]);
+
+      // Phase 2: clear (drop well below hysteresis band).
+      const phase2 = computeTransitions({
+        thresholds: [0.8],
+        usedBytes: 700,
+        quotaBytes: 1000,
+        previousState: phase1.nextState,
+        now,
+      });
+      expect(phase2.transitions).toEqual([
+        { threshold: 0.8, direction: 'cleared' },
+      ]);
+
+      // Phase 3: re-cross.
+      const phase3 = computeTransitions({
+        thresholds: [0.8],
+        usedBytes: 850,
+        quotaBytes: 1000,
+        previousState: phase2.nextState,
+        now,
+      });
+      expect(phase3.transitions).toEqual([
+        { threshold: 0.8, direction: 'crossed' },
+      ]);
+    });
+
+    it('short-circuits when quotaBytes <= 0', () => {
+      const result = computeTransitions({
+        thresholds: [0.5],
+        usedBytes: 1000,
+        quotaBytes: 0,
+        previousState: {},
+        now,
+      });
+      expect(result.transitions).toEqual([]);
+    });
+
+    it('preserves observability fields on no-change ticks', () => {
+      const prior = {
+        [thresholdStateKey(0.8)]: {
+          crossed: true,
+          lastCrossedAt: '2026-06-29T00:00:00.000Z',
+        },
+      };
+      const { nextState } = computeTransitions({
+        thresholds: [0.8],
+        usedBytes: 900,
+        quotaBytes: 1000,
+        previousState: prior,
+        now,
+      });
+      expect(nextState[thresholdStateKey(0.8)]?.lastCrossedAt).toBe(
+        '2026-06-29T00:00:00.000Z'
+      );
+    });
+
+    it('honors the documented hysteresis constant', () => {
+      // Guard against accidental changes to the constant value.
+      expect(STORAGE_THRESHOLD_HYSTERESIS).toBeCloseTo(0.05);
+    });
+  });
+
+  describe('evaluateStorageThresholds() integration', () => {
+    it('emits the crossed event and persists state', async () => {
+      const adapter = makeAdapter({
+        [`${TENANTS_COLLECTION}::t1`]: makeRecord({ quotaBytes: 1000 }),
+      });
+      const bus = new MeteringBus({
+        sink,
+        flushIntervalMs: 1000,
+        maxBatchSize: 100,
+      });
+      setMeteringBus(bus);
+
+      const { transitions } = await evaluateStorageThresholds({
+        dataAdapter: adapter,
+        tenantId: 't1',
+        usedBytes: 850,
+        now: () => new Date('2026-06-30T12:00:00.000Z'),
+      });
+      await bus.flush();
+
+      expect(transitions.map((t) => t.direction)).toEqual([
+        'crossed',
+        'crossed',
+      ]);
+      expect(sink.events).toHaveLength(2);
+      expect(sink.events[0]!.type).toBe('tenant.storage.threshold_crossed');
+      expect(sink.events[0]!.meta).toMatchObject({
+        tenantId: 't1',
+        usedBytes: 850,
+        quotaBytes: 1000,
+        crossedAt: '2026-06-30T12:00:00.000Z',
+      });
+
+      // Persisted state should now have both crossed=true.
+      const persisted = await adapter.fetchData<TenantRecord>(
+        TENANTS_COLLECTION,
+        't1'
+      );
+      expect(persisted?.storageThresholdState?.[thresholdStateKey(0.5)]?.crossed).toBe(
+        true
+      );
+      expect(persisted?.storageThresholdState?.[thresholdStateKey(0.8)]?.crossed).toBe(
+        true
+      );
+    });
+
+    it('does not re-fire on a second evaluation at the same usage', async () => {
+      const adapter = makeAdapter({
+        [`${TENANTS_COLLECTION}::t1`]: makeRecord({ quotaBytes: 1000 }),
+      });
+      const bus = new MeteringBus({
+        sink,
+        flushIntervalMs: 1000,
+        maxBatchSize: 100,
+      });
+      setMeteringBus(bus);
+
+      await evaluateStorageThresholds({
+        dataAdapter: adapter,
+        tenantId: 't1',
+        usedBytes: 850,
+        now: () => new Date('2026-06-30T12:00:00.000Z'),
+      });
+      await evaluateStorageThresholds({
+        dataAdapter: adapter,
+        tenantId: 't1',
+        usedBytes: 860,
+        now: () => new Date('2026-06-30T12:01:00.000Z'),
+      });
+      await bus.flush();
+
+      // Only first call should have emitted.
+      expect(sink.events.filter((e) => e.type === 'tenant.storage.threshold_crossed'))
+        .toHaveLength(2); // 0.5 + 0.8 from first call only
+    });
+
+    it('emits cleared after usage drops below hysteresis band', async () => {
+      const adapter = makeAdapter({
+        [`${TENANTS_COLLECTION}::t1`]: makeRecord({ quotaBytes: 1000 }),
+      });
+      const bus = new MeteringBus({
+        sink,
+        flushIntervalMs: 1000,
+        maxBatchSize: 100,
+      });
+      setMeteringBus(bus);
+
+      await evaluateStorageThresholds({
+        dataAdapter: adapter,
+        tenantId: 't1',
+        usedBytes: 850,
+        now: () => new Date('2026-06-30T12:00:00.000Z'),
+      });
+      // Drop to 700/1000 = 0.70; 0.8 threshold - 0.05 = 0.75; cleared.
+      // 0.5 threshold - 0.05 = 0.45; 0.70 > 0.45 so 0.5 stays crossed.
+      await evaluateStorageThresholds({
+        dataAdapter: adapter,
+        tenantId: 't1',
+        usedBytes: 700,
+        now: () => new Date('2026-06-30T13:00:00.000Z'),
+      });
+      await bus.flush();
+
+      const clearedEvents = sink.events.filter(
+        (e) => e.type === 'tenant.storage.threshold_cleared'
+      );
+      expect(clearedEvents).toHaveLength(1);
+      expect(clearedEvents[0]!.meta).toMatchObject({
+        threshold: 0.8,
+        usedBytes: 700,
+      });
+    });
+
+    it('uses custom thresholds when set on the tenant doc', async () => {
+      const adapter = makeAdapter({
+        [`${TENANTS_COLLECTION}::t1`]: makeRecord({
+          quotaBytes: 1000,
+          storageThresholds: [0.25, 0.75],
+        }),
+      });
+      const bus = new MeteringBus({
+        sink,
+        flushIntervalMs: 1000,
+        maxBatchSize: 100,
+      });
+      setMeteringBus(bus);
+
+      await evaluateStorageThresholds({
+        dataAdapter: adapter,
+        tenantId: 't1',
+        usedBytes: 300,
+        now: () => new Date('2026-06-30T12:00:00.000Z'),
+      });
+      await bus.flush();
+
+      // 0.25 crossed (300/1000 = 0.30), 0.75 not.
+      const crossed = sink.events.filter(
+        (e) => e.type === 'tenant.storage.threshold_crossed'
+      );
+      expect(crossed).toHaveLength(1);
+      expect(crossed[0]!.meta).toMatchObject({ threshold: 0.25 });
+    });
+
+    it('uses default thresholds when no override is set', async () => {
+      const adapter = makeAdapter({
+        [`${TENANTS_COLLECTION}::t1`]: makeRecord({
+          quotaBytes: 1000,
+          // no storageThresholds
+        }),
+      });
+      const bus = new MeteringBus({
+        sink,
+        flushIntervalMs: 1000,
+        maxBatchSize: 100,
+      });
+      setMeteringBus(bus);
+
+      // 510 / 1000 = 0.51 \u2192 should cross 0.5 (default), not 0.8.
+      await evaluateStorageThresholds({
+        dataAdapter: adapter,
+        tenantId: 't1',
+        usedBytes: 510,
+        now: () => new Date('2026-06-30T12:00:00.000Z'),
+      });
+      await bus.flush();
+
+      const crossed = sink.events.filter(
+        (e) => e.type === 'tenant.storage.threshold_crossed'
+      );
+      expect(crossed).toHaveLength(1);
+      expect(crossed[0]!.meta).toMatchObject({ threshold: 0.5 });
+    });
+
+    it('short-circuits when quotaBytes is null (unlimited)', async () => {
+      const adapter = makeAdapter({
+        [`${TENANTS_COLLECTION}::t1`]: makeRecord({ quotaBytes: null }),
+      });
+      const bus = new MeteringBus({
+        sink,
+        flushIntervalMs: 1000,
+        maxBatchSize: 100,
+      });
+      setMeteringBus(bus);
+
+      const result = await evaluateStorageThresholds({
+        dataAdapter: adapter,
+        tenantId: 't1',
+        usedBytes: 10_000_000,
+        now: () => new Date('2026-06-30T12:00:00.000Z'),
+      });
+      await bus.flush();
+
+      expect(result.transitions).toEqual([]);
+      expect(sink.events).toHaveLength(0);
+    });
+
+    it('short-circuits when quotaBytes is 0 (uploads blocked)', async () => {
+      const adapter = makeAdapter({
+        [`${TENANTS_COLLECTION}::t1`]: makeRecord({ quotaBytes: 0 }),
+      });
+      const bus = new MeteringBus({
+        sink,
+        flushIntervalMs: 1000,
+        maxBatchSize: 100,
+      });
+      setMeteringBus(bus);
+
+      const result = await evaluateStorageThresholds({
+        dataAdapter: adapter,
+        tenantId: 't1',
+        usedBytes: 0,
+        now: () => new Date('2026-06-30T12:00:00.000Z'),
+      });
+      await bus.flush();
+
+      expect(result.transitions).toEqual([]);
+      expect(sink.events).toHaveLength(0);
+    });
+
+    it('swallows fetch errors and returns no transitions', async () => {
+      const adapter = makeAdapter();
+      // Force fetchData to throw.
+      (adapter.fetchData as unknown as { mockImplementation: Function }).mockImplementation(
+        async () => {
+          throw new Error('boom');
+        }
+      );
+
+      const result = await evaluateStorageThresholds({
+        dataAdapter: adapter,
+        tenantId: 't1',
+        usedBytes: 850,
+        now: () => new Date('2026-06-30T12:00:00.000Z'),
+      });
+
+      expect(result.transitions).toEqual([]);
+    });
+  });
+});

--- a/functions/src/services/tenant/storageThresholdEvaluator.ts
+++ b/functions/src/services/tenant/storageThresholdEvaluator.ts
@@ -1,0 +1,282 @@
+/**
+ * Per-tenant storage threshold evaluator (issue #196).
+ *
+ * Given a tenant's current quota and usage, emits webhook events when
+ * usage **crosses** or **clears** a configured threshold. Hosts that
+ * resell AuraPix subscribe to these events to drive billing / upsell /
+ * hard-cap flows without polling `GET /v1/tenants/:id/usage`.
+ *
+ * Design notes:
+ *   - Each threshold fires `tenant.storage.threshold_crossed` at most
+ *     once per crossing direction. After a `_crossed` event the
+ *     threshold is considered "armed for clear"; `_cleared` only fires
+ *     once usage has dropped by at least
+ *     {@link STORAGE_THRESHOLD_HYSTERESIS} below the threshold. This
+ *     keeps webhook traffic quiet when usage hovers right around a
+ *     threshold (#196 acceptance criteria).
+ *   - State is persisted on the tenant doc (`storageThresholdState`),
+ *     so a restart never re-fires events for thresholds that were
+ *     already crossed.
+ *   - Evaluation is piggy-backed on the upload quota check
+ *     (`handlers/images/upload.ts`) and on the trash purge job
+ *     (`jobs/purgeTrash.ts`). No new scheduler.
+ *   - When `quotaBytes` is `null` (unlimited) or `<= 0`, the evaluator
+ *     short-circuits and does nothing \u2014 thresholds are a percentage
+ *     of the cap and only make sense when one is defined.
+ *
+ * The evaluator is **best-effort**: any error reading or writing the
+ * tenant doc is logged at warn level and swallowed. We never want a
+ * threshold-tracking failure to break an upload.
+ */
+
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+import { logger } from '../../utils/logger.js';
+import { emitMeteringEvent } from '../../services/metering/index.js';
+import {
+  DEFAULT_STORAGE_THRESHOLDS,
+  STORAGE_THRESHOLD_HYSTERESIS,
+  TENANTS_COLLECTION,
+  thresholdStateKey,
+  type StorageThresholdState,
+  type TenantRecord,
+} from '../../models/TenantRecord.js';
+import type { TenantId } from '../../domain/tenant/Tenant.js';
+
+export interface EvaluateStorageThresholdsInput {
+  dataAdapter: DataAdapter;
+  tenantId: TenantId;
+  /** Current storage usage in bytes (post-write for uploads, post-purge for trash). */
+  usedBytes: number;
+  /**
+   * Test hook for deterministic `crossedAt` / `clearedAt` values. Defaults
+   * to `new Date()`.
+   */
+  now?: () => Date;
+  /**
+   * Optional pre-fetched tenant record. Callers that already loaded the
+   * record (e.g. the upload handler's quota check) can pass it in to
+   * avoid a second read. The evaluator will still write back to the
+   * data adapter when state changes.
+   */
+  tenantRecord?: TenantRecord;
+}
+
+export interface ThresholdTransition {
+  threshold: number;
+  direction: 'crossed' | 'cleared';
+}
+
+export interface EvaluateStorageThresholdsResult {
+  /**
+   * One entry per threshold that changed state during this evaluation.
+   * In practice usually 0 or 1; multi-step transitions happen when a
+   * single upload spans several thresholds at once.
+   */
+  transitions: ThresholdTransition[];
+}
+
+/**
+ * Resolve the effective threshold list for a tenant. Sorted ascending,
+ * deduped via the canonical {@link thresholdStateKey} representation.
+ */
+export function resolveThresholds(record: TenantRecord | null | undefined): number[] {
+  const raw =
+    record?.storageThresholds && record.storageThresholds.length > 0
+      ? record.storageThresholds
+      : DEFAULT_STORAGE_THRESHOLDS;
+  const seen = new Set<string>();
+  const out: number[] = [];
+  for (const t of raw) {
+    if (!Number.isFinite(t) || t <= 0) continue;
+    const fixed = Number(t.toFixed(3));
+    const key = fixed.toFixed(3);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(fixed);
+  }
+  out.sort((a, b) => a - b);
+  return out;
+}
+
+/**
+ * Pure decision function: given the previous per-threshold state, a
+ * fresh usage reading, and the quota, return the next state plus the
+ * list of transitions (events to fire).
+ *
+ * Hysteresis rule: a threshold flips from `crossed=true` back to
+ * `crossed=false` (and fires `_cleared`) only when
+ *   `usedFraction <= threshold - STORAGE_THRESHOLD_HYSTERESIS`.
+ * This guarantees no oscillation when usage hovers right around the
+ * threshold.
+ *
+ * Exposed for unit tests.
+ */
+export function computeTransitions(args: {
+  thresholds: readonly number[];
+  usedBytes: number;
+  quotaBytes: number;
+  previousState: Record<string, StorageThresholdState>;
+  now: Date;
+}): {
+  nextState: Record<string, StorageThresholdState>;
+  transitions: ThresholdTransition[];
+} {
+  const { thresholds, usedBytes, quotaBytes, previousState, now } = args;
+  const transitions: ThresholdTransition[] = [];
+  const nextState: Record<string, StorageThresholdState> = { ...previousState };
+
+  // Guard: quotaBytes must be > 0 for fractions to be meaningful.
+  if (!Number.isFinite(quotaBytes) || quotaBytes <= 0) {
+    return { nextState, transitions };
+  }
+
+  const usedFraction = Math.max(0, usedBytes) / quotaBytes;
+  const isoNow = now.toISOString();
+
+  for (const threshold of thresholds) {
+    const key = thresholdStateKey(threshold);
+    const prior = previousState[key] ?? { crossed: false };
+
+    if (!prior.crossed && usedFraction >= threshold) {
+      // First time crossing this threshold (or first time since clear).
+      nextState[key] = {
+        ...prior,
+        crossed: true,
+        lastCrossedAt: isoNow,
+      };
+      transitions.push({ threshold, direction: 'crossed' });
+      continue;
+    }
+
+    if (prior.crossed && usedFraction <= threshold - STORAGE_THRESHOLD_HYSTERESIS) {
+      // Cleared, with hysteresis band satisfied.
+      nextState[key] = {
+        ...prior,
+        crossed: false,
+        lastClearedAt: isoNow,
+      };
+      transitions.push({ threshold, direction: 'cleared' });
+      continue;
+    }
+
+    // No change. Carry prior state forward unchanged so we don't
+    // accidentally erase `lastCrossedAt` / `lastClearedAt` observability
+    // fields by writing `undefined` over them.
+    nextState[key] = prior;
+  }
+
+  return { nextState, transitions };
+}
+
+/**
+ * Evaluate the tenant's current usage against its threshold config and
+ * emit any `tenant.storage.threshold_crossed` / `_cleared` events that
+ * are due. Persists updated state back to the tenant doc.
+ *
+ * Never throws \u2014 errors are logged and swallowed so callers can wire
+ * this safely on the hot path (upload quota check, purge job).
+ */
+export async function evaluateStorageThresholds(
+  input: EvaluateStorageThresholdsInput
+): Promise<EvaluateStorageThresholdsResult> {
+  const { dataAdapter, tenantId, usedBytes } = input;
+  const now = (input.now ?? (() => new Date()))();
+  try {
+    // Re-read the tenant record (or accept a pre-fetched one) so we
+    // always update the freshest version. We deliberately don't lock
+    // here; the worst case under racy uploads is a duplicate event,
+    // which is bounded by hysteresis on the next evaluation.
+    const existing =
+      input.tenantRecord ??
+      (await dataAdapter.fetchData<TenantRecord>(TENANTS_COLLECTION, tenantId));
+
+    const quotaBytes = existing?.quotaBytes ?? null;
+    if (quotaBytes === null || quotaBytes <= 0) {
+      // Unlimited quota or no upload allowed at all \u2014 threshold events
+      // do not apply. (`quotaBytes === 0` means uploads are blocked
+      // entirely; firing a "100% full" event there is misleading.)
+      return { transitions: [] };
+    }
+
+    const thresholds = resolveThresholds(existing ?? null);
+    if (thresholds.length === 0) {
+      return { transitions: [] };
+    }
+
+    const previousState = existing?.storageThresholdState ?? {};
+    const { nextState, transitions } = computeTransitions({
+      thresholds,
+      usedBytes,
+      quotaBytes,
+      previousState,
+      now,
+    });
+
+    if (transitions.length === 0) {
+      return { transitions: [] };
+    }
+
+    // Persist state first, then emit. If the write fails we won't
+    // accidentally re-fire on the next call (state stays as previous,
+    // so this evaluation's effects are simply lost \u2014 the next upload
+    // will retry).
+    const nowIso = now.toISOString();
+    const nextRecord: TenantRecord = {
+      id: tenantId,
+      quotaBytes: existing?.quotaBytes ?? quotaBytes,
+      storageThresholds:
+        existing?.storageThresholds === undefined
+          ? null
+          : existing.storageThresholds,
+      storageThresholdState: nextState,
+      createdAt: existing?.createdAt ?? nowIso,
+      updatedAt: nowIso,
+    };
+    await dataAdapter.storeData(TENANTS_COLLECTION, tenantId, nextRecord);
+
+    // Emit one event per transition. Sorted ascending by threshold so
+    // hosts that process the batch in order see the natural progression
+    // (e.g. 0.5 crossed before 0.8).
+    for (const t of transitions) {
+      if (t.direction === 'crossed') {
+        emitMeteringEvent({
+          tenantId,
+          type: 'tenant.storage.threshold_crossed',
+          count: 1,
+          resourceId: thresholdStateKey(t.threshold),
+          occurredAt: nowIso,
+          meta: {
+            tenantId,
+            threshold: t.threshold,
+            usedBytes: Math.max(0, usedBytes),
+            quotaBytes,
+            crossedAt: nowIso,
+          },
+        });
+      } else {
+        emitMeteringEvent({
+          tenantId,
+          type: 'tenant.storage.threshold_cleared',
+          count: 1,
+          resourceId: thresholdStateKey(t.threshold),
+          occurredAt: nowIso,
+          meta: {
+            tenantId,
+            threshold: t.threshold,
+            usedBytes: Math.max(0, usedBytes),
+            quotaBytes,
+            clearedAt: nowIso,
+          },
+        });
+      }
+    }
+
+    return { transitions };
+  } catch (err) {
+    logger.warn(
+      { err, tenantId, usedBytes },
+      'evaluateStorageThresholds: failed; swallowing to keep caller hot path healthy'
+    );
+    return { transitions: [] };
+  }
+}

--- a/functions/src/services/tenant/tenantRecordService.ts
+++ b/functions/src/services/tenant/tenantRecordService.ts
@@ -8,7 +8,11 @@
  */
 import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
 import {
+  STORAGE_THRESHOLDS_MAX_COUNT,
+  STORAGE_THRESHOLD_MAX,
+  STORAGE_THRESHOLD_MIN_EXCLUSIVE,
   TENANTS_COLLECTION,
+  type StorageThresholdState,
   type TenantRecord,
 } from '../../models/TenantRecord.js';
 import type { TenantId } from '../../domain/tenant/Tenant.js';
@@ -57,7 +61,11 @@ export async function getTenantRecord(
 export async function patchTenantRecord(
   dataAdapter: DataAdapter,
   tenantId: TenantId,
-  patch: { quotaBytes?: number | null }
+  patch: {
+    quotaBytes?: number | null;
+    storageThresholds?: number[] | null;
+    storageThresholdState?: Record<string, StorageThresholdState>;
+  }
 ): Promise<TenantRecord> {
   const existing = await dataAdapter.fetchData<TenantRecord>(
     TENANTS_COLLECTION,
@@ -70,6 +78,14 @@ export async function patchTenantRecord(
       patch.quotaBytes === undefined
         ? (existing?.quotaBytes ?? readDefaultQuotaBytes())
         : patch.quotaBytes,
+    storageThresholds:
+      patch.storageThresholds === undefined
+        ? (existing?.storageThresholds ?? null)
+        : patch.storageThresholds,
+    storageThresholdState:
+      patch.storageThresholdState === undefined
+        ? (existing?.storageThresholdState ?? {})
+        : patch.storageThresholdState,
     createdAt: existing?.createdAt ?? now,
     updatedAt: now,
   };
@@ -87,6 +103,59 @@ export function validateQuotaBytesInput(value: unknown): number | null {
     throw new Error('quotaBytes must be a non-negative finite number or null');
   }
   return Math.floor(value);
+}
+
+/**
+ * Validate / normalize a `storageThresholds` payload submitted via the
+ * admin API (issue #196). Returns the normalized, sorted, deduped array
+ * or throws with a stable message.
+ *
+ * Accepts `null` to mean "clear the override and revert to
+ * {@link DEFAULT_STORAGE_THRESHOLDS}".
+ */
+export function validateStorageThresholdsInput(
+  value: unknown
+): number[] | null {
+  if (value === null) return null;
+  if (!Array.isArray(value)) {
+    throw new Error('storageThresholds must be an array of numbers or null');
+  }
+  if (value.length === 0) {
+    throw new Error('storageThresholds must contain at least one entry');
+  }
+  if (value.length > STORAGE_THRESHOLDS_MAX_COUNT) {
+    throw new Error(
+      `storageThresholds may contain at most ${STORAGE_THRESHOLDS_MAX_COUNT} entries`
+    );
+  }
+  const seen = new Set<string>();
+  const normalized: number[] = [];
+  for (const raw of value) {
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+      throw new Error(
+        'storageThresholds entries must be finite numbers'
+      );
+    }
+    if (raw <= STORAGE_THRESHOLD_MIN_EXCLUSIVE) {
+      throw new Error(
+        `storageThresholds entries must be greater than ${STORAGE_THRESHOLD_MIN_EXCLUSIVE}`
+      );
+    }
+    if (raw > STORAGE_THRESHOLD_MAX) {
+      throw new Error(
+        `storageThresholds entries must be ≤ ${STORAGE_THRESHOLD_MAX}`
+      );
+    }
+    // Normalize to 3 decimal places to dedupe near-equal values that
+    // would otherwise produce duplicate state keys.
+    const fixed = Number(raw.toFixed(3));
+    const key = fixed.toFixed(3);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(fixed);
+  }
+  normalized.sort((a, b) => a - b);
+  return normalized;
 }
 
 /** Exposed for tests. */


### PR DESCRIPTION
## Summary

Implements per-tenant storage threshold notifications so hosts that resell AuraPix can drive billing / upsell / hard-cap flows without polling `GET /v1/tenants/:id/usage`. Two new webhook events fire on the existing host webhook pipeline (signing + rotation from #161 already covers auth) whenever a tenant's storage usage **crosses** or **clears** a configured threshold.

## Changes

### New webhook events (registered in `eventCatalog.ts`)
- `tenant.storage.threshold_crossed` — payload: `tenantId`, `threshold`, `usedBytes`, `quotaBytes`, `crossedAt`.
- `tenant.storage.threshold_cleared` — payload: `tenantId`, `threshold`, `usedBytes`, `quotaBytes`, `clearedAt`.
- `CATALOG_VERSION` bumped to `2026-06-30`; both events now appear in `GET /v1/host/webhook-events` automatically (#176).

### Hysteresis (no flapping)
- `STORAGE_THRESHOLD_HYSTERESIS = 0.05` (5% of quota).
- A threshold fires `_crossed` at most once per crossing direction; `_cleared` only fires once usage has dropped at least 5% below and then crosses up again.
- State persisted on the tenant doc (`storageThresholdState`) so a restart never re-fires events for already-crossed thresholds.

### Default thresholds
- `[0.5, 0.8, 0.95, 1.0]`. Values up to `1.5` allowed on a per-tenant basis for overage alerting.

### Per-tenant config endpoint
- `GET    /v1/tenants/:tenantId/storage/thresholds` (`tenants.read`)
- `PUT    /v1/tenants/:tenantId/storage/thresholds` (`tenants.write`) — body `{ "thresholds": number[] }`
- `DELETE /v1/tenants/:tenantId/storage/thresholds` (`tenants.write`) — revert to defaults
- Validates: 1–8 entries, each in `(0, 1.5]`, dedupes (3-decimal normalization), sorts ascending. Mounted on both `/v1/tenants` and `/api/v1/tenants` like the other tenant routers.

### Evaluation cadence (no new scheduler)
- **Upload path** (`handlers/images/upload.ts`): after a successful upload, computes post-upload `usedBytes` and invokes the evaluator (fire-and-forget so it never blocks the response).
- **Trash purge job** (`jobs/purgeTrash.ts`): after each tenant's purge, re-evaluates so `_cleared` events fire when reclaimed bytes bring usage back below a previously-crossed threshold. Requires a `usageStore` to be wired (optional; skipped silently when not available — the next upload's piggy-backed evaluation will catch up).

### Safety
- Evaluator is best-effort: any error reading or writing the tenant doc is logged at warn and swallowed so it can never break the upload hot path.

## Testing

- **31 new tests** added (all passing):
  - `services/tenant/storageThresholdEvaluator.test.ts` — 18 tests: `resolveThresholds()`, pure `computeTransitions()` decision function (first crossing, no double-fire, clear-with-hysteresis, re-cross, observability-field preservation, quota=0 / null short-circuit), and end-to-end `evaluateStorageThresholds()` integration (event emission, persistence, custom thresholds, default thresholds, error swallowing).
  - `routes/tenantStorageThresholdsV1.test.ts` — 13 tests: auth (401/403), scope checks, validation (missing body, null thresholds, out-of-range, >8 entries), happy-path PUT with normalization, overage values >1.0, DELETE reverting to defaults.
- Full test suite: 643 passing, 13 failing (same 13 pre-existing failures on `main` in `test/routes/{tenantUsersV1,auditEventsV1,photosV1}.test.ts`; none of those files were touched).
- `tsc --noEmit`: 0 new errors in changed files (33 pre-existing baseline errors unchanged).

## Acceptance criteria checklist

- [x] `tenant.storage.threshold_crossed` and `tenant.storage.threshold_cleared` emitted on the existing webhook pipeline with correct signing.
- [x] Hysteresis: a threshold does not re-fire `crossed` until usage has dropped ≥5% below and then crossed up again.
- [x] `PUT /v1/tenants/{tenantId}/storage/thresholds` requires `tenants.write`; validates range and length.
- [x] Events appear in `GET /v1/host/webhook-events` catalog (#176).
- [x] Unit tests cover: first crossing, no double-fire, clear-then-recross, default thresholds, custom thresholds.
- [x] Docs updated under `docs/features/usage-and-billing.md` (+ regenerated `docs/features/metering-events.md`).

## Notes / caveats

- The issue body used `tenants:write` (colon form), but the codebase uses `tenants.write` (dot form) consistently across all other routers and the `TenantApiKeyScope` enum — used the codebase convention.
- `runPurgeTrashJob` got an **optional** `usageStore` parameter for the `_cleared` evaluation in the purge path. Wiring it from production scheduler entrypoint is left to whoever wires the production purge job (the production wiring already lives outside `runPurgeTrashJob` itself; the upload-path evaluation alone satisfies the acceptance criteria, and the purge-path evaluation is opportunistic).

Fixes rwrife/AuraPix#196