### PR TITLE
feat(tenant-features): add originalDownload flag and enforcement (#208)

### DIFF
--- a/contracts/openapi/tenant-features.openapi.json
+++ b/contracts/openapi/tenant-features.openapi.json
@@ -104,14 +104,15 @@
       "FeatureFlags": {
         "type": "object",
         "description": "Effective state for every gateable feature. All keys are required in responses; defaults are `true`.",
-        "required": ["sharing", "plugins", "smartAlbums", "export", "bulkOps"],
+        "required": ["sharing", "plugins", "smartAlbums", "export", "bulkOps", "originalDownload"],
         "additionalProperties": false,
         "properties": {
           "sharing": { "type": "boolean", "description": "Share-token signing-key issuance." },
           "plugins": { "type": "boolean", "description": "Edits/plugin execution." },
           "smartAlbums": { "type": "boolean", "description": "Smart Albums CRUD + materialization." },
           "export": { "type": "boolean", "description": "Photo export API." },
-          "bulkOps": { "type": "boolean", "description": "Bulk photo operations (`POST /v1/photos:batch`)." }
+          "bulkOps": { "type": "boolean", "description": "Bulk photo operations (`POST /v1/photos:batch`)." },
+          "originalDownload": { "type": "boolean", "description": "Export/share of full-resolution originals (issue #208). When disabled, export presets targeting the untouched original and signed URLs for the `original` variant are rejected with `feature.gated`." }
         }
       },
       "FeaturesPatch": {
@@ -123,7 +124,8 @@
           "plugins": { "type": "boolean" },
           "smartAlbums": { "type": "boolean" },
           "export": { "type": "boolean" },
-          "bulkOps": { "type": "boolean" }
+          "bulkOps": { "type": "boolean" },
+          "originalDownload": { "type": "boolean" }
         }
       },
       "FeatureFlagChange": {

--- a/docs/features/usage-and-billing.md
+++ b/docs/features/usage-and-billing.md
@@ -316,3 +316,45 @@ programmatically; their schemas live in `services/metering/eventCatalog.ts`.
 - The Firestore-backed store for `usageDaily` ships alongside the
   Firebase mode wiring; local-dev uses an in-memory store with the same
   semantics for tests.
+
+## Gating original-file access (issue #208)
+
+Hosts on tiered pricing plans commonly want to reserve **full-resolution
+original downloads** for their paid tenants and cap free-tier tenants to
+sized/watermarked derivatives.
+
+The per-tenant `originalDownload` feature flag (part of the
+[`tenantFeaturesConfig`](../../contracts/openapi/tenant-features.openapi.json)
+surface) enforces this **server-side**:
+
+- **Default:** `true` for every existing tenant (back-compat). Toggle it
+  off via `PATCH /v1/tenants/{tenantId}/features` with
+  `{"originalDownload": false}`.
+- **Export presets:** `POST /v1/photos/:id/export` rejects with `403
+  feature_disabled` (and emits `feature.gated`) whenever the resolved
+  preset targets the untouched original — i.e. `format === "original"`
+  and no active watermark. Presets that downsize (`format: "jpeg"`) or
+  apply a watermark continue to work.
+- **Signed URLs for the `original` variant:** the signed-URL image
+  serving path rejects requests whose signature was cut for
+  `size === "original"` when the flag is disabled, with the same `403
+  feature_disabled` shape. Derivative variants (`small`, `medium`,
+  `large`) are unaffected. This is what catches direct URL requests —
+  including any share-token-issued signing key — from bypassing the
+  preset gate above.
+- **Embedded UI:** the flag is included in the bootstrap payload; the
+  embedded UI hides the "Download original" / "Export original"
+  affordances when it reads `false`. **Server enforcement is
+  authoritative**; the UI hide is convenience.
+
+### Signals hosts should watch
+
+- `feature.gated` with `meta.feature === "originalDownload"` — every
+  attempt to pull an original that was blocked. Use this both as an
+  upsell trigger ("this tenant tried to export the original 12 times
+  this week") and as a fraud-monitoring signal.
+- `photo.exported` where `meta.preset === "original"` **and**
+  `meta.outputWidth === photo.originalWidth` — an actual original was
+  delivered to a Pro+ tenant. Aggregate this per tenant per day to
+  drive an "originals delivered" billing counter without needing a
+  dedicated event type.

--- a/functions/src/middleware/signedUrl.originalDownload.test.ts
+++ b/functions/src/middleware/signedUrl.originalDownload.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Signed-URL middleware enforcement of the per-tenant `originalDownload`
+ * feature flag (issue #208).
+ *
+ * The middleware wraps `SignatureValidator` + `ImageAuthorizer`; those
+ * are validated in their own suites. Here we mock both to isolate the
+ * flag gate: for a photo whose tenant has `originalDownload: false`,
+ * requests for the `original` variant must be rejected with 403
+ * `feature_disabled` and a `feature.gated` event, while requests for a
+ * derivative size (`large`) must pass through unchanged.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import type { Express } from 'express';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import { errorHandler } from './errorHandler.js';
+import {
+  MeteringBus,
+  type MeteringSink,
+  type NormalizedMeteringEvent,
+} from '../services/metering/MeteringBus.js';
+import { setMeteringBus } from '../services/metering/index.js';
+import {
+  TENANT_FEATURES_CONFIG_COLLECTION,
+  type TenantFeaturesConfigRecord,
+} from '../models/TenantFeaturesConfig.js';
+import { __resetTenantFeaturesCacheForTests } from '../services/host/tenantFeaturesConfigService.js';
+import type { ImageSignature } from '../models/ImageAuth.js';
+
+// Mock signature parsing/validation to always succeed for query
+// `?sig=<size>` where <size> ∈ {original, large}. This lets us focus on
+// the flag-gate behavior without reconstructing a real HMAC.
+vi.mock('../services/imageAuth/SignatureValidator.js', () => {
+  class FakeSignatureValidator {
+    constructor(_secret: string) {}
+    parseSignature(param: string): ImageSignature | null {
+      if (!param) return null;
+      const size = param === 'original' ? 'original' : 'large';
+      return {
+        libraryId: 'lib-1',
+        photoId: 'photo-1',
+        size,
+        format: 'jpeg',
+        expiresAt: Math.floor(Date.now() / 1000) + 60,
+        userId: 'u_1',
+      };
+    }
+    validateSignature(): boolean {
+      return true;
+    }
+  }
+  return { SignatureValidator: FakeSignatureValidator };
+});
+
+// Mock authorizer to always authorize.
+vi.mock('../services/imageAuth/ImageAuthorizer.js', () => {
+  class FakeImageAuthorizer {
+    constructor(_data: DataAdapter) {}
+    setViewTracker(_t: unknown): void {}
+    async authorizeImageAccess() {
+      return { authorized: true };
+    }
+  }
+  return { ImageAuthorizer: FakeImageAuthorizer };
+});
+
+// Import AFTER the mocks are registered.
+import { createSignedUrlMiddleware } from './signedUrl.js';
+
+class CapturingSink implements MeteringSink {
+  events: NormalizedMeteringEvent[] = [];
+  async deliver(events: NormalizedMeteringEvent[]): Promise<void> {
+    this.events.push(...events);
+  }
+}
+
+function makeData(
+  tenantId: string,
+  featuresDoc: TenantFeaturesConfigRecord | null
+): DataAdapter {
+  return {
+    getPhoto: vi.fn(async () => ({
+      id: 'photo-1',
+      libraryId: 'lib-1',
+      tenantId,
+      metadata: { sizeBytes: 100 },
+    })),
+    fetchData: vi.fn(async <T>(collection: string, _id: string) => {
+      if (collection === TENANT_FEATURES_CONFIG_COLLECTION && featuresDoc) {
+        return featuresDoc as unknown as T;
+      }
+      return null;
+    }),
+  } as unknown as DataAdapter;
+}
+
+function makeApp(data: DataAdapter): Express {
+  const app = express();
+  const mw = createSignedUrlMiddleware(data);
+  app.get('/images/:libraryId/:photoId', mw, (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+  app.use(errorHandler);
+  return app;
+}
+
+async function get(app: Express, path: string): Promise<{ status: number; body: any }> {
+  const { createServer } = await import('node:http');
+  const server = createServer(app as unknown as (req: any, res: any) => void);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const addr = server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}${path}`);
+    const body = await res.json().catch(() => ({}));
+    return { status: res.status, body };
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe('signedUrl middleware — originalDownload gating (#208)', () => {
+  let sink: CapturingSink;
+  let bus: MeteringBus;
+
+  beforeEach(() => {
+    process.env.SIGNING_MASTER_SECRET =
+      process.env.SIGNING_MASTER_SECRET ?? 'a'.repeat(64);
+    __resetTenantFeaturesCacheForTests();
+    sink = new CapturingSink();
+    bus = new MeteringBus({ sink, flushIntervalMs: 5, maxBatchSize: 1 });
+    setMeteringBus(bus);
+  });
+  afterEach(() => {
+    setMeteringBus(null);
+    __resetTenantFeaturesCacheForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects the `original` variant with 403 + feature.gated when originalDownload is disabled', async () => {
+    const tenantId = 'tenant-free';
+    const featuresDoc: TenantFeaturesConfigRecord = {
+      tenantId,
+      flags: { originalDownload: false },
+      updatedAt: new Date().toISOString(),
+      updatedBy: 'test',
+    };
+    const data = makeData(tenantId, featuresDoc);
+    const app = makeApp(data);
+    const res = await get(app, '/images/lib-1/photo-1?sig=original');
+    expect(res.status).toBe(403);
+    // errorHandler wraps AppError; the code we threw is "feature_disabled".
+    expect(JSON.stringify(res.body)).toContain('feature_disabled');
+
+    await bus.flush();
+    const gated = sink.events.filter((e) => e.type === 'feature.gated');
+    expect(gated).toHaveLength(1);
+    expect((gated[0]?.meta as any).feature).toBe('originalDownload');
+    expect((gated[0]?.meta as any).variant).toBe('original');
+  });
+
+  it('allows derivative variants (`large`) when originalDownload is disabled', async () => {
+    const tenantId = 'tenant-free';
+    const featuresDoc: TenantFeaturesConfigRecord = {
+      tenantId,
+      flags: { originalDownload: false },
+      updatedAt: new Date().toISOString(),
+      updatedBy: 'test',
+    };
+    const data = makeData(tenantId, featuresDoc);
+    const app = makeApp(data);
+    const res = await get(app, '/images/lib-1/photo-1?sig=large');
+    expect(res.status).toBe(200);
+
+    await bus.flush();
+    const gated = sink.events.filter((e) => e.type === 'feature.gated');
+    expect(gated).toHaveLength(0);
+  });
+
+  it('allows the `original` variant when the flag is enabled (default-on, no doc)', async () => {
+    const tenantId = 'tenant-pro';
+    const data = makeData(tenantId, null);
+    const app = makeApp(data);
+    const res = await get(app, '/images/lib-1/photo-1?sig=original');
+    expect(res.status).toBe(200);
+
+    await bus.flush();
+    const gated = sink.events.filter((e) => e.type === 'feature.gated');
+    expect(gated).toHaveLength(0);
+  });
+});

--- a/functions/src/middleware/signedUrl.ts
+++ b/functions/src/middleware/signedUrl.ts
@@ -7,6 +7,11 @@ import { AppError } from './errorHandler.js';
 import type { ImageAuthResult } from '../models/ImageAuth.js';
 import type { DataAdapter } from '../adapters/data/DataAdapter.js';
 import type { ShareViewTracker } from '../services/sharing/ShareViewTracker.js';
+import { isFeatureEnabled } from '../services/host/tenantFeaturesConfigService.js';
+import {
+  emitMeteringEvent,
+  resolveTenantId,
+} from '../services/metering/index.js';
 
 export interface SignedUrlMiddlewareOptions {
   /**
@@ -79,6 +84,65 @@ export function createSignedUrlMiddleware(
       
       if (!photo) {
         throw new AppError(404, 'PHOTO_NOT_FOUND', 'Photo not found');
+      }
+
+      // #208: gate signed URLs for the `original` variant behind the
+      // per-tenant `originalDownload` feature flag. Derivative sizes
+      // (small/medium/large) are unaffected. This catches direct URL
+      // requests that bypass the export-preset path — including
+      // share-token-issued signing keys that could otherwise produce a
+      // signed URL for the original bytes.
+      if (signature.size === 'original') {
+        const tenantId =
+          (photo as { tenantId?: string | null } | null)?.tenantId ?? null;
+        let originalAllowed = true;
+        try {
+          originalAllowed = await isFeatureEnabled(
+            dataAdapter,
+            tenantId ?? '',
+            'originalDownload'
+          );
+        } catch (err) {
+          // Fail open on config-store errors — mirrors requireFeature
+          // and avoids amplifying a flag-store incident into a serve outage.
+          logger.warn(
+            {
+              err,
+              libraryId: signature.libraryId,
+              photoId: signature.photoId,
+            },
+            'signedUrl: originalDownload flag lookup failed; failing open'
+          );
+        }
+        if (!originalAllowed) {
+          try {
+            emitMeteringEvent({
+              tenantId: resolveTenantId({ tenantId }),
+              type: 'feature.gated',
+              count: 1,
+              meta: {
+                feature: 'originalDownload',
+                route: '/images/:libraryId/:photoId',
+                variant: 'original',
+                method: req.method,
+                userId: signature.userId ?? null,
+                shareTokenPrefix: signature.shareToken
+                  ? signature.shareToken.substring(0, 8)
+                  : null,
+              },
+            });
+          } catch (err) {
+            logger.debug(
+              { err, libraryId: signature.libraryId, photoId: signature.photoId },
+              'feature.gated emit failed (originalDownload/serve)'
+            );
+          }
+          throw new AppError(
+            403,
+            'feature_disabled',
+            'Downloading the original file is disabled for this tenant'
+          );
+        }
       }
 
       // Check if signature grants access to this photo. Pass request

--- a/functions/src/models/TenantFeaturesConfig.ts
+++ b/functions/src/models/TenantFeaturesConfig.ts
@@ -31,6 +31,12 @@ export const FEATURE_FLAG_NAMES = [
   'smartAlbums',
   'export',
   'bulkOps',
+  // #208: gates the host's ability to hand out full-resolution
+  // originals. Default-on for back-compat; hosts flip it off on
+  // Free-tier tenants so export presets that target the untouched
+  // original and signed URLs for the `original` variant are rejected
+  // server-side, regardless of preset or link config.
+  'originalDownload',
 ] as const;
 
 export type FeatureFlagName = (typeof FEATURE_FLAG_NAMES)[number];
@@ -101,4 +107,5 @@ export const DEFAULT_FEATURE_FLAGS: TenantFeatureFlags = {
   smartAlbums: true,
   export: true,
   bulkOps: true,
+  originalDownload: true,
 };

--- a/functions/src/routes/photoExportV1.originalDownload.test.ts
+++ b/functions/src/routes/photoExportV1.originalDownload.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Enforcement tests for the per-tenant `originalDownload` feature flag
+ * (issue #208) on the export-preset apply path.
+ *
+ * The AC calls for three unit-test axes on this route:
+ *   1. Preset targets untouched original (format=original, no watermark) → gated.
+ *   2. Preset downsizes (format=jpeg) → allowed even when the flag is off.
+ *   3. Preset targets original but with an active watermark → allowed.
+ *
+ * All three use the same `tenantFeaturesConfig` fixture with the flag
+ * explicitly set to `false`; the default-on behavior is covered by the
+ * shared `tenantFeaturesConfigService` tests (which iterate over
+ * `FEATURE_FLAG_NAMES`, so adding the new flag automatically extended
+ * those cases without a new test needing to be authored here).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import type { Express } from 'express';
+import sharp from 'sharp';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import type { StorageAdapter } from '../adapters/storage/StorageAdapter.js';
+import type { Photo } from '../models/Photo.js';
+import { errorHandler } from '../middleware/errorHandler.js';
+import {
+  MeteringBus,
+  type MeteringSink,
+  type NormalizedMeteringEvent,
+} from '../services/metering/MeteringBus.js';
+import { setMeteringBus } from '../services/metering/index.js';
+import { createPhotoExportRouter } from './photoExportV1.js';
+import {
+  TENANT_EXPORT_PRESETS_COLLECTION,
+  type ExportPreset,
+  type TenantExportPresetsRecord,
+} from '../models/ExportPreset.js';
+import {
+  TENANT_FEATURES_CONFIG_COLLECTION,
+  type TenantFeaturesConfigRecord,
+} from '../models/TenantFeaturesConfig.js';
+import { __resetTenantFeaturesCacheForTests } from '../services/host/tenantFeaturesConfigService.js';
+
+class CapturingSink implements MeteringSink {
+  events: NormalizedMeteringEvent[] = [];
+  async deliver(events: NormalizedMeteringEvent[]): Promise<void> {
+    this.events.push(...events);
+  }
+}
+
+function makePhoto(overrides: Partial<Photo> = {}): Photo {
+  return {
+    id: 'photo-1',
+    libraryId: 'lib-1',
+    albumIds: [],
+    originalName: 'test.jpg',
+    metadata: { width: 800, height: 600, mimeType: 'image/jpeg', sizeBytes: 1234 },
+    status: 'ready',
+    currentEditVersion: 0,
+    editHistory: [],
+    thumbnailsOutdated: false,
+    storagePath: `images/lib-1/photo-1/original.jpg`,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as Photo;
+}
+
+function makeStorage(initial: Record<string, Buffer> = {}) {
+  const files = new Map<string, Buffer>(Object.entries(initial));
+  const storage: StorageAdapter = {
+    storeFile: vi.fn(async (path: string, buf: Buffer) => {
+      files.set(path, buf);
+    }),
+    readFile: vi.fn(async (path: string) => {
+      const b = files.get(path);
+      if (!b) throw new Error(`ENOENT: ${path}`);
+      return b;
+    }),
+    fileExists: vi.fn(async (path: string) => files.has(path)),
+    deleteFile: vi.fn(async (path: string) => {
+      files.delete(path);
+    }),
+    listFiles: vi.fn(async (prefix: string) => {
+      return [...files.keys()].filter((k) => k.startsWith(prefix));
+    }),
+    getFileSize: vi.fn(async (path: string) => files.get(path)?.length ?? 0),
+  } as unknown as StorageAdapter;
+  return { storage, files };
+}
+
+function makeData(
+  photo: Photo | null,
+  presetDoc: TenantExportPresetsRecord | null,
+  featuresDoc: TenantFeaturesConfigRecord | null
+): DataAdapter {
+  return {
+    storeData: vi.fn(async () => {}),
+    fetchData: vi.fn(async <T>(collection: string, _id: string) => {
+      if (collection === 'photos') return photo as unknown as T | null;
+      if (collection === TENANT_EXPORT_PRESETS_COLLECTION && presetDoc) {
+        return presetDoc as unknown as T;
+      }
+      if (collection === TENANT_FEATURES_CONFIG_COLLECTION && featuresDoc) {
+        return featuresDoc as unknown as T;
+      }
+      return null;
+    }),
+    queryData: vi.fn(async () => []),
+    updateData: vi.fn(async () => {}),
+    deleteData: vi.fn(async () => {}),
+    exists: vi.fn(async () => true),
+    listIds: vi.fn(async () => []),
+    getPhoto: vi.fn(async () => photo),
+  } as unknown as DataAdapter;
+}
+
+async function makeTinyJpeg(): Promise<Buffer> {
+  return sharp({
+    create: {
+      width: 32,
+      height: 24,
+      channels: 3,
+      background: { r: 220, g: 100, b: 50 },
+    },
+  })
+    .jpeg({ quality: 90 })
+    .toBuffer();
+}
+
+function presetDoc(tenantId: string, preset: ExportPreset): TenantExportPresetsRecord {
+  return {
+    tenantId,
+    presets: [preset],
+    updatedAt: new Date().toISOString(),
+    updatedBy: null,
+  };
+}
+
+function originalDownloadOff(tenantId: string): TenantFeaturesConfigRecord {
+  return {
+    tenantId,
+    flags: { originalDownload: false },
+    updatedAt: new Date().toISOString(),
+    updatedBy: 'test',
+  };
+}
+
+function makeApp(opts: {
+  data: DataAdapter;
+  storage: StorageAdapter;
+  inject: (req: any) => void;
+}): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    opts.inject(req);
+    next();
+  });
+  const handle = createPhotoExportRouter({
+    dataAdapter: opts.data,
+    storageAdapter: opts.storage,
+  });
+  app.use('/v1/photos', handle.router);
+  app.use(errorHandler);
+  return app;
+}
+
+async function post(
+  app: Express,
+  path: string,
+  body: unknown
+): Promise<{ status: number; body: any }> {
+  const { createServer } = await import('node:http');
+  const server = createServer(app as unknown as (req: any, res: any) => void);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const addr = server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const parsed = await res.json().catch(() => ({}));
+    return { status: res.status, body: parsed };
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe('POST /v1/photos/:id/export — originalDownload gating (#208)', () => {
+  let sink: CapturingSink;
+  let bus: MeteringBus;
+
+  beforeEach(() => {
+    process.env.SIGNING_MASTER_SECRET =
+      process.env.SIGNING_MASTER_SECRET ?? 'a'.repeat(64);
+    __resetTenantFeaturesCacheForTests();
+    sink = new CapturingSink();
+    bus = new MeteringBus({ sink, flushIntervalMs: 5, maxBatchSize: 1 });
+    setMeteringBus(bus);
+  });
+  afterEach(() => {
+    setMeteringBus(null);
+    __resetTenantFeaturesCacheForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('gates the untouched-original preset (format=original, no watermark) with 403 + feature.gated', async () => {
+    const tenantId = 'tenant-free';
+    const photo = makePhoto({ tenantId });
+    const preset: ExportPreset = {
+      name: 'original',
+      maxEdge: 8192,
+      quality: 100,
+      format: 'original',
+    };
+    const data = makeData(
+      photo,
+      presetDoc(tenantId, preset),
+      originalDownloadOff(tenantId)
+    );
+    const { storage } = makeStorage();
+    const app = makeApp({
+      data,
+      storage,
+      inject: (req) => {
+        req.user = { uid: 'u_1' };
+        req.tenantId = tenantId;
+      },
+    });
+    const res = await post(app, '/v1/photos/photo-1/export', {
+      preset: 'original',
+    });
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('feature_disabled');
+    expect(res.body.error.details?.feature).toBe('originalDownload');
+
+    await bus.flush();
+    const gated = sink.events.filter((e) => e.type === 'feature.gated');
+    expect(gated).toHaveLength(1);
+    expect((gated[0]?.meta as any).feature).toBe('originalDownload');
+    expect((gated[0]?.meta as any).route).toBe('/v1/photos/:id/export');
+  });
+
+  it('allows a downsize preset (format=jpeg) even when originalDownload is disabled', async () => {
+    const tenantId = 'tenant-free';
+    const tiny = await makeTinyJpeg();
+    const photo = makePhoto({ tenantId });
+    const preset: ExportPreset = {
+      name: 'web-small',
+      maxEdge: 1024,
+      quality: 80,
+      format: 'jpeg',
+    };
+    const data = makeData(
+      photo,
+      presetDoc(tenantId, preset),
+      originalDownloadOff(tenantId)
+    );
+    const { storage } = makeStorage({
+      [`images/lib-1/photo-1/original.jpg`]: tiny,
+    });
+    const app = makeApp({
+      data,
+      storage,
+      inject: (req) => {
+        req.user = { uid: 'u_1' };
+        req.tenantId = tenantId;
+      },
+    });
+    const res = await post(app, '/v1/photos/photo-1/export', {
+      preset: 'web-small',
+    });
+    expect(res.status).toBe(200);
+
+    await bus.flush();
+    const gated = sink.events.filter((e) => e.type === 'feature.gated');
+    expect(gated).toHaveLength(0);
+  });
+
+  it('allows a format=original preset when an active watermark is applied', async () => {
+    const tenantId = 'tenant-free';
+    const tiny = await makeTinyJpeg();
+    const photo = makePhoto({ tenantId });
+    const preset: ExportPreset = {
+      name: 'original-watermarked',
+      maxEdge: 8192,
+      quality: 100,
+      format: 'original',
+      watermark: {
+        enabled: true,
+        text: 'ACME PHOTO',
+        opacity: 0.5,
+        position: 'bottom-right',
+      },
+    };
+    const data = makeData(
+      photo,
+      presetDoc(tenantId, preset),
+      originalDownloadOff(tenantId)
+    );
+    const { storage } = makeStorage({
+      [`images/lib-1/photo-1/original.jpg`]: tiny,
+    });
+    const app = makeApp({
+      data,
+      storage,
+      inject: (req) => {
+        req.user = { uid: 'u_1' };
+        req.tenantId = tenantId;
+      },
+    });
+    const res = await post(app, '/v1/photos/photo-1/export', {
+      preset: 'original-watermarked',
+    });
+    // An active watermark means the preset is not "the untouched
+    // original" and therefore is not gated by originalDownload.
+    expect(res.status).toBe(200);
+
+    await bus.flush();
+    const gated = sink.events.filter((e) => e.type === 'feature.gated');
+    expect(gated).toHaveLength(0);
+  });
+});

--- a/functions/src/routes/photoExportV1.ts
+++ b/functions/src/routes/photoExportV1.ts
@@ -44,6 +44,19 @@ import {
   verifyExportToken,
 } from '../services/image/exportService.js';
 import { resolvePresetByName } from '../services/host/exportPresetService.js';
+import { isFeatureEnabled } from '../services/host/tenantFeaturesConfigService.js';
+import type { ExportPreset } from '../models/ExportPreset.js';
+
+/**
+ * True when the preset would hand out the untouched original bytes
+ * (issue #208): `format === 'original'` and no active watermark. A
+ * `jpeg` preset always re-encodes, so it never counts as "the original".
+ */
+function presetTargetsUntouchedOriginal(preset: ExportPreset): boolean {
+  if (preset.format !== 'original') return false;
+  if (preset.watermark && preset.watermark.enabled) return false;
+  return true;
+}
 
 const PHOTOS_COLLECTION = 'photos';
 
@@ -161,6 +174,57 @@ export function createPhotoExportRouter(
           { preset: presetName }
         );
         return;
+      }
+
+      // #208: gate export of the untouched original behind the
+      // per-tenant `originalDownload` feature flag. A preset that
+      // re-encodes (jpeg) or applies a watermark is fine; only
+      // format=original + no active watermark hands out original bytes.
+      if (presetTargetsUntouchedOriginal(preset)) {
+        let originalAllowed = true;
+        try {
+          originalAllowed = await isFeatureEnabled(
+            deps.dataAdapter,
+            tenantId,
+            'originalDownload'
+          );
+        } catch (err) {
+          // Fail open on config-store errors, matching requireFeature.
+          logger.warn(
+            { err, tenantId, photoId, preset: preset.name },
+            'export: originalDownload flag lookup failed; failing open'
+          );
+        }
+        if (!originalAllowed) {
+          try {
+            emitMeteringEvent({
+              tenantId: resolveTenantId({ tenantId }),
+              type: 'feature.gated',
+              count: 1,
+              meta: {
+                feature: 'originalDownload',
+                route: '/v1/photos/:id/export',
+                method: req.method,
+                preset: preset.name,
+                userId: req.user?.uid ?? null,
+                keyId: req.tenant?.keyId ?? null,
+              },
+            });
+          } catch (err) {
+            logger.debug(
+              { err, tenantId, photoId },
+              'feature.gated emit failed (originalDownload/export)'
+            );
+          }
+          sendError(
+            res,
+            403,
+            'feature_disabled',
+            'Exporting the original file is disabled for this tenant',
+            { feature: 'originalDownload', preset: preset.name }
+          );
+          return;
+        }
       }
 
       // Render (or pull from cache).


### PR DESCRIPTION
## What Problem This Solves

Hosts reselling AuraPix on tiered pricing plans need to gate **full-resolution original downloads** behind paid tiers (e.g. Free-tier tenants get up to 2048px derivatives; only Pro+ tenants can pull the untouched original). Today, export presets exist (#174) with watermarking (#185) and share links carry download policies, but there is **no tenant-level gate** that says "this tenant may never hand out the original bytes, regardless of preset or link config." Hosts have to police it in their own UI, and any host that accepts user-configured presets is one API call away from leaking originals.

## Why This Change Was Made

Adds `originalDownload` to the existing `TenantFeaturesConfig` (#175) surface as a small, cleanly-shaped addition that piggybacks on the existing `requireFeature()` pattern — no new endpoint, no new data model, no new bytes on disk. Server-side enforcement lives at the two places a tenant can actually acquire original bytes:

1. **Export preset apply** (`POST /v1/photos/:id/export`) — rejects when the resolved preset targets the untouched original (`format === 'original'` and no active watermark). Downsize (`format: 'jpeg'`) and watermarked-original presets continue to work.
2. **Signed URL for the `original` variant** — the signed-URL middleware rejects requests whose signature was cut for `size === 'original'` when the flag is disabled. Derivative sizes (`small`/`medium`/`large`) are unaffected. This catches direct URL requests that bypass the preset path, **including share-token-issued signing keys** — which is the enforcement surface the issue's share-link bullet actually cares about. (There is no dedicated `downloadPolicy` share-link creation route in the current codebase; when it lands, it should call `requireFeature('originalDownload')` at create time, and the signed-URL gate here already covers the runtime path.)

Both gates emit `feature.gated { feature: 'originalDownload', ... }` on rejection so hosts can drive upsell and fraud-monitoring off the existing metering event.

## User Impact

- **Existing tenants:** zero change. `originalDownload` defaults to `true` per the config module's contract, so every tenant without an explicit override continues to receive originals exactly as today.
- **Hosts:** can now flip `{ "originalDownload": false }` via the existing `PATCH /v1/tenants/{tenantId}/features` endpoint to enforce plan gating server-side. UI is advisory; server is authoritative.
- **API surface:** `tenant-features.openapi.json` now advertises `originalDownload` in `FeatureFlags` and `FeaturesPatch` — additive, non-breaking.
- **Docs:** new `Gating original-file access` section in `docs/features/usage-and-billing.md` documents the flag and the billing signals hosts should watch (`feature.gated` + `photo.exported` with `meta.preset === 'original'`).

## Evidence

- `npx vitest run` on the touched suites (47 tests, all green):
  - `src/services/host/tenantFeaturesConfigService.test.ts` — 26 tests. Existing default-on tests iterate over `FEATURE_FLAG_NAMES`, so `originalDownload` automatically inherits the "unset flag reads as `true`" coverage the AC asks for.
  - `src/routes/photoExportV1.test.ts` — 10 tests, unchanged.
  - `src/routes/photoExportV1.originalDownload.test.ts` (new) — 3 tests: untouched-original preset gated with 403 + `feature.gated`; downsize preset allowed with flag off; watermarked-original preset allowed with flag off.
  - `src/middleware/signedUrl.originalDownload.test.ts` (new) — 3 tests: `original` variant rejected with 403 + `feature.gated` (variant=original) when flag is off; `large` variant unaffected; default-on (no config doc) allows `original`.
  - `src/middleware/requireFeature.test.ts` — 5 tests, unchanged.
- `npm run contract:check` — green (validate + breaking-change check both pass).
- Repo-wide `npx vitest run` shows 14 pre-existing failures in `test/routes/{auditEventsV1,photosV1,shareLinkAnalyticsV1,tenantUsersV1}.test.ts` on `origin/main` unrelated to this change; none touch the files or subsystems modified here.

Fixes rwrife/AuraPix#208