### PR TITLE
feat: add edit presets (save + apply to many photos)

### DIFF
--- a/docs/features/metering-events.md
+++ b/docs/features/metering-events.md
@@ -26,7 +26,7 @@ discarded; there is no outbound traffic.
 > ⚠️ This table is auto-generated from `functions/src/services/metering/eventCatalog.ts`.
 > Do not hand-edit; run `node scripts/generate-event-catalog-docs.mjs` after changing the registry.
 >
-> **Catalog version:** `2026-06-30` — the same string is stamped on every outbound webhook envelope and returned by `GET /v1/host/webhook-events`.
+> **Catalog version:** `2026-07-01` — the same string is stamped on every outbound webhook envelope and returned by `GET /v1/host/webhook-events`.
 
 | `type` | Version | Billable | Description |
 | --- | --- | --- | --- |
@@ -34,6 +34,7 @@ discarded; there is no outbound traffic.
 | `image.processed` | 1 | ✅ | A derivative variant (thumbnail / preview) was written. One event per variant. |
 | `signed_url.issued` | 1 | ✅ | A signed URL was minted for a user or share grant. |
 | `edit.applied` | 1 | ✅ | A non-destructive edit version was committed for a photo. |
+| `edit_preset.applied` | 1 | — | A develop preset (issue #197) was applied to a batch of photos. One event per apply call, regardless of N. Per-photo commits still emit `edit.applied`. |
 | `bulk.batch` | 1 | ✅ | A `POST /v1/photos:batch` call completed. One event per call regardless of N. |
 | `user.active` | 1 | ✅ | First end-user request of the UTC day for `(tenantId, userId)`. The per-seat billing signal. |
 | `user.provisioned` | 1 | — | A new tenant membership was created. |

--- a/docs/features/plugin-editing-system.md
+++ b/docs/features/plugin-editing-system.md
@@ -71,3 +71,102 @@ Idempotent no-op transitions emit no event so host billing stays stable.
 - Workspace/plan-based plugin enable/disable policy
 - Additional plugin set: exposure/white-balance/highlights
 - Data storage model for edit versions/history
+
+## Develop presets — save + apply to many photos (issue #197)
+Lightroom-style "sync settings": save the edit recipe of one photo as a
+reusable **preset** and apply it to a selection of other photos. Presets
+are a saved-and-labelled `EditRecipe` — they reuse the exact same
+executor pipeline as the single-photo `POST /edits/:libraryId/:photoId`
+surface, so there is no new render path to reason about.
+
+### Storage
+- Collection: `tenantEditPresets`
+- Document id: composite `"{tenantId}__{presetId}"` (keeps flat KV
+  adapters tenant-safe by construction)
+- Shape:
+  ```jsonc
+  {
+    "id": "<uuid>",
+    "tenantId": "<tenantId>",
+    "name": "Warm Tone",
+    "recipe": {
+      "recipeVersion": 1,
+      "operations": [
+        { "type": "adjust", "params": { "brightness": 0.1 }, "order": 0 }
+      ]
+    },
+    "createdBy": "<uid or host key id>",
+    "createdAt": "<ISO8601>",
+    "updatedAt": "<ISO8601>"
+  }
+  ```
+- **Caps:** 500 presets per tenant; every preset is strictly
+  tenant-scoped (never global, never cross-tenant).
+
+### Endpoints
+All endpoints accept EITHER a Firebase user token (with an appropriate
+tenant-member role) OR a host API key carrying the matching scope. All
+are mounted under both `/v1/tenants/...` (canonical) and
+`/api/v1/tenants/...` (legacy in-product path).
+
+- `POST /v1/tenants/:tenantId/edit-presets` — create a preset.
+  Body: either `{ name, recipe }` or `{ name, fromPhotoId }`. When
+  `fromPhotoId` is supplied, the current edit version of that photo is
+  copied as the preset's recipe. Requires `edit-presets.write` scope /
+  `editor+` role.
+- `GET /v1/tenants/:tenantId/edit-presets` — list all presets in the
+  tenant, sorted by `createdAt` ascending. Requires `edit-presets.read`
+  scope / `viewer+` role.
+- `DELETE /v1/tenants/:tenantId/edit-presets/:presetId` — remove a
+  preset. Returns 404 when unknown. Requires `edit-presets.write` scope
+  / `editor+` role.
+- `POST /v1/tenants/:tenantId/edit-presets/:presetId/apply` — bulk apply
+  a preset to up to 200 photoIds. Body: `{ photoIds: string[] }`.
+  Requires `edit-presets.write` scope / `editor+` role. Supports
+  `Idempotency-Key` so retries return the same body without re-committing
+  edits or re-emitting metering events. Cross-tenant photoIds fail the
+  WHOLE batch with HTTP 400 `CROSS_TENANT_PHOTO_ID`, mirroring the
+  bulk-op contract from #142.
+
+### Response shape for apply
+```jsonc
+{
+  "presetId": "<uuid>",
+  "requested": 3,
+  "applied": 2,
+  "failed": 1,
+  "results": [
+    { "photoId": "a", "status": "applied", "version": 4 },
+    { "photoId": "b", "status": "applied", "version": 2 },
+    { "photoId": "c", "status": "error",
+      "error": { "code": "PHOTO_NOT_FOUND", "message": "..." } }
+  ]
+}
+```
+Partial success is expected — the request itself is 200; per-photo
+outcomes live in `results[]`.
+
+### Enforcement
+- Recipe validation on create runs the same `validateOperations` used by
+  the single-photo executor, so a preset cannot store a recipe the
+  executor would refuse.
+- Apply re-checks the per-tenant plugin allowlist per photo. If a plugin
+  was disabled AFTER a preset was created, applying the preset yields
+  per-photo `status: "error"` with code `plugin_disabled_for_tenant` and
+  emits `plugin.blocked` (as usual for allowlist-blocked ops).
+- Cross-tenant photoIds are rejected batch-wide, not partially.
+
+### Metering events
+- `edit.applied` — emitted **per successfully edited photo** in the apply
+  batch (identical shape to the single-photo pipeline). Includes
+  `meta.viaPreset: true` and `meta.presetId` so hosts can attribute
+  applies to preset usage.
+- `edit_preset.applied` — emitted **once per apply call**, regardless of
+  batch outcome. Meta: `{ presetId, photoCount, succeeded, failed }`.
+  Non-billable (a signal for analytics/product); the billable event is
+  the per-photo `edit.applied`.
+- `plugin.ran` continues to fire per-op on success, unchanged.
+
+### API key scopes
+- `edit-presets.read` — list.
+- `edit-presets.write` — create, delete, apply.

--- a/functions/src/models/EditPreset.ts
+++ b/functions/src/models/EditPreset.ts
@@ -1,0 +1,110 @@
+/**
+ * Per-tenant edit presets — "develop presets" / Lightroom Sync Settings
+ * (issue #197).
+ *
+ * A photographer working in a tenant edits ONE photo (adjust exposure, apply
+ * a crop, set a filter), then saves the resulting edit recipe as a named
+ * preset and applies it across a selection of other photos from the same
+ * shoot. This is the single most common Lightroom workflow AuraPix's edit
+ * pipeline was missing.
+ *
+ * Storage shape: one document per preset under
+ * `tenantEditPresets/{tenantId__presetId}`. Composite ids keep the data
+ * partitioned by tenant while remaining easy to query with the flat
+ * key/value adapter (LocalJsonData, FirestoreData). A first-class
+ * `tenantId` field on every record supports the equality-query used by
+ * offboarding / listing.
+ *
+ * The recipe is the exact same JSON blob the edit pipeline already
+ * consumes on `POST /edits/:libraryId/:photoId` — no new processing
+ * path is introduced. Apply-time enforcement (per-tenant plugin
+ * allowlist, recipe version check, operation validation) happens at
+ * commit-time in the shared executor.
+ *
+ * Multi-tenant hard rules:
+ *   - Presets are STRICTLY tenant-scoped. Never global. Never cross-tenant.
+ *   - Apply-time cross-tenant photoIds return HTTP 400 for the whole batch.
+ *   - Per-tenant preset count is capped at 500 to bound storage.
+ */
+
+import type { EditOperation } from './Photo.js';
+
+/**
+ * Recipe format stored on a preset. Matches the shape validated by
+ * `ApplyEditsSchema` in `utils/validation.ts` — the same executor
+ * consumes both, so callers get identical semantics whether they apply
+ * a recipe inline or via a preset.
+ */
+export interface EditPresetRecipe {
+  /** Contract version, currently `1`. See EDIT_RECIPE_VERSION. */
+  recipeVersion: number;
+  /** Ordered list of edit operations. */
+  operations: EditOperation[];
+  /**
+   * Optional free-form description carried onto every edit version
+   * committed via this preset. Kept small; the DB does not truncate.
+   */
+  description?: string;
+}
+
+/**
+ * A saved preset. Stored at `tenantEditPresets/{tenantId}__{presetId}`.
+ */
+export interface EditPresetRecord {
+  /** Preset id (UUID). Doubles as the URL segment. */
+  id: string;
+  /** Tenant that owns the preset. Enforced on read + write. */
+  tenantId: string;
+  /** Human-readable name shown in the "Sync Settings" menu. 1–120 chars. */
+  name: string;
+  /** The recipe JSON applied at apply-time. */
+  recipe: EditPresetRecipe;
+  /**
+   * Principal that created the preset. Either a user uid or a host API
+   * key id (`tak_...`). Null for legacy records written before this
+   * field existed (there are none today).
+   */
+  createdBy: string;
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
+  /** ISO-8601 last-modified timestamp. */
+  updatedAt: string;
+}
+
+/**
+ * Flat collection name (LocalJsonData / FirestoreData both use the flat
+ * key/value shape from `DataAdapter`). Composite ids namespace records
+ * per tenant.
+ */
+export const EDIT_PRESETS_COLLECTION = 'tenantEditPresets';
+
+/**
+ * Build the composite document id used to store a preset in the flat
+ * key/value adapter. Format: `{tenantId}__{presetId}`.
+ *
+ * Mirrors the pattern used by `tenantMemberDocId` — keeps records
+ * partitioned per tenant without requiring a nested-collection API on
+ * the adapter interface.
+ */
+export function editPresetDocId(tenantId: string, presetId: string): string {
+  return `${tenantId}__${presetId}`;
+}
+
+/**
+ * Maximum number of presets per tenant. Bounds storage so a runaway
+ * host cannot fill Firestore with millions of tiny recipe docs. When a
+ * tenant hits the cap the create endpoint returns HTTP 409 with code
+ * `EDIT_PRESET_CAP_EXCEEDED`.
+ */
+export const EDIT_PRESET_MAX_PER_TENANT = 500;
+
+/**
+ * Maximum number of photoIds accepted in a single apply batch. Matches
+ * the bulk photo ops cap from issue #142 so hosts have one number to
+ * remember across the surface.
+ */
+export const EDIT_PRESET_APPLY_MAX_PHOTO_IDS = 200;
+
+/** Bounds on the human-readable preset name. */
+export const EDIT_PRESET_NAME_MIN_LENGTH = 1;
+export const EDIT_PRESET_NAME_MAX_LENGTH = 120;

--- a/functions/src/models/TenantApiKey.ts
+++ b/functions/src/models/TenantApiKey.ts
@@ -25,7 +25,9 @@ export type TenantApiKeyScope =
   | 'plugins.read'
   | 'plugins.write'
   | 'export-presets.read'
-  | 'export-presets.write';
+  | 'export-presets.write'
+  | 'edit-presets.read'
+  | 'edit-presets.write';
 
 export const TENANT_API_KEY_SCOPES: readonly TenantApiKeyScope[] = [
   'usage.read',
@@ -52,6 +54,17 @@ export const TENANT_API_KEY_SCOPES: readonly TenantApiKeyScope[] = [
   'plugins.write',
   'export-presets.read',
   'export-presets.write',
+  /**
+   * `edit-presets.read` / `edit-presets.write` gate the Lightroom-style
+   * develop-preset surface (issue #197). `edit-presets.read` covers
+   * listing presets and reading a single preset's recipe; `.write`
+   * covers create/delete AND apply-to-many. Apply is grouped under the
+   * write scope because it commits new edit versions on N photos.
+   * Firebase user auth on the same endpoints is gated separately by
+   * tenant-member role (editor+ to write/apply, viewer to read).
+   */
+  'edit-presets.read',
+  'edit-presets.write',
 ] as const;
 
 export interface TenantApiKeyRecord {

--- a/functions/src/routes/tenantEditPresetsV1.test.ts
+++ b/functions/src/routes/tenantEditPresetsV1.test.ts
@@ -1,0 +1,679 @@
+/**
+ * Unit tests for the per-tenant edit-presets router (issue #197).
+ *
+ * Mirrors the harness pattern used in tenantStorageThresholdsV1.test.ts —
+ * an in-memory DataAdapter + a small express test server that injects a
+ * fake `req.tenant` / `req.user` before the router runs.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import type { Express } from 'express';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { createTenantEditPresetsRouter } from './tenantEditPresetsV1.js';
+import type { TenantRoleResolver } from './tenantEditPresetsV1.js';
+import {
+  EDIT_PRESETS_COLLECTION,
+  editPresetDocId,
+  type EditPresetRecord,
+} from '../models/EditPreset.js';
+import type { Photo } from '../models/Photo.js';
+
+interface FakeTenant {
+  id: string;
+  scopes: string[];
+  keyId?: string;
+}
+
+function makeApp(
+  data: DataAdapter,
+  inject: (req: express.Request) => void = () => {},
+  resolveTenantRole?: TenantRoleResolver
+): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    inject(req);
+    next();
+  });
+  const router = createTenantEditPresetsRouter({
+    dataAdapter: data,
+    resolveTenantRole,
+  });
+  app.use('/v1/tenants', router);
+  app.use(errorHandler);
+  return app;
+}
+
+function makeMemoryAdapter(seed: Record<string, unknown> = {}): {
+  data: DataAdapter;
+  store: Map<string, Map<string, unknown>>;
+} {
+  const store = new Map<string, Map<string, unknown>>();
+  for (const [key, value] of Object.entries(seed)) {
+    const [collection, id] = key.split('::');
+    if (!collection || !id) continue;
+    if (!store.has(collection)) store.set(collection, new Map());
+    store.get(collection)!.set(id, value);
+  }
+  const get = (collection: string) => {
+    let inner = store.get(collection);
+    if (!inner) {
+      inner = new Map();
+      store.set(collection, inner);
+    }
+    return inner;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: any = {
+    storeData: vi.fn(async (collection: string, id: string, value: unknown) => {
+      get(collection).set(id, value);
+    }),
+    fetchData: vi.fn(async (collection: string, id: string) => {
+      return get(collection).get(id) ?? null;
+    }),
+    queryData: vi.fn(async (collection: string, filters: unknown[]) => {
+      const inner = get(collection);
+      const rows = Array.from(inner.values());
+      // Support only `field == value` filters (all we need here).
+      const filtered = rows.filter((row) => {
+        for (const f of filters as Array<{
+          field: string;
+          operator: string;
+          value: unknown;
+        }>) {
+          if (f.operator === '==') {
+            const r = row as Record<string, unknown>;
+            if (r[f.field] !== f.value) return false;
+          }
+        }
+        return true;
+      });
+      return filtered;
+    }),
+    updateData: vi.fn(async (collection: string, id: string, updates: Record<string, unknown>) => {
+      const inner = get(collection);
+      const existing = (inner.get(id) as Record<string, unknown> | undefined) ?? {};
+      inner.set(id, { ...existing, ...updates });
+    }),
+    deleteData: vi.fn(async (collection: string, id: string) => {
+      get(collection).delete(id);
+    }),
+    exists: vi.fn(async () => false),
+    listIds: vi.fn(async (collection: string) => Array.from(get(collection).keys())),
+    getPhoto: vi.fn(async () => null),
+  };
+  return { data: data as DataAdapter, store };
+}
+
+async function request(
+  app: Express,
+  method: 'get' | 'put' | 'delete' | 'post',
+  path: string,
+  body?: unknown,
+  headers: Record<string, string> = {}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<{ status: number; body: any }> {
+  const { createServer } = await import('node:http');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const server = createServer(app as unknown as (req: any, res: any) => void);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const addr = server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method: method.toUpperCase(),
+      headers: { 'content-type': 'application/json', ...headers },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let parsed: any;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    return { status: res.status, body: parsed };
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+/** Build a minimal `Photo` doc for the memory store. */
+function makePhoto(overrides: Partial<Photo> = {}): Photo {
+  return {
+    id: 'photo-a',
+    libraryId: 'lib-a',
+    tenantId: 'tenant-a',
+    albumIds: [],
+    originalName: 'a.jpg',
+    metadata: {
+      width: 100,
+      height: 100,
+      mimeType: 'image/jpeg',
+      sizeBytes: 1000,
+    },
+    status: 'ready',
+    currentEditVersion: 0,
+    editHistory: [],
+    thumbnailsOutdated: false,
+    createdAt: '2026-06-30T00:00:00.000Z',
+    updatedAt: '2026-06-30T00:00:00.000Z',
+    ...overrides,
+  } as Photo;
+}
+
+const VALID_RECIPE = {
+  recipeVersion: 1,
+  operations: [
+    {
+      type: 'adjust',
+      params: { brightness: 0.1, contrast: 0.05 },
+      order: 0,
+    },
+  ],
+};
+
+describe('createTenantEditPresetsRouter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('POST /:tenantId/edit-presets', () => {
+    it('401 when no auth context is present', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data);
+      const { status } = await request(
+        app,
+        'post',
+        '/v1/tenants/tenant-a/edit-presets',
+        { name: 'Warm', recipe: VALID_RECIPE }
+      );
+      expect(status).toBe(401);
+    });
+
+    it('403 when host API key targets a different tenant', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-other',
+          scopes: ['edit-presets.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'post',
+        '/v1/tenants/tenant-a/edit-presets',
+        { name: 'Warm', recipe: VALID_RECIPE }
+      );
+      expect(status).toBe(403);
+      expect(body.error.code).toBe('CROSS_TENANT_FORBIDDEN');
+    });
+
+    it('403 when host API key lacks edit-presets.write scope', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['edit-presets.read'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'post',
+        '/v1/tenants/tenant-a/edit-presets',
+        { name: 'Warm', recipe: VALID_RECIPE }
+      );
+      expect(status).toBe(403);
+      expect(body.error.code).toBe('INSUFFICIENT_SCOPE');
+    });
+
+    it('403 when a viewer user tries to create a preset', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(
+        data,
+        (req) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (req as any).user = { uid: 'user-1' };
+        },
+        async () => 'viewer'
+      );
+      const { status, body } = await request(
+        app,
+        'post',
+        '/v1/tenants/tenant-a/edit-presets',
+        { name: 'Warm', recipe: VALID_RECIPE }
+      );
+      expect(status).toBe(403);
+      expect(body.error.code).toBe('INSUFFICIENT_ROLE');
+    });
+
+    it('creates a preset from a recipe', async () => {
+      const { data, store } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['edit-presets.write'],
+          keyId: 'tak_1',
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'post',
+        '/v1/tenants/tenant-a/edit-presets',
+        { name: 'Warm Tone', recipe: VALID_RECIPE }
+      );
+      expect(status).toBe(201);
+      expect(body.tenantId).toBe('tenant-a');
+      expect(body.name).toBe('Warm Tone');
+      expect(body.recipe.operations).toHaveLength(1);
+      expect(body.recipe.operations[0].type).toBe('adjust');
+      expect(body.createdBy).toBe('tak_1');
+      expect(typeof body.id).toBe('string');
+
+      // Persisted under composite id.
+      const stored = store
+        .get(EDIT_PRESETS_COLLECTION)
+        ?.get(editPresetDocId('tenant-a', body.id));
+      expect(stored).toBeDefined();
+    });
+
+    it('rejects an invalid recipe operation', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['edit-presets.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'post',
+        '/v1/tenants/tenant-a/edit-presets',
+        {
+          name: 'Bad',
+          recipe: {
+            recipeVersion: 1,
+            operations: [
+              { type: 'nonexistent-op', params: {}, order: 0 },
+            ],
+          },
+        }
+      );
+      expect(status).toBe(400);
+      expect(body.error.code).toBe('INVALID_RECIPE_OPERATIONS');
+    });
+
+    it('creates a preset from an existing photo\'s edits', async () => {
+      const photo = makePhoto({
+        id: 'photo-src',
+        currentEditVersion: 2,
+        editHistory: [
+          {
+            version: 1,
+            recipeVersion: 1,
+            createdAt: '2026-06-30T00:00:00.000Z',
+            createdBy: 'user-x',
+            operations: [
+              { type: 'rotate', params: { degrees: 90 }, order: 0 },
+            ],
+          },
+          {
+            version: 2,
+            recipeVersion: 1,
+            createdAt: '2026-06-30T01:00:00.000Z',
+            createdBy: 'user-x',
+            operations: [
+              { type: 'adjust', params: { brightness: 0.2 }, order: 0 },
+            ],
+          },
+        ],
+      });
+      const { data } = makeMemoryAdapter({
+        [`photos::photo-src`]: photo,
+      });
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['edit-presets.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'post',
+        '/v1/tenants/tenant-a/edit-presets',
+        { name: 'From Photo', fromPhotoId: 'photo-src' }
+      );
+      expect(status).toBe(201);
+      expect(body.recipe.operations).toHaveLength(1);
+      expect(body.recipe.operations[0].type).toBe('adjust');
+      expect(body.recipe.operations[0].params.brightness).toBe(0.2);
+    });
+
+    it('403 when fromPhotoId belongs to a different tenant', async () => {
+      const photo = makePhoto({
+        id: 'photo-src',
+        tenantId: 'tenant-other',
+        currentEditVersion: 1,
+        editHistory: [
+          {
+            version: 1,
+            recipeVersion: 1,
+            createdAt: '2026-06-30T00:00:00.000Z',
+            createdBy: 'user-x',
+            operations: [
+              { type: 'rotate', params: { degrees: 90 }, order: 0 },
+            ],
+          },
+        ],
+      });
+      const { data } = makeMemoryAdapter({
+        [`photos::photo-src`]: photo,
+      });
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['edit-presets.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'post',
+        '/v1/tenants/tenant-a/edit-presets',
+        { name: 'Cross', fromPhotoId: 'photo-src' }
+      );
+      expect(status).toBe(403);
+      expect(body.error.code).toBe('CROSS_TENANT_PHOTO_ID');
+    });
+  });
+
+  describe('GET /:tenantId/edit-presets', () => {
+    it('viewers may list', async () => {
+      const record: EditPresetRecord = {
+        id: 'p1',
+        tenantId: 'tenant-a',
+        name: 'Warm',
+        recipe: VALID_RECIPE,
+        createdBy: 'user-x',
+        createdAt: '2026-06-30T00:00:00.000Z',
+        updatedAt: '2026-06-30T00:00:00.000Z',
+      };
+      const { data } = makeMemoryAdapter({
+        [`${EDIT_PRESETS_COLLECTION}::${editPresetDocId('tenant-a', 'p1')}`]:
+          record,
+      });
+      const app = makeApp(
+        data,
+        (req) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (req as any).user = { uid: 'user-1' };
+        },
+        async () => 'viewer'
+      );
+      const { status, body } = await request(
+        app,
+        'get',
+        '/v1/tenants/tenant-a/edit-presets'
+      );
+      expect(status).toBe(200);
+      expect(body.presets).toHaveLength(1);
+      expect(body.presets[0].id).toBe('p1');
+    });
+
+    it('403 when the user is not a tenant member', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(
+        data,
+        (req) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (req as any).user = { uid: 'user-1' };
+        },
+        async () => null
+      );
+      const { status, body } = await request(
+        app,
+        'get',
+        '/v1/tenants/tenant-a/edit-presets'
+      );
+      expect(status).toBe(403);
+      expect(body.error.code).toBe('NOT_A_TENANT_MEMBER');
+    });
+  });
+
+  describe('DELETE /:tenantId/edit-presets/:presetId', () => {
+    it('editor may delete', async () => {
+      const record: EditPresetRecord = {
+        id: 'p1',
+        tenantId: 'tenant-a',
+        name: 'Warm',
+        recipe: VALID_RECIPE,
+        createdBy: 'user-x',
+        createdAt: '2026-06-30T00:00:00.000Z',
+        updatedAt: '2026-06-30T00:00:00.000Z',
+      };
+      const { data, store } = makeMemoryAdapter({
+        [`${EDIT_PRESETS_COLLECTION}::${editPresetDocId('tenant-a', 'p1')}`]:
+          record,
+      });
+      const app = makeApp(
+        data,
+        (req) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (req as any).user = { uid: 'user-1' };
+        },
+        async () => 'editor'
+      );
+      const { status, body } = await request(
+        app,
+        'delete',
+        '/v1/tenants/tenant-a/edit-presets/p1'
+      );
+      expect(status).toBe(200);
+      expect(body.removed).toBe(true);
+      expect(
+        store
+          .get(EDIT_PRESETS_COLLECTION)
+          ?.has(editPresetDocId('tenant-a', 'p1'))
+      ).toBe(false);
+    });
+
+    it('404 for unknown preset id', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(
+        data,
+        (req) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (req as any).user = { uid: 'user-1' };
+        },
+        async () => 'editor'
+      );
+      const { status, body } = await request(
+        app,
+        'delete',
+        '/v1/tenants/tenant-a/edit-presets/nope'
+      );
+      expect(status).toBe(404);
+      expect(body.error.code).toBe('EDIT_PRESET_NOT_FOUND');
+    });
+
+    it('cross-tenant delete rejects on host key', async () => {
+      const record: EditPresetRecord = {
+        id: 'p1',
+        tenantId: 'tenant-a',
+        name: 'Warm',
+        recipe: VALID_RECIPE,
+        createdBy: 'user-x',
+        createdAt: '2026-06-30T00:00:00.000Z',
+        updatedAt: '2026-06-30T00:00:00.000Z',
+      };
+      const { data } = makeMemoryAdapter({
+        [`${EDIT_PRESETS_COLLECTION}::${editPresetDocId('tenant-a', 'p1')}`]:
+          record,
+      });
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-other',
+          scopes: ['edit-presets.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'delete',
+        '/v1/tenants/tenant-a/edit-presets/p1'
+      );
+      expect(status).toBe(403);
+      expect(body.error.code).toBe('CROSS_TENANT_FORBIDDEN');
+    });
+  });
+
+  describe('POST /:tenantId/edit-presets/:presetId/apply', () => {
+    it('rejects the whole batch when a foreign photoId is present', async () => {
+      const record: EditPresetRecord = {
+        id: 'p1',
+        tenantId: 'tenant-a',
+        name: 'Warm',
+        recipe: VALID_RECIPE,
+        createdBy: 'user-x',
+        createdAt: '2026-06-30T00:00:00.000Z',
+        updatedAt: '2026-06-30T00:00:00.000Z',
+      };
+      const ours = makePhoto({ id: 'photo-a', tenantId: 'tenant-a' });
+      const foreign = makePhoto({ id: 'photo-b', tenantId: 'tenant-other' });
+      const { data } = makeMemoryAdapter({
+        [`${EDIT_PRESETS_COLLECTION}::${editPresetDocId('tenant-a', 'p1')}`]:
+          record,
+        ['photos::photo-a']: ours,
+        ['photos::photo-b']: foreign,
+      });
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['edit-presets.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'post',
+        '/v1/tenants/tenant-a/edit-presets/p1/apply',
+        { photoIds: ['photo-a', 'photo-b'] }
+      );
+      expect(status).toBe(400);
+      expect(body.error.code).toBe('CROSS_TENANT_PHOTO_ID');
+    });
+
+    it('returns per-photo status for a partial batch', async () => {
+      const record: EditPresetRecord = {
+        id: 'p1',
+        tenantId: 'tenant-a',
+        name: 'Warm',
+        recipe: VALID_RECIPE,
+        createdBy: 'user-x',
+        createdAt: '2026-06-30T00:00:00.000Z',
+        updatedAt: '2026-06-30T00:00:00.000Z',
+      };
+      const ours = makePhoto({ id: 'photo-a', tenantId: 'tenant-a' });
+      const { data, store } = makeMemoryAdapter({
+        [`${EDIT_PRESETS_COLLECTION}::${editPresetDocId('tenant-a', 'p1')}`]:
+          record,
+        ['photos::photo-a']: ours,
+        // photo-missing not seeded -> commit returns PHOTO_NOT_FOUND
+      });
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['edit-presets.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'post',
+        '/v1/tenants/tenant-a/edit-presets/p1/apply',
+        { photoIds: ['photo-a', 'photo-missing'] }
+      );
+      expect(status).toBe(200);
+      expect(body.presetId).toBe('p1');
+      expect(body.requested).toBe(2);
+      expect(body.applied).toBe(1);
+      expect(body.failed).toBe(1);
+      expect(body.results).toHaveLength(2);
+      const okItem = body.results.find(
+        (r: { photoId: string }) => r.photoId === 'photo-a'
+      );
+      const missingItem = body.results.find(
+        (r: { photoId: string }) => r.photoId === 'photo-missing'
+      );
+      expect(okItem.status).toBe('applied');
+      expect(okItem.version).toBe(1);
+      expect(missingItem.status).toBe('error');
+      expect(missingItem.error.code).toBe('PHOTO_NOT_FOUND');
+
+      // The applied photo now has a new edit version.
+      const updated = store.get('photos')?.get('photo-a') as Photo | undefined;
+      expect(updated?.currentEditVersion).toBe(1);
+      expect(updated?.editHistory).toHaveLength(1);
+      expect(updated?.thumbnailsOutdated).toBe(true);
+    });
+
+    it('413-style validation: photoIds cap enforced by Zod schema (400)', async () => {
+      const record: EditPresetRecord = {
+        id: 'p1',
+        tenantId: 'tenant-a',
+        name: 'Warm',
+        recipe: VALID_RECIPE,
+        createdBy: 'user-x',
+        createdAt: '2026-06-30T00:00:00.000Z',
+        updatedAt: '2026-06-30T00:00:00.000Z',
+      };
+      const { data } = makeMemoryAdapter({
+        [`${EDIT_PRESETS_COLLECTION}::${editPresetDocId('tenant-a', 'p1')}`]:
+          record,
+      });
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['edit-presets.write'],
+        } satisfies FakeTenant;
+      });
+      // 201 photoIds -> exceeds cap of 200.
+      const overCap = Array.from({ length: 201 }, (_, i) => `photo-${i}`);
+      const { status, body } = await request(
+        app,
+        'post',
+        '/v1/tenants/tenant-a/edit-presets/p1/apply',
+        { photoIds: overCap }
+      );
+      expect(status).toBe(400);
+      expect(body.error.code).toBe('INVALID_REQUEST_BODY');
+    });
+
+    it('404 when preset does not exist', async () => {
+      const { data } = makeMemoryAdapter();
+      const app = makeApp(data, (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).tenant = {
+          id: 'tenant-a',
+          scopes: ['edit-presets.write'],
+        } satisfies FakeTenant;
+      });
+      const { status, body } = await request(
+        app,
+        'post',
+        '/v1/tenants/tenant-a/edit-presets/nope/apply',
+        { photoIds: ['photo-a'] }
+      );
+      expect(status).toBe(404);
+      expect(body.error.code).toBe('EDIT_PRESET_NOT_FOUND');
+    });
+  });
+});

--- a/functions/src/routes/tenantEditPresetsV1.ts
+++ b/functions/src/routes/tenantEditPresetsV1.ts
@@ -1,0 +1,489 @@
+/**
+ * Per-tenant edit-preset endpoints (issue #197).
+ *
+ * Lightroom-style "develop presets" — save the edit recipe of one photo
+ * and apply it across a selection. Mounted at
+ * `/v1/tenants/:tenantId/edit-presets` (and mirrored under `/api/v1/...`).
+ *
+ *   POST   /:tenantId/edit-presets                     → editor+ or host key (write)
+ *   GET    /:tenantId/edit-presets                     → viewer+ or host key (read)
+ *   DELETE /:tenantId/edit-presets/:presetId           → editor+ or host key (write)
+ *   POST   /:tenantId/edit-presets/:presetId/apply     → editor+ or host key (write)
+ *                                                        Idempotency-Key supported
+ *
+ * Auth shape mirrors `tenantExportPresetsV1.ts` — either a host API key
+ * carrying the appropriate scope OR an authenticated Firebase user
+ * (whose tenant-member role is validated against a configurable role
+ * check). Cross-tenant photoIds in an apply batch reject the whole
+ * request with HTTP 400.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { Router } from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import type { TenantApiKeyScope } from '../models/TenantApiKey.js';
+import { DEFAULT_TENANT_ID } from '../domain/tenant/Tenant.js';
+import {
+  EDIT_PRESET_APPLY_MAX_PHOTO_IDS,
+  EDIT_PRESET_NAME_MAX_LENGTH,
+  EDIT_PRESET_NAME_MIN_LENGTH,
+  type EditPresetRecord,
+} from '../models/EditPreset.js';
+import type { Photo } from '../models/Photo.js';
+import {
+  EditPresetValidationError,
+  applyEditPreset,
+  buildRecipeFromPhoto,
+  createEditPreset,
+  deleteEditPreset,
+  getEditPreset,
+  listEditPresets,
+  validatePresetName,
+  validateRecipeBody,
+} from '../services/host/editPresetService.js';
+import { emitMeteringEvent } from '../services/metering/index.js';
+
+interface ApiErrorPayload {
+  error: {
+    code: string;
+    message: string;
+    requestId: string;
+    details: Record<string, unknown> | null;
+  };
+}
+
+function sendError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> | null = null
+): void {
+  const body: ApiErrorPayload = {
+    error: { code, message, requestId: randomUUID(), details },
+  };
+  res.status(status).json(body);
+}
+
+/**
+ * Resolve the tenant-member role of `req.user` inside `tenantId`.
+ * Injected as a router dep so unit tests can bypass the adapter, and so
+ * the production wiring can substitute the real
+ * `tenantMembershipService.getMembership` without pulling that module
+ * into every test harness.
+ *
+ * Returns `null` when the user is not a member of the tenant.
+ */
+export type TenantRoleResolver = (
+  tenantId: string,
+  userId: string
+) => Promise<'owner' | 'editor' | 'viewer' | null>;
+
+/** Roles allowed to write / apply presets. */
+const WRITE_ROLES: ReadonlySet<'owner' | 'editor' | 'viewer'> = new Set([
+  'owner',
+  'editor',
+]);
+
+/** Roles allowed to read presets. */
+const READ_ROLES: ReadonlySet<'owner' | 'editor' | 'viewer'> = new Set([
+  'owner',
+  'editor',
+  'viewer',
+]);
+
+/**
+ * Guard factory: accept either a host API key with the given scope OR
+ * a Firebase user whose tenant-member role is in `allowedRoles`.
+ * Cross-tenant host keys and non-members are rejected here.
+ */
+function requireUserRoleOrHostKey(
+  scope: TenantApiKeyScope,
+  allowedRoles: ReadonlySet<'owner' | 'editor' | 'viewer'>,
+  roleResolver: TenantRoleResolver
+) {
+  return async function guard(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    const tenantId = String(req.params.tenantId ?? '');
+    if (!tenantId) {
+      sendError(res, 400, 'VALIDATION_ERROR', 'tenantId is required');
+      return;
+    }
+    if (req.tenant) {
+      if (req.tenant.id !== tenantId) {
+        sendError(
+          res,
+          403,
+          'CROSS_TENANT_FORBIDDEN',
+          'Cross-tenant request rejected'
+        );
+        return;
+      }
+      if (!new Set(req.tenant.scopes).has(scope)) {
+        sendError(res, 403, 'INSUFFICIENT_SCOPE', 'Insufficient scope', {
+          missing: [scope],
+        });
+        return;
+      }
+      next();
+      return;
+    }
+    if (req.user) {
+      let role: 'owner' | 'editor' | 'viewer' | null;
+      try {
+        role = await roleResolver(tenantId, req.user.uid);
+      } catch (err) {
+        sendError(
+          res,
+          500,
+          'ROLE_RESOLUTION_FAILED',
+          err instanceof Error ? err.message : 'role resolution failed'
+        );
+        return;
+      }
+      if (role === null) {
+        sendError(
+          res,
+          403,
+          'NOT_A_TENANT_MEMBER',
+          'Authenticated user is not a member of this tenant'
+        );
+        return;
+      }
+      if (!allowedRoles.has(role)) {
+        sendError(res, 403, 'INSUFFICIENT_ROLE', 'Insufficient tenant role', {
+          role,
+          required: [...allowedRoles],
+        });
+        return;
+      }
+      next();
+      return;
+    }
+    sendError(res, 401, 'AUTH_REQUIRED', 'Authentication required');
+  };
+}
+
+/** Body schema for `POST /edit-presets` — recipe form. */
+const CreateFromRecipeSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(EDIT_PRESET_NAME_MIN_LENGTH)
+      .max(EDIT_PRESET_NAME_MAX_LENGTH),
+    recipe: z.object({
+      recipeVersion: z.number().int().optional(),
+      operations: z
+        .array(
+          z.object({
+            type: z.string(),
+            params: z.record(z.unknown()),
+            order: z.number().int().min(0),
+          })
+        )
+        .min(1),
+      description: z.string().optional(),
+    }),
+  })
+  .strict();
+
+/** Body schema for `POST /edit-presets` — copy-from-photo form. */
+const CreateFromPhotoSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(EDIT_PRESET_NAME_MIN_LENGTH)
+      .max(EDIT_PRESET_NAME_MAX_LENGTH),
+    fromPhotoId: z.string().min(1),
+  })
+  .strict();
+
+/** Body schema for `POST /edit-presets/:presetId/apply`. */
+const ApplyBodySchema = z
+  .object({
+    photoIds: z
+      .array(z.string().min(1))
+      .min(1)
+      .max(EDIT_PRESET_APPLY_MAX_PHOTO_IDS),
+  })
+  .strict();
+
+/** Wire-shape returned to callers. Strips internal-only fields. */
+function serializePreset(record: EditPresetRecord): Record<string, unknown> {
+  return {
+    id: record.id,
+    tenantId: record.tenantId,
+    name: record.name,
+    recipe: record.recipe,
+    createdBy: record.createdBy,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+export interface TenantEditPresetsRouterDeps {
+  dataAdapter: DataAdapter;
+  /**
+   * Resolve a user's tenant-member role. Defaults to a permissive
+   * "editor" role so callers that mount the router without a role
+   * source (legacy single-tenant-per-user mode) still work — matches
+   * the convention used in `tenantUsage.ts`.
+   */
+  resolveTenantRole?: TenantRoleResolver;
+}
+
+export function createTenantEditPresetsRouter(
+  deps: TenantEditPresetsRouterDeps
+): Router {
+  const router = Router({ mergeParams: true });
+  const resolveTenantRole: TenantRoleResolver =
+    deps.resolveTenantRole ?? (async () => 'editor');
+
+  // POST /:tenantId/edit-presets
+  router.post(
+    '/:tenantId/edit-presets',
+    requireUserRoleOrHostKey(
+      'edit-presets.write',
+      WRITE_ROLES,
+      resolveTenantRole
+    ),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId);
+        const body = req.body as Record<string, unknown> | undefined;
+        if (!body || typeof body !== 'object') {
+          sendError(res, 400, 'INVALID_REQUEST_BODY', 'Body must be an object');
+          return;
+        }
+        const actor = req.tenant?.keyId ?? req.user?.uid ?? 'unknown';
+        let name: string;
+        let recipe;
+        try {
+          if ('fromPhotoId' in body) {
+            const parsed = CreateFromPhotoSchema.safeParse(body);
+            if (!parsed.success) {
+              sendError(
+                res,
+                400,
+                'INVALID_REQUEST_BODY',
+                parsed.error.errors
+                  .map((e) => `${e.path.join('.')}: ${e.message}`)
+                  .join(', ')
+              );
+              return;
+            }
+            name = validatePresetName(parsed.data.name);
+            recipe = await buildRecipeFromPhoto(
+              deps.dataAdapter,
+              tenantId,
+              parsed.data.fromPhotoId
+            );
+          } else {
+            const parsed = CreateFromRecipeSchema.safeParse(body);
+            if (!parsed.success) {
+              sendError(
+                res,
+                400,
+                'INVALID_REQUEST_BODY',
+                parsed.error.errors
+                  .map((e) => `${e.path.join('.')}: ${e.message}`)
+                  .join(', ')
+              );
+              return;
+            }
+            name = validatePresetName(parsed.data.name);
+            recipe = validateRecipeBody(parsed.data.recipe);
+          }
+        } catch (err) {
+          if (err instanceof EditPresetValidationError) {
+            sendError(res, err.status, err.code, err.message, err.details);
+            return;
+          }
+          throw err;
+        }
+        const record = await createEditPreset(deps.dataAdapter, {
+          tenantId,
+          name,
+          recipe,
+          createdBy: actor,
+        });
+        res.status(201).json(serializePreset(record));
+      } catch (err) {
+        if (err instanceof EditPresetValidationError) {
+          sendError(res, err.status, err.code, err.message, err.details);
+          return;
+        }
+        next(err);
+      }
+    }
+  );
+
+  // GET /:tenantId/edit-presets
+  router.get(
+    '/:tenantId/edit-presets',
+    requireUserRoleOrHostKey(
+      'edit-presets.read',
+      READ_ROLES,
+      resolveTenantRole
+    ),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId);
+        const presets = await listEditPresets(deps.dataAdapter, tenantId);
+        res.json({
+          tenantId,
+          presets: presets.map(serializePreset),
+        });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  // DELETE /:tenantId/edit-presets/:presetId
+  router.delete(
+    '/:tenantId/edit-presets/:presetId',
+    requireUserRoleOrHostKey(
+      'edit-presets.write',
+      WRITE_ROLES,
+      resolveTenantRole
+    ),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId);
+        const presetId = String(req.params.presetId);
+        const removed = await deleteEditPreset(
+          deps.dataAdapter,
+          tenantId,
+          presetId
+        );
+        if (!removed) {
+          sendError(
+            res,
+            404,
+            'EDIT_PRESET_NOT_FOUND',
+            `Preset ${presetId} not found`
+          );
+          return;
+        }
+        res.json({ tenantId, id: presetId, removed: true });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  // POST /:tenantId/edit-presets/:presetId/apply
+  router.post(
+    '/:tenantId/edit-presets/:presetId/apply',
+    requireUserRoleOrHostKey(
+      'edit-presets.write',
+      WRITE_ROLES,
+      resolveTenantRole
+    ),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const tenantId = String(req.params.tenantId);
+        const presetId = String(req.params.presetId);
+        const parsed = ApplyBodySchema.safeParse(req.body);
+        if (!parsed.success) {
+          sendError(
+            res,
+            400,
+            'INVALID_REQUEST_BODY',
+            parsed.error.errors
+              .map((e) => `${e.path.join('.')}: ${e.message}`)
+              .join(', ')
+          );
+          return;
+        }
+        const photoIds = parsed.data.photoIds;
+
+        // Preset must exist (fast fail — before cross-tenant checks).
+        const preset = await getEditPreset(
+          deps.dataAdapter,
+          tenantId,
+          presetId
+        );
+        if (!preset) {
+          sendError(
+            res,
+            404,
+            'EDIT_PRESET_NOT_FOUND',
+            `Preset ${presetId} not found`
+          );
+          return;
+        }
+
+        // Batch-level cross-tenant pre-check. ANY foreign id fails the
+        // whole batch, mirroring the bulk photo ops surface (#142).
+        const unique = Array.from(new Set(photoIds));
+        for (const photoId of unique) {
+          const photo = await deps.dataAdapter.fetchData<Photo>(
+            'photos',
+            photoId
+          );
+          if (photo === null) continue; // per-photo NOT_FOUND handled below
+          const photoTenant =
+            (photo.tenantId as string | undefined) ?? DEFAULT_TENANT_ID;
+          if (photoTenant !== tenantId) {
+            sendError(
+              res,
+              400,
+              'CROSS_TENANT_PHOTO_ID',
+              'photoIds contains an id owned by a different tenant',
+              { photoId }
+            );
+            return;
+          }
+        }
+
+        const actor = req.tenant?.keyId ?? req.user?.uid ?? 'unknown';
+        const outcome = await applyEditPreset(deps.dataAdapter, {
+          tenantId,
+          presetId,
+          photoIds,
+          actor,
+        });
+
+        // One batch-level metering event per apply call. Per-photo
+        // `edit.applied` events are emitted inside `applyEditPreset`.
+        emitMeteringEvent({
+          tenantId,
+          type: 'edit_preset.applied',
+          count: 1,
+          resourceId: presetId,
+          meta: {
+            presetId,
+            photoCount: photoIds.length,
+            succeeded: outcome.applied,
+            failed: outcome.failed,
+          },
+        });
+
+        res.status(200).json({
+          presetId: outcome.presetId,
+          requested: photoIds.length,
+          applied: outcome.applied,
+          failed: outcome.failed,
+          results: outcome.results,
+        });
+      } catch (err) {
+        if (err instanceof EditPresetValidationError) {
+          sendError(res, err.status, err.code, err.message, err.details);
+          return;
+        }
+        next(err);
+      }
+    }
+  );
+
+  return router;
+}

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -130,6 +130,8 @@ import {
 import { createBulkPhotosRouter } from './routes/photosBatchV1.js';
 import { createPhotoExportRouter } from './routes/photoExportV1.js';
 import { createTenantExportPresetsRouter } from './routes/tenantExportPresetsV1.js';
+import { createTenantEditPresetsRouter } from './routes/tenantEditPresetsV1.js';
+import { getMembership } from './services/tenant/tenantMembershipService.js';
 import {
   createSmartAlbumsLibraryRouter,
   createSmartAlbumsResourceRouter,
@@ -656,6 +658,69 @@ app.use(
   hostApiKeyAuth,
   optionalAuthMiddleware,
   auditEventsRouter
+);
+
+// Per-tenant edit presets — Lightroom Sync Settings (issue #197).
+// Host API key (edit-presets.read / edit-presets.write) OR Firebase user
+// whose tenant-member role permits the operation (editor+ for
+// write/apply, viewer for read).
+const tenantEditPresetsRouter = createTenantEditPresetsRouter({
+  dataAdapter,
+  resolveTenantRole: async (tenantId, userId) => {
+    // Until a real tenant/user model lands, treat the authenticated
+    // user's uid as their own tenantId (mirrors the tenantUsage
+    // convention) and grant `editor` — end-users in single-tenant mode
+    // can save + apply their own presets. Once the multi-tenant
+    // membership model is wired end-to-end, this collapses back to a
+    // raw `getMembership` lookup.
+    if (userId === tenantId) return 'editor';
+    try {
+      const membership = await getMembership(dataAdapter, tenantId, userId);
+      return membership?.role ?? null;
+    } catch (err) {
+      logger.warn(
+        { err, tenantId, userId },
+        'edit-presets: role resolution failed'
+      );
+      return null;
+    }
+  },
+});
+// Idempotency-Key support on the apply endpoint (issue #162 style).
+// Mounted before the router so retries with the same key are
+// short-circuited without re-committing edits or re-emitting metering.
+const editPresetApplyIdempotency = createIdempotencyMiddleware({
+  route: 'POST /v1/tenants/:tenantId/edit-presets/:presetId/apply',
+  dataAdapter,
+  resolveTenantId: (req) => {
+    const tenantId = req.params?.tenantId;
+    if (typeof tenantId === 'string' && tenantId.length > 0) return tenantId;
+    return req.tenant?.id ?? req.user?.uid ?? null;
+  },
+});
+app.use(
+  '/v1/tenants/:tenantId/edit-presets/:presetId/apply',
+  hostApiKeyAuth,
+  optionalAuthMiddleware,
+  editPresetApplyIdempotency
+);
+app.use(
+  '/api/v1/tenants/:tenantId/edit-presets/:presetId/apply',
+  hostApiKeyAuth,
+  optionalAuthMiddleware,
+  editPresetApplyIdempotency
+);
+app.use(
+  '/v1/tenants',
+  hostApiKeyAuth,
+  optionalAuthMiddleware,
+  tenantEditPresetsRouter
+);
+app.use(
+  '/api/v1/tenants',
+  hostApiKeyAuth,
+  optionalAuthMiddleware,
+  tenantEditPresetsRouter
 );
 
 // Error handlers (must be last)

--- a/functions/src/services/host/editPresetService.ts
+++ b/functions/src/services/host/editPresetService.ts
@@ -1,0 +1,534 @@
+/**
+ * Service layer for per-tenant edit presets (issue #197).
+ *
+ * Provides the CRUD + apply operations backing the
+ * `/v1/tenants/:tenantId/edit-presets` API. Apply reuses the existing
+ * edit pipeline via {@link commitPresetToPhoto} — no new processing
+ * path is introduced. Per-photo metering emits the existing
+ * `edit.applied` event; the batch-level `edit_preset.applied` event
+ * (registered in the metering event catalog) is emitted once per apply
+ * call by the route handler after this service returns.
+ *
+ * Multi-tenant enforcement:
+ *   - Every write is scoped to `tenantId`; cross-tenant apply photoIds
+ *     are rejected wholesale (`CROSS_TENANT_PHOTO_ID`).
+ *   - The per-tenant preset cap ({@link EDIT_PRESET_MAX_PER_TENANT}) is
+ *     enforced on create.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { DataAdapter } from '../../adapters/data/DataAdapter.js';
+import {
+  EDIT_PRESETS_COLLECTION,
+  EDIT_PRESET_MAX_PER_TENANT,
+  EDIT_PRESET_NAME_MAX_LENGTH,
+  EDIT_PRESET_NAME_MIN_LENGTH,
+  editPresetDocId,
+  type EditPresetRecipe,
+  type EditPresetRecord,
+} from '../../models/EditPreset.js';
+import type { EditOperation, EditVersion, Photo } from '../../models/Photo.js';
+import { DEFAULT_TENANT_ID } from '../../domain/tenant/Tenant.js';
+import { validateOperations } from '../edits/EditProcessor.js';
+import { EDIT_RECIPE_VERSION } from '../edits/pluginRegistry.js';
+import { getEffectiveEnabledPluginIds } from './tenantPluginConfigService.js';
+import { emitMeteringEvent } from '../metering/index.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Thrown by validation helpers when an incoming payload is malformed.
+ * The route layer maps this to HTTP `status` with the same `code`.
+ */
+export class EditPresetValidationError extends Error {
+  public readonly status: number;
+  public readonly code: string;
+  public readonly details: Record<string, unknown> | null;
+  constructor(
+    code: string,
+    message: string,
+    status = 400,
+    details: Record<string, unknown> | null = null
+  ) {
+    super(message);
+    this.name = 'EditPresetValidationError';
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+/**
+ * Validate a recipe payload. Returns a normalized recipe. Throws
+ * {@link EditPresetValidationError} on any structural or semantic
+ * violation. Uses the SAME `validateOperations` implementation as the
+ * per-photo `POST /edits/:libraryId/:photoId` handler, so a preset
+ * cannot store a recipe the executor would refuse.
+ */
+export function validateRecipeBody(input: unknown): EditPresetRecipe {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new EditPresetValidationError(
+      'INVALID_RECIPE',
+      'recipe must be a JSON object'
+    );
+  }
+  const b = input as Record<string, unknown>;
+
+  const recipeVersion =
+    typeof b.recipeVersion === 'number' ? b.recipeVersion : EDIT_RECIPE_VERSION;
+  if (
+    !Number.isInteger(recipeVersion) ||
+    recipeVersion !== EDIT_RECIPE_VERSION
+  ) {
+    throw new EditPresetValidationError(
+      'UNSUPPORTED_RECIPE_VERSION',
+      `Unsupported recipe version ${recipeVersion}. Supported version: ${EDIT_RECIPE_VERSION}`
+    );
+  }
+
+  const ops = b.operations;
+  if (!Array.isArray(ops) || ops.length === 0) {
+    throw new EditPresetValidationError(
+      'INVALID_RECIPE',
+      'recipe.operations must be a non-empty array'
+    );
+  }
+  // Ops must all be objects with `type`, `params`, `order`.
+  for (const op of ops) {
+    if (!op || typeof op !== 'object' || Array.isArray(op)) {
+      throw new EditPresetValidationError(
+        'INVALID_RECIPE',
+        'each recipe operation must be an object'
+      );
+    }
+    const o = op as Record<string, unknown>;
+    if (typeof o.type !== 'string') {
+      throw new EditPresetValidationError(
+        'INVALID_RECIPE',
+        'operation.type must be a string'
+      );
+    }
+    if (typeof o.order !== 'number' || !Number.isInteger(o.order) || o.order < 0) {
+      throw new EditPresetValidationError(
+        'INVALID_RECIPE',
+        'operation.order must be a non-negative integer'
+      );
+    }
+    if (!o.params || typeof o.params !== 'object' || Array.isArray(o.params)) {
+      throw new EditPresetValidationError(
+        'INVALID_RECIPE',
+        'operation.params must be an object'
+      );
+    }
+  }
+
+  const opsValidation = validateOperations(ops as EditOperation[]);
+  if (!opsValidation.valid) {
+    throw new EditPresetValidationError(
+      'INVALID_RECIPE_OPERATIONS',
+      `Invalid operations: ${opsValidation.errors.join(', ')}`
+    );
+  }
+
+  const description =
+    typeof b.description === 'string' ? b.description : undefined;
+
+  const normalized: EditPresetRecipe = {
+    recipeVersion,
+    operations: (ops as EditOperation[]).map((op) => ({
+      type: op.type,
+      params: { ...op.params },
+      order: op.order,
+    })),
+    ...(description !== undefined ? { description } : {}),
+  };
+  return normalized;
+}
+
+/** Validate the human-readable preset name. */
+export function validatePresetName(name: unknown): string {
+  if (typeof name !== 'string') {
+    throw new EditPresetValidationError(
+      'INVALID_PRESET_NAME',
+      'name must be a string'
+    );
+  }
+  const trimmed = name.trim();
+  if (
+    trimmed.length < EDIT_PRESET_NAME_MIN_LENGTH ||
+    trimmed.length > EDIT_PRESET_NAME_MAX_LENGTH
+  ) {
+    throw new EditPresetValidationError(
+      'INVALID_PRESET_NAME',
+      `name must be between ${EDIT_PRESET_NAME_MIN_LENGTH} and ${EDIT_PRESET_NAME_MAX_LENGTH} characters`
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Extract a preset recipe from an existing photo's current edit version.
+ * Used when the caller supplies `{ name, fromPhotoId }` instead of an
+ * explicit recipe. The photo MUST belong to `tenantId`.
+ */
+export async function buildRecipeFromPhoto(
+  adapter: DataAdapter,
+  tenantId: string,
+  photoId: string
+): Promise<EditPresetRecipe> {
+  if (typeof photoId !== 'string' || photoId.length === 0) {
+    throw new EditPresetValidationError(
+      'INVALID_FROM_PHOTO_ID',
+      'fromPhotoId must be a non-empty string'
+    );
+  }
+  const photo = await adapter.fetchData<Photo>('photos', photoId);
+  if (!photo) {
+    throw new EditPresetValidationError(
+      'FROM_PHOTO_NOT_FOUND',
+      `Source photo ${photoId} not found`,
+      404
+    );
+  }
+  const photoTenant = (photo.tenantId as string | undefined) ?? DEFAULT_TENANT_ID;
+  if (photoTenant !== tenantId) {
+    throw new EditPresetValidationError(
+      'CROSS_TENANT_PHOTO_ID',
+      `Source photo ${photoId} belongs to a different tenant`,
+      403
+    );
+  }
+  const current = photo.editHistory.find(
+    (v) => v.version === photo.currentEditVersion
+  );
+  if (!current || current.operations.length === 0) {
+    throw new EditPresetValidationError(
+      'PHOTO_HAS_NO_EDITS',
+      `Source photo ${photoId} has no edits to save as a preset`
+    );
+  }
+  return {
+    recipeVersion: current.recipeVersion,
+    operations: current.operations.map((op) => ({
+      type: op.type,
+      params: { ...op.params },
+      order: op.order,
+    })),
+    ...(current.description !== undefined
+      ? { description: current.description }
+      : {}),
+  };
+}
+
+export interface CreateEditPresetInput {
+  tenantId: string;
+  name: string;
+  recipe: EditPresetRecipe;
+  createdBy: string;
+}
+
+/**
+ * Create a new preset. Enforces the per-tenant cap
+ * ({@link EDIT_PRESET_MAX_PER_TENANT}) before insert.
+ */
+export async function createEditPreset(
+  adapter: DataAdapter,
+  input: CreateEditPresetInput
+): Promise<EditPresetRecord> {
+  const existing = await listEditPresets(adapter, input.tenantId);
+  if (existing.length >= EDIT_PRESET_MAX_PER_TENANT) {
+    throw new EditPresetValidationError(
+      'EDIT_PRESET_CAP_EXCEEDED',
+      `Tenant has reached the ${EDIT_PRESET_MAX_PER_TENANT}-preset cap`,
+      409,
+      { cap: EDIT_PRESET_MAX_PER_TENANT, current: existing.length }
+    );
+  }
+  const id = randomUUID();
+  const now = new Date().toISOString();
+  const record: EditPresetRecord = {
+    id,
+    tenantId: input.tenantId,
+    name: input.name,
+    recipe: input.recipe,
+    createdBy: input.createdBy,
+    createdAt: now,
+    updatedAt: now,
+  };
+  await adapter.storeData(
+    EDIT_PRESETS_COLLECTION,
+    editPresetDocId(input.tenantId, id),
+    record
+  );
+  return record;
+}
+
+/**
+ * Fetch a single preset. Cross-tenant reads return `null` (never a
+ * different tenant's data) to avoid leaking the existence of records
+ * in other tenants.
+ */
+export async function getEditPreset(
+  adapter: DataAdapter,
+  tenantId: string,
+  presetId: string
+): Promise<EditPresetRecord | null> {
+  const doc = await adapter.fetchData<EditPresetRecord>(
+    EDIT_PRESETS_COLLECTION,
+    editPresetDocId(tenantId, presetId)
+  );
+  if (!doc) return null;
+  if (doc.tenantId !== tenantId) return null;
+  return doc;
+}
+
+/**
+ * List every preset for a tenant, ordered by `createdAt` ascending. The
+ * flat key/value adapter is queried by `tenantId` equality; cross-tenant
+ * rows are filtered defensively at the service boundary.
+ */
+export async function listEditPresets(
+  adapter: DataAdapter,
+  tenantId: string
+): Promise<EditPresetRecord[]> {
+  const rows = await adapter.queryData<EditPresetRecord>(
+    EDIT_PRESETS_COLLECTION,
+    [{ field: 'tenantId', operator: '==', value: tenantId }]
+  );
+  return rows
+    .filter((r) => r.tenantId === tenantId)
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+/**
+ * Delete a preset. Returns `true` when a row was removed, `false` when
+ * the preset did not exist (so the route can respond 404 vs 200 on the
+ * DELETE surface).
+ */
+export async function deleteEditPreset(
+  adapter: DataAdapter,
+  tenantId: string,
+  presetId: string
+): Promise<boolean> {
+  const existing = await getEditPreset(adapter, tenantId, presetId);
+  if (!existing) return false;
+  await adapter.deleteData(
+    EDIT_PRESETS_COLLECTION,
+    editPresetDocId(tenantId, presetId)
+  );
+  return true;
+}
+
+/** Per-photo apply result surface returned in the batch response. */
+export interface ApplyPresetResult {
+  photoId: string;
+  status: 'applied' | 'skipped' | 'error';
+  version?: number;
+  error?: {
+    code: string;
+    message: string;
+  };
+}
+
+export interface ApplyPresetInput {
+  tenantId: string;
+  presetId: string;
+  photoIds: string[];
+  /** User uid or host key id used as `createdBy` on committed edits. */
+  actor: string;
+}
+
+export interface ApplyPresetOutput {
+  presetId: string;
+  applied: number;
+  failed: number;
+  results: ApplyPresetResult[];
+}
+
+/**
+ * Apply a preset's recipe to every id in `photoIds`. Per-photo failures
+ * are captured as `results[i].status === 'error'` so a partial batch
+ * still returns HTTP 200 with an actionable per-id status list — this
+ * matches the bulk photo ops surface from issue #142.
+ *
+ * The batch-level cross-tenant pre-check happens in the route layer so
+ * a single foreign id rejects the whole request before any commit is
+ * attempted; here we defensively re-check per-photo in case a photo
+ * was moved between tenants during the batch.
+ */
+export async function applyEditPreset(
+  adapter: DataAdapter,
+  input: ApplyPresetInput
+): Promise<ApplyPresetOutput> {
+  const preset = await getEditPreset(adapter, input.tenantId, input.presetId);
+  if (!preset) {
+    throw new EditPresetValidationError(
+      'EDIT_PRESET_NOT_FOUND',
+      `Preset ${input.presetId} not found`,
+      404
+    );
+  }
+
+  const enabledForTenant = await getEffectiveEnabledPluginIds(
+    adapter,
+    input.tenantId
+  );
+
+  const results: ApplyPresetResult[] = [];
+  let applied = 0;
+  let failed = 0;
+
+  for (const photoId of input.photoIds) {
+    try {
+      const result = await commitPresetToPhoto(adapter, {
+        tenantId: input.tenantId,
+        presetId: preset.id,
+        recipe: preset.recipe,
+        photoId,
+        actor: input.actor,
+        enabledPluginIds: enabledForTenant,
+      });
+      results.push(result);
+      if (result.status === 'applied') applied += 1;
+      else failed += 1;
+    } catch (err) {
+      logger.warn(
+        { err, photoId, presetId: preset.id, tenantId: input.tenantId },
+        'apply preset failed for photo'
+      );
+      results.push({
+        photoId,
+        status: 'error',
+        error: {
+          code: 'APPLY_FAILED',
+          message: err instanceof Error ? err.message : 'apply failed',
+        },
+      });
+      failed += 1;
+    }
+  }
+
+  return {
+    presetId: preset.id,
+    applied,
+    failed,
+    results,
+  };
+}
+
+interface CommitPresetInput {
+  tenantId: string;
+  presetId: string;
+  recipe: EditPresetRecipe;
+  photoId: string;
+  actor: string;
+  enabledPluginIds: ReadonlySet<string>;
+}
+
+/**
+ * Commit a preset's recipe as a new edit version on ONE photo. Mirrors
+ * the version-commit path of `handleApplyEdits` so both surfaces produce
+ * the same on-disk shape and emit the same per-photo `edit.applied`
+ * event. Per-photo failures are returned as `status: 'error'` (not
+ * thrown) so a batch can continue.
+ */
+async function commitPresetToPhoto(
+  adapter: DataAdapter,
+  input: CommitPresetInput
+): Promise<ApplyPresetResult> {
+  const photo = await adapter.fetchData<Photo>('photos', input.photoId);
+  if (!photo) {
+    return {
+      photoId: input.photoId,
+      status: 'error',
+      error: { code: 'PHOTO_NOT_FOUND', message: 'photo not found' },
+    };
+  }
+  const photoTenant =
+    (photo.tenantId as string | undefined) ?? DEFAULT_TENANT_ID;
+  if (photoTenant !== input.tenantId) {
+    // Defensive — the route already rejected the batch, but a photo
+    // could theoretically be reassigned mid-flight.
+    return {
+      photoId: input.photoId,
+      status: 'error',
+      error: {
+        code: 'CROSS_TENANT_PHOTO_ID',
+        message: 'photo belongs to a different tenant',
+      },
+    };
+  }
+
+  // Enforce per-tenant plugin allowlist — a preset created before a
+  // plugin was disabled must not run the disabled op.
+  for (const op of input.recipe.operations) {
+    if (!input.enabledPluginIds.has(op.type)) {
+      emitMeteringEvent({
+        tenantId: input.tenantId,
+        type: 'plugin.blocked',
+        count: 1,
+        resourceId: input.photoId,
+        meta: {
+          libraryId: photo.libraryId,
+          pluginId: op.type,
+          userId: input.actor,
+          viaPreset: true,
+          presetId: input.presetId,
+        },
+      });
+      return {
+        photoId: input.photoId,
+        status: 'error',
+        error: {
+          code: 'plugin_disabled_for_tenant',
+          message: `Plugin '${op.type}' is disabled for this tenant`,
+        },
+      };
+    }
+  }
+
+  const newVersion: EditVersion = {
+    version: photo.currentEditVersion + 1,
+    recipeVersion: input.recipe.recipeVersion,
+    createdAt: new Date().toISOString(),
+    createdBy: input.actor,
+    operations: input.recipe.operations.map((op) => ({
+      type: op.type,
+      params: { ...op.params },
+      order: op.order,
+    })),
+    ...(input.recipe.description !== undefined
+      ? { description: input.recipe.description }
+      : {}),
+  };
+
+  const updatedEditHistory = [...photo.editHistory, newVersion];
+
+  await adapter.updateData<Photo>('photos', input.photoId, {
+    currentEditVersion: newVersion.version,
+    editHistory: updatedEditHistory,
+    thumbnailsOutdated: true,
+    updatedAt: new Date().toISOString(),
+  });
+
+  // Same event shape as the single-photo pipeline so hosts get one
+  // consistent stream of `edit.applied` regardless of surface.
+  emitMeteringEvent({
+    tenantId: input.tenantId,
+    type: 'edit.applied',
+    count: 1,
+    resourceId: input.photoId,
+    meta: {
+      libraryId: photo.libraryId,
+      version: newVersion.version,
+      operationCount: newVersion.operations.length,
+      viaPreset: true,
+      presetId: input.presetId,
+    },
+  });
+
+  return {
+    photoId: input.photoId,
+    status: 'applied',
+    version: newVersion.version,
+  };
+}

--- a/functions/src/services/metering/eventCatalog.ts
+++ b/functions/src/services/metering/eventCatalog.ts
@@ -45,7 +45,7 @@
  *
  * Use a date string so the value is human-readable in logs.
  */
-export const CATALOG_VERSION = '2026-06-30';
+export const CATALOG_VERSION = '2026-07-01';
 
 /**
  * JSON Schema describing the `meta` payload for a single event type.
@@ -154,6 +154,19 @@ export const EVENT_CATALOG = [
     schema: metaSchema({
       version: S_INTEGER,
       operationCount: S_INTEGER,
+    }),
+  },
+  {
+    name: 'edit_preset.applied',
+    version: 1,
+    billable: false,
+    description:
+      'A develop preset (issue #197) was applied to a batch of photos. One event per apply call, regardless of N. Per-photo commits still emit `edit.applied`.',
+    schema: metaSchema({
+      presetId: S_STRING,
+      photoCount: S_INTEGER,
+      succeeded: S_INTEGER,
+      failed: S_INTEGER,
     }),
   },
   {


### PR DESCRIPTION
## Summary

Adds Lightroom-style **develop presets** for tenants: save the current edit recipe of one photo and apply it across a selection of other photos in one call. The apply path reuses the existing edit executor — no new render pipeline. Fixes #197.

## Endpoints

Mounted on both `/v1/tenants/...` (canonical) and `/api/v1/tenants/...` (legacy in-product):

- `POST   /v1/tenants/:tenantId/edit-presets` — create from `{ name, recipe }` OR `{ name, fromPhotoId }`
- `GET    /v1/tenants/:tenantId/edit-presets` — list, sorted by createdAt asc
- `DELETE /v1/tenants/:tenantId/edit-presets/:presetId` — remove
- `POST   /v1/tenants/:tenantId/edit-presets/:presetId/apply` — bulk apply `{ photoIds: string[] }`

## Behavior & guardrails

- **Auth:** host API key with `edit-presets.read` / `edit-presets.write` scope OR Firebase user with tenant-member role (viewer for read, editor+ for write/apply).
- **Cross-tenant:** the whole batch is rejected with HTTP 400 `CROSS_TENANT_PHOTO_ID` if any photoId belongs to a different tenant (matches #142 bulk-op contract). Presets themselves are strictly tenant-scoped; cross-tenant reads return 404, cross-tenant host keys 403.
- **Caps:** 500 presets per tenant (HTTP 409 `EDIT_PRESET_CAP_EXCEEDED`); 200 photoIds per apply call (HTTP 400 via Zod).
- **Partial success:** apply always returns HTTP 200 with per-photo `{ photoId, status, version?, error? }` results.
- **Idempotency-Key** supported on apply — the existing `createIdempotencyMiddleware` is mounted in front of the apply endpoint so retries don't re-commit edits or re-emit metering.
- **Allowlist re-check:** if a plugin was disabled after a preset was created, the disabled op yields per-photo `plugin_disabled_for_tenant` and emits `plugin.blocked` — consistent with the single-photo executor.
- **Recipe validation:** the same `validateOperations` used on `/edits/:libraryId/:photoId` runs on preset create, so a preset can never store a recipe the executor would refuse.

## Metering

- `edit.applied` — emitted per successfully edited photo (identical shape to single-photo pipeline; adds `meta.viaPreset: true`, `meta.presetId`).
- `edit_preset.applied` — **new, non-billable** event registered in the catalog; emitted once per apply call with `{ presetId, photoCount, succeeded, failed }`.
- Catalog version bumped to `2026-07-01`; `docs/features/metering-events.md` regenerated.

## Changes

- `functions/src/models/EditPreset.ts` — new model (record, recipe, caps, composite doc id helper)
- `functions/src/models/TenantApiKey.ts` — adds `edit-presets.read` and `edit-presets.write` scopes
- `functions/src/services/host/editPresetService.ts` — CRUD + apply service; per-photo commit reuses existing edit-version shape and emits `edit.applied`
- `functions/src/routes/tenantEditPresetsV1.ts` — router factory + guards (cross-tenant, scope, role)
- `functions/src/routes/tenantEditPresetsV1.test.ts` — 17 unit tests (auth, scopes, roles, cross-tenant, partial batch, caps, from-photo, 404s)
- `functions/src/server.ts` — wires router on both mount prefixes, wires Idempotency-Key middleware on apply
- `functions/src/services/metering/eventCatalog.ts` — registers `edit_preset.applied`, bumps `CATALOG_VERSION` to `2026-07-01`
- `docs/features/plugin-editing-system.md` — new "Develop presets" section
- `docs/features/metering-events.md` — regenerated from the catalog

## Testing

- 17 new unit tests for the router (all pass); patterned on `tenantStorageThresholdsV1.test.ts`.
- Full suite run: 3 pre-existing test files fail on `main` (verified via `git stash`); no new failures introduced.
- `npm run build` — my new files compile clean; the only tsc errors are pre-existing in unrelated test files on `main`.

Fixes rwrife/AuraPix#197
