### PR TITLE
feat(photos): ad-hoc photo search endpoint (#207)

### DIFF
--- a/contracts/openapi/photos-search.openapi.json
+++ b/contracts/openapi/photos-search.openapi.json
@@ -1,0 +1,177 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AuraPix Photos Search API",
+    "version": "1.0.0",
+    "description": "Contract artifact for the ad-hoc photo search endpoint (issue #207). One POST that composes existing photo indexes: filename prefix, tag AND-set, rating range, flag, color label, capturedAt range, camera, trashed. Returns the same PhotoSummary shape as GET /api/v1/photos. Filter combinations that would require an index we do not maintain are rejected with HTTP 409 and a machine-readable hint; there is no client-side filtering fallback."
+  },
+  "servers": [
+    { "url": "https://api.aurapix.example" }
+  ],
+  "paths": {
+    "/v1/photos:search": {
+      "post": {
+        "operationId": "photosSearchV1",
+        "summary": "Ad-hoc photo search",
+        "description": "Search photos in a single library for the caller's tenant using any combination of the indexed filters. Gated by the per-tenant `search` feature flag (default-on). `Idempotency-Key` is supported.",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": { "type": "string", "minLength": 1, "maxLength": 200 },
+            "description": "Optional idempotency key; a retried POST within the retention window replays the original response."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/PhotosSearchRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search result page",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PhotosSearchResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request body",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+          },
+          "401": { "description": "Authentication required" },
+          "403": {
+            "description": "The `search` feature flag is disabled for this tenant",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+          },
+          "404": {
+            "description": "libraryId does not belong to the caller's tenant",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+          },
+          "409": {
+            "description": "Requested filter combination has no server-side index. Body includes a `hint` string.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/UnsupportedQueryError" } } }
+          },
+          "429": {
+            "description": "Per-tenant rate limit exceeded",
+            "headers": {
+              "Retry-After": { "schema": { "type": "integer", "minimum": 1 } }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PhotosSearchRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "libraryId": { "type": "string", "minLength": 1 },
+          "q": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200,
+            "description": "Case-insensitive prefix match against `filenameLower`; also matches tags exactly."
+          },
+          "tags": {
+            "type": "array",
+            "description": "AND-semantics: photo must carry every listed tag.",
+            "items": { "type": "string", "minLength": 1, "maxLength": 64 },
+            "maxItems": 50
+          },
+          "rating": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "gte": { "type": "integer", "minimum": 0, "maximum": 5 },
+              "lte": { "type": "integer", "minimum": 0, "maximum": 5 }
+            }
+          },
+          "flag": { "type": "string", "enum": ["pick", "reject", "unflagged"] },
+          "colorLabel": {
+            "type": "string",
+            "enum": ["red", "yellow", "green", "blue", "purple", "none"]
+          },
+          "capturedBetween": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "from": { "type": "string", "format": "date-time" },
+              "to": { "type": "string", "format": "date-time" }
+            }
+          },
+          "camera": { "type": "string", "minLength": 1, "maxLength": 200 },
+          "trashed": { "type": "boolean" },
+          "limit": { "type": "integer", "minimum": 1, "maximum": 200, "default": 50 },
+          "cursor": { "type": "string", "minLength": 1 }
+        }
+      },
+      "PhotoSummary": {
+        "type": "object",
+        "required": ["id", "libraryId", "originalName", "status", "createdAt", "updatedAt"],
+        "properties": {
+          "id": { "type": "string" },
+          "libraryId": { "type": "string" },
+          "originalName": { "type": "string" },
+          "status": { "type": "string", "enum": ["uploading", "processing", "ready", "error"] },
+          "metadata": { "type": "object", "additionalProperties": true },
+          "exif": { "type": "object", "additionalProperties": true },
+          "tags": { "type": "array", "items": { "type": "string" } },
+          "rating": { "type": "integer", "minimum": 0, "maximum": 5 },
+          "flag": { "type": ["string", "null"], "enum": ["pick", "reject", null] },
+          "colorLabel": {
+            "type": ["string", "null"],
+            "enum": ["red", "yellow", "green", "blue", "purple", null]
+          },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "PhotosSearchResponse": {
+        "type": "object",
+        "required": ["items"],
+        "properties": {
+          "items": { "type": "array", "items": { "$ref": "#/components/schemas/PhotoSummary" } },
+          "nextCursor": { "type": "string" },
+          "totalEstimate": { "type": "integer", "minimum": 0 }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "message"],
+            "properties": {
+              "code": { "type": "string" },
+              "message": { "type": "string" }
+            }
+          }
+        }
+      },
+      "UnsupportedQueryError": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "message", "hint"],
+            "properties": {
+              "code": { "type": "string", "const": "unsupported_query_combination" },
+              "message": { "type": "string" },
+              "hint": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/features/library-and-organization.md
+++ b/docs/features/library-and-organization.md
@@ -182,3 +182,68 @@ gate on it for higher tiers. See
 A composite index on `(tenantId, libraryId, tags array-contains,
 updatedAt desc)` supports the tag-narrowed photo query without
 collection-scan amplification.
+
+## Ad-hoc Search (issue #207)
+
+Smart Albums (above) are the answer for **saved** filters that materialize
+over time. `POST /v1/photos:search` is the answer for **one-shot** queries
+— the user types "sunset", "canon 5d", "last month", "5-star only", or
+"red-label" into a search box and expects results back immediately.
+
+```
+POST /v1/photos:search
+{
+  "libraryId": "lib_...",
+  "q": "sunset",                        // case-insensitive prefix on filenameLower + exact tag match
+  "tags": ["travel", "family"],         // AND semantics
+  "rating": { "gte": 4 },
+  "flag": "pick",                       // or "reject" / "unflagged"
+  "colorLabel": "red",                  // or ..., "none"
+  "capturedBetween": { "from": "2026-01-01T00:00:00Z", "to": "2026-02-01T00:00:00Z" },
+  "camera": "5D",
+  "trashed": false,
+  "limit": 50,
+  "cursor": "..."
+}
+→ 200 { items: PhotoSummary[], nextCursor?: string, totalEstimate?: number }
+```
+
+The endpoint composes the existing photo indexes; there is no new
+storage engine and no full-text yet. Full-text (filename substring,
+caption search, semantic/vector search) is intentionally deferred.
+
+### Query planner and 409
+
+Filter combinations that would require an index we do not currently
+maintain (for example, cross-library search over a tenant without
+`libraryId`) return HTTP `409 unsupported_query_combination` with a
+machine-readable `hint`. There is deliberately no silent client-side
+filtering fallback — hosts must see the 409 so we can add the missing
+index in a follow-up without breaking callers.
+
+### Feature flag
+
+Gated by the per-tenant `search` feature flag (default-on). Hosts can
+disable search on Free-tier tenants and enable it on Pro tiers via
+`PATCH /v1/tenants/:id/features`.
+
+### Metering
+
+- `photos.searched { libraryId, resultCount, hasFullText, filterCount }`
+  — one billable event per successful call, regardless of result count.
+- `photos.search.unsupported { requestedFilters }` — non-billable; emitted
+  when the query planner rejects a combo with 409, so hosts can spot
+  demand for indexes we do not yet maintain.
+
+### Idempotency
+
+`Idempotency-Key` is honored on this endpoint so a retried POST after a
+network blip replays the original response instead of double-metering.
+
+### `filenameLower`
+
+To support the case-insensitive prefix on `q`, the Photo document
+carries a denormalized `filenameLower` field written at photo-create
+time (and on rename). Older photos written before the search rollout
+may lack the field; the handler falls back to
+`originalName.toLowerCase()` in memory for those.

--- a/functions/src/models/Photo.ts
+++ b/functions/src/models/Photo.ts
@@ -104,6 +104,15 @@ export interface Photo {
   albumIds: string[];
   originalName: string;
   /**
+   * Denormalized lowercase copy of {@link originalName} used to power
+   * case-insensitive prefix search on the ad-hoc `/v1/photos:search`
+   * endpoint (issue #207). Written on photo create and on rename.
+   * Optional for backwards compatibility with photos written before
+   * the search rollout; treat a missing value as
+   * `originalName.toLowerCase()`.
+   */
+  filenameLower?: string;
+  /**
    * Indicates what was originally uploaded.
    * - raster: jpeg/png/heic/etc
    * - raw: camera RAW (arw/cr3/nef/etc)
@@ -189,6 +198,7 @@ export function createPhotoDocument(
     tenantId,
     albumIds: [],
     originalName,
+    filenameLower: originalName.toLowerCase(),
     sourceType: source?.sourceType,
     rawOriginal: source?.rawOriginal,
     storagePaths,

--- a/functions/src/models/TenantFeaturesConfig.ts
+++ b/functions/src/models/TenantFeaturesConfig.ts
@@ -37,6 +37,10 @@ export const FEATURE_FLAG_NAMES = [
   // original and signed URLs for the `original` variant are rejected
   // server-side, regardless of preset or link config.
   'originalDownload',
+  // #207: gates ad-hoc photo search (`POST /v1/photos:search`).
+  // Default-on for back-compat so existing tenants keep search
+  // access; hosts flip it off to reserve search for paid tiers.
+  'search',
 ] as const;
 
 export type FeatureFlagName = (typeof FEATURE_FLAG_NAMES)[number];
@@ -108,4 +112,5 @@ export const DEFAULT_FEATURE_FLAGS: TenantFeatureFlags = {
   export: true,
   bulkOps: true,
   originalDownload: true,
+  search: true,
 };

--- a/functions/src/routes/photosSearchV1.test.ts
+++ b/functions/src/routes/photosSearchV1.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Unit tests for `POST /v1/photos:search` (issue #207).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import type { Express } from 'express';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import type { Photo } from '../models/Photo.js';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { createPhotosSearchV1Router } from './photosSearchV1.js';
+
+interface InjectCtx {
+  tenantId?: string;
+  userId?: string;
+}
+
+function makeApp(
+  data: DataAdapter,
+  ctx: InjectCtx = { tenantId: 'tenant-a', userId: 'u1' }
+): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (ctx.userId) {
+      (req as express.Request & { user?: unknown }).user = {
+        uid: ctx.userId,
+        // tenantId is not part of AuthUser but our route reads it via a cast.
+        ...(ctx.tenantId ? { tenantId: ctx.tenantId } : {}),
+      } as unknown as express.Request['user'];
+    }
+    if (ctx.tenantId) {
+      (req as express.Request & { tenantId?: string }).tenantId = ctx.tenantId;
+    }
+    next();
+  });
+  app.use('/v1/photos:search', createPhotosSearchV1Router(data));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeAdapter(seedPhotos: Photo[]): DataAdapter {
+  const photos = new Map<string, Photo>(seedPhotos.map((p) => [p.id, p]));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: any = {
+    storeData: vi.fn(async (_c: string, id: string, v: Photo) => {
+      photos.set(id, v);
+    }),
+    fetchData: vi.fn(async (_c: string, id: string) => photos.get(id) ?? null),
+    queryData: vi.fn(
+      async (
+        _c: string,
+        filters: Array<{ field: string; operator: string; value: unknown }>
+      ) => {
+        const out: Photo[] = [];
+        for (const p of photos.values()) {
+          let ok = true;
+          for (const f of filters) {
+            if (f.operator !== '==') continue;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            if ((p as any)[f.field] !== f.value) {
+              ok = false;
+              break;
+            }
+          }
+          if (ok) out.push(p);
+        }
+        return out;
+      }
+    ),
+    updateData: vi.fn(),
+    deleteData: vi.fn(),
+    exists: vi.fn(async () => false),
+    listIds: vi.fn(async () => Array.from(photos.keys())),
+    getPhoto: vi.fn(async () => null),
+  };
+  return data as DataAdapter;
+}
+
+function makePhoto(overrides: Partial<Photo> = {}): Photo {
+  return {
+    id: 'p1',
+    libraryId: 'lib-a',
+    tenantId: 'tenant-a',
+    albumIds: [],
+    originalName: 'Sunset.jpg',
+    filenameLower: 'sunset.jpg',
+    metadata: {
+      width: 100,
+      height: 100,
+      mimeType: 'image/jpeg',
+      sizeBytes: 100,
+      cameraMake: 'Canon',
+      cameraModel: 'Canon EOS 5D',
+    },
+    status: 'ready',
+    currentEditVersion: 0,
+    editHistory: [],
+    thumbnailsOutdated: false,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-01T00:00:00.000Z',
+    tags: [],
+    rating: 0,
+    flag: null,
+    colorLabel: null,
+    ...overrides,
+  } as Photo;
+}
+
+async function post(
+  app: Express,
+  path: string,
+  body: unknown
+): Promise<{ status: number; body: unknown }> {
+  const { createServer } = await import('node:http');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const server = createServer(app as unknown as (req: any, res: any) => void);
+  await new Promise<void>((r) => server.listen(0, r));
+  const addr = server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    return { status: res.status, body: parsed };
+  } finally {
+    await new Promise<void>((r) => server.close(() => r()));
+  }
+}
+
+describe('POST /v1/photos:search', () => {
+  it('filters by filename prefix (case-insensitive)', async () => {
+    const app = makeApp(
+      makeAdapter([
+        makePhoto({ id: 'p1', originalName: 'Sunset.jpg', filenameLower: 'sunset.jpg' }),
+        makePhoto({ id: 'p2', originalName: 'Beach.jpg', filenameLower: 'beach.jpg' }),
+      ])
+    );
+    const res = await post(app, '/v1/photos:search', {
+      libraryId: 'lib-a',
+      q: 'SUN',
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { items: Array<{ id: string }> };
+    expect(body.items.map((i) => i.id)).toEqual(['p1']);
+  });
+
+  it('AND-combines multiple filters (tags + rating + flag)', async () => {
+    const app = makeApp(
+      makeAdapter([
+        makePhoto({ id: 'a', tags: ['travel', 'sunset'], rating: 5, flag: 'pick' }),
+        makePhoto({ id: 'b', tags: ['travel'], rating: 5, flag: 'pick' }),
+        makePhoto({ id: 'c', tags: ['travel', 'sunset'], rating: 3, flag: 'pick' }),
+        makePhoto({ id: 'd', tags: ['travel', 'sunset'], rating: 5, flag: null }),
+      ])
+    );
+    const res = await post(app, '/v1/photos:search', {
+      libraryId: 'lib-a',
+      tags: ['travel', 'sunset'],
+      rating: { gte: 4 },
+      flag: 'pick',
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { items: Array<{ id: string }> };
+    expect(body.items.map((i) => i.id)).toEqual(['a']);
+  });
+
+  it('rejects unsupported combo (missing libraryId) with 409 + hint', async () => {
+    const app = makeApp(makeAdapter([]));
+    const res = await post(app, '/v1/photos:search', {
+      q: 'sunset',
+    });
+    expect(res.status).toBe(409);
+    const body = res.body as { error: { code: string; hint: string } };
+    expect(body.error.code).toBe('unsupported_query_combination');
+    expect(typeof body.error.hint).toBe('string');
+    expect(body.error.hint.length).toBeGreaterThan(0);
+  });
+
+  it('cross-tenant libraryId returns 404', async () => {
+    const app = makeApp(
+      makeAdapter([
+        makePhoto({ id: 'p1', libraryId: 'lib-a', tenantId: 'tenant-b' }),
+      ]),
+      { tenantId: 'tenant-a', userId: 'u1' }
+    );
+    const res = await post(app, '/v1/photos:search', {
+      libraryId: 'lib-a',
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('paginates via cursor', async () => {
+    const photos = Array.from({ length: 5 }, (_, i) =>
+      makePhoto({
+        id: `p${i}`,
+        originalName: `img${i}.jpg`,
+        filenameLower: `img${i}.jpg`,
+        // stagger createdAt so sort is deterministic (newest first).
+        createdAt: `2026-06-0${i + 1}T00:00:00.000Z`,
+      })
+    );
+    const app = makeApp(makeAdapter(photos));
+
+    const first = await post(app, '/v1/photos:search', {
+      libraryId: 'lib-a',
+      limit: 2,
+    });
+    expect(first.status).toBe(200);
+    const b1 = first.body as {
+      items: Array<{ id: string }>;
+      nextCursor?: string;
+      totalEstimate: number;
+    };
+    expect(b1.items.length).toBe(2);
+    expect(b1.totalEstimate).toBe(5);
+    expect(b1.nextCursor).toBeTruthy();
+
+    const second = await post(app, '/v1/photos:search', {
+      libraryId: 'lib-a',
+      limit: 2,
+      cursor: b1.nextCursor,
+    });
+    expect(second.status).toBe(200);
+    const b2 = second.body as { items: Array<{ id: string }>; nextCursor?: string };
+    expect(b2.items.length).toBe(2);
+    // Different page.
+    expect(b2.items.map((i) => i.id)).not.toEqual(b1.items.map((i) => i.id));
+  });
+
+  it('requires authentication', async () => {
+    const app = makeApp(makeAdapter([]), {});
+    const res = await post(app, '/v1/photos:search', { libraryId: 'lib-a' });
+    expect(res.status).toBe(401);
+  });
+
+  it('filters by camera substring match', async () => {
+    const app = makeApp(
+      makeAdapter([
+        makePhoto({
+          id: 'p1',
+          metadata: {
+            width: 1,
+            height: 1,
+            mimeType: 'image/jpeg',
+            sizeBytes: 1,
+            cameraMake: 'Canon',
+            cameraModel: 'Canon EOS 5D Mark IV',
+          },
+        }),
+        makePhoto({
+          id: 'p2',
+          metadata: {
+            width: 1,
+            height: 1,
+            mimeType: 'image/jpeg',
+            sizeBytes: 1,
+            cameraMake: 'Sony',
+            cameraModel: 'A7 IV',
+          },
+        }),
+      ])
+    );
+    const res = await post(app, '/v1/photos:search', {
+      libraryId: 'lib-a',
+      camera: '5d',
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { items: Array<{ id: string }> };
+    expect(body.items.map((i) => i.id)).toEqual(['p1']);
+  });
+
+  it('excludes trashed photos by default', async () => {
+    const app = makeApp(
+      makeAdapter([
+        makePhoto({ id: 'live' }),
+        makePhoto({ id: 'gone', trashedAt: '2026-06-15T00:00:00.000Z' }),
+      ])
+    );
+    const res = await post(app, '/v1/photos:search', { libraryId: 'lib-a' });
+    const body = res.body as { items: Array<{ id: string }> };
+    expect(body.items.map((i) => i.id)).toEqual(['live']);
+  });
+
+  it('trashed=true returns only trashed photos', async () => {
+    const app = makeApp(
+      makeAdapter([
+        makePhoto({ id: 'live' }),
+        makePhoto({ id: 'gone', trashedAt: '2026-06-15T00:00:00.000Z' }),
+      ])
+    );
+    const res = await post(app, '/v1/photos:search', {
+      libraryId: 'lib-a',
+      trashed: true,
+    });
+    const body = res.body as { items: Array<{ id: string }> };
+    expect(body.items.map((i) => i.id)).toEqual(['gone']);
+  });
+});

--- a/functions/src/routes/photosSearchV1.ts
+++ b/functions/src/routes/photosSearchV1.ts
@@ -1,0 +1,383 @@
+/**
+ * Ad-hoc photo search endpoint (issue #207).
+ *
+ *   POST /v1/photos:search
+ *
+ * Single composable entrypoint over the existing Photo indexes:
+ * filename prefix (`q`), tag AND-set (`tags`), rating range, flag,
+ * color label, capturedAt range, camera, trashed. Returns
+ * `PhotoSummary[]` in the same shape as `photosListV1` plus a
+ * cursor. Tenant scoping is enforced from `req.tenant` /
+ * `req.tenantId`; cross-tenant `libraryId` returns 404.
+ *
+ * Rejects filter combinations that would require an index we don't
+ * currently maintain with HTTP 409 `unsupported_query_combination`
+ * plus a machine-readable `hint`. There is deliberately no silent
+ * client-side filtering fallback for those combos — hosts must
+ * see the 409 so they can wait for a follow-up index.
+ *
+ * v1 is deliberately narrow:
+ *   - `q` is a case-insensitive prefix on the denormalized
+ *     `filenameLower` field (plus exact tag match).
+ *   - No full-text / semantic search.
+ *   - No saved queries (that's Smart Albums, #165).
+ */
+import { Router } from 'express';
+import { z } from 'zod';
+import type { DataAdapter } from '../adapters/data/DataAdapter.js';
+import type { Photo } from '../models/Photo.js';
+import { emitMeteringEvent } from '../services/metering/index.js';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+/** Base64url-encode a JSON cursor payload. */
+function encodeCursor(payload: { offset: number }): string {
+  return Buffer.from(JSON.stringify(payload), 'utf8')
+    .toString('base64')
+    .replace(/=+$/, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function decodeCursor(raw: string): { offset: number } | null {
+  try {
+    const b64 = raw.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    const json = Buffer.from(padded, 'base64').toString('utf8');
+    const parsed = JSON.parse(json);
+    if (typeof parsed.offset === 'number' && parsed.offset >= 0) {
+      return { offset: parsed.offset };
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+const RATING_RANGE = z
+  .object({
+    gte: z.number().int().min(0).max(5).optional(),
+    lte: z.number().int().min(0).max(5).optional(),
+  })
+  .strict();
+
+const DATE_RANGE = z
+  .object({
+    from: z.string().datetime().optional(),
+    to: z.string().datetime().optional(),
+  })
+  .strict();
+
+export const photosSearchRequestSchema = z
+  .object({
+    libraryId: z.string().min(1).optional(),
+    q: z.string().min(1).max(200).optional(),
+    tags: z.array(z.string().min(1).max(64)).max(50).optional(),
+    rating: RATING_RANGE.optional(),
+    flag: z.enum(['pick', 'reject', 'unflagged']).optional(),
+    colorLabel: z
+      .enum(['red', 'yellow', 'green', 'blue', 'purple', 'none'])
+      .optional(),
+    capturedBetween: DATE_RANGE.optional(),
+    camera: z.string().min(1).max(200).optional(),
+    trashed: z.boolean().optional(),
+    limit: z.number().int().min(1).max(MAX_LIMIT).optional(),
+    cursor: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type PhotosSearchRequest = z.infer<typeof photosSearchRequestSchema>;
+
+/**
+ * Determine which query index a request would need. If the caller omits
+ * `libraryId` but provides most filters, we currently have no cross-library
+ * per-tenant scan — reject with 409 rather than silently fanning out.
+ */
+function planQuery(req: PhotosSearchRequest): { ok: true } | { ok: false; hint: string } {
+  if (!req.libraryId) {
+    return {
+      ok: false,
+      hint:
+        "libraryId is required in v1; cross-library search over a tenant is not indexed. " +
+        "Pass a libraryId in the body.",
+    };
+  }
+  return { ok: true };
+}
+
+function requestedFilterNames(req: PhotosSearchRequest): string[] {
+  const names: string[] = [];
+  for (const k of [
+    'libraryId',
+    'q',
+    'tags',
+    'rating',
+    'flag',
+    'colorLabel',
+    'capturedBetween',
+    'camera',
+    'trashed',
+  ] as const) {
+    if (req[k] !== undefined) names.push(k);
+  }
+  return names;
+}
+
+function countFilters(req: PhotosSearchRequest): number {
+  // Everything except pagination / libraryId scoping.
+  return requestedFilterNames(req).filter(
+    (n) => n !== 'libraryId'
+  ).length;
+}
+
+function normalizedTags(input?: string[]): string[] {
+  if (!input) return [];
+  return input.map((t) => t.trim().toLowerCase()).filter((t) => t.length > 0);
+}
+
+function matchFilename(photo: Photo, q?: string): boolean {
+  if (!q) return true;
+  const needle = q.trim().toLowerCase();
+  if (!needle) return true;
+  const hay =
+    photo.filenameLower ??
+    (typeof photo.originalName === 'string'
+      ? photo.originalName.toLowerCase()
+      : '');
+  if (hay.startsWith(needle)) return true;
+  // Also allow tag equality against the same needle so hosts can send a
+  // single `q` and match either a filename prefix or a tag exactly.
+  const tags = photo.tags ?? [];
+  return tags.includes(needle);
+}
+
+function matchTags(photo: Photo, wanted: string[]): boolean {
+  if (wanted.length === 0) return true;
+  const have = new Set((photo.tags ?? []).map((t) => t.toLowerCase()));
+  for (const t of wanted) {
+    if (!have.has(t)) return false;
+  }
+  return true;
+}
+
+function matchRating(photo: Photo, r?: { gte?: number; lte?: number }): boolean {
+  if (!r) return true;
+  const v = photo.rating ?? 0;
+  if (typeof r.gte === 'number' && v < r.gte) return false;
+  if (typeof r.lte === 'number' && v > r.lte) return false;
+  return true;
+}
+
+function matchFlag(photo: Photo, wanted?: PhotosSearchRequest['flag']): boolean {
+  if (!wanted) return true;
+  const f = photo.flag ?? null;
+  if (wanted === 'unflagged') return f === null;
+  return f === wanted;
+}
+
+function matchColorLabel(
+  photo: Photo,
+  wanted?: PhotosSearchRequest['colorLabel']
+): boolean {
+  if (!wanted) return true;
+  const c = photo.colorLabel ?? null;
+  if (wanted === 'none') return c === null;
+  return c === wanted;
+}
+
+function matchCaptured(
+  photo: Photo,
+  range?: { from?: string; to?: string }
+): boolean {
+  if (!range) return true;
+  const captured =
+    photo.exif?.capturedAt || photo.metadata?.takenAt || null;
+  if (!captured) return false;
+  if (range.from && captured < range.from) return false;
+  if (range.to && captured > range.to) return false;
+  return true;
+}
+
+function matchCamera(photo: Photo, wanted?: string): boolean {
+  if (!wanted) return true;
+  const needle = wanted.trim().toLowerCase();
+  const model = (
+    photo.metadata?.cameraModel ??
+    photo.exif?.camera ??
+    ''
+  ).toLowerCase();
+  const make = (
+    photo.metadata?.cameraMake ??
+    ''
+  ).toLowerCase();
+  return model.includes(needle) || make.includes(needle);
+}
+
+function matchTrashed(photo: Photo, wanted?: boolean): boolean {
+  const isTrashed = !!photo.trashedAt;
+  if (wanted === undefined) {
+    // Default: exclude trashed photos, matching photosListV1 behavior.
+    return !isTrashed;
+  }
+  return wanted ? isTrashed : !isTrashed;
+}
+
+function photoSummary(p: Photo) {
+  return {
+    id: p.id,
+    libraryId: p.libraryId,
+    originalName: p.originalName,
+    status: p.status,
+    metadata: p.metadata,
+    exif: p.exif,
+    tags: p.tags ?? [],
+    rating: p.rating ?? 0,
+    flag: p.flag ?? null,
+    colorLabel: p.colorLabel ?? null,
+    createdAt: p.createdAt,
+    updatedAt: p.updatedAt,
+  };
+}
+
+export function createPhotosSearchV1Router(dataAdapter: DataAdapter): Router {
+  const router = Router();
+
+  router.post('/', async (req, res, next) => {
+    try {
+      if (!req.user && !req.tenant) {
+        res.status(401).json({
+          error: { code: 'AUTH_REQUIRED', message: 'Authentication required' },
+        });
+        return;
+      }
+
+      const parsed = photosSearchRequestSchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        res.status(400).json({
+          error: {
+            code: 'INVALID_BODY',
+            message: 'Invalid search request',
+            details: parsed.error.issues,
+          },
+        });
+        return;
+      }
+      const body = parsed.data;
+
+      const plan = planQuery(body);
+      if (!plan.ok) {
+        emitMeteringEvent({
+          type: 'photos.search.unsupported',
+          tenantId:
+            (req as { tenantId?: string }).tenantId ??
+            req.tenant?.id ??
+            'unknown',
+          count: 1,
+          ...(body.libraryId ? { resourceId: body.libraryId } : {}),
+          occurredAt: new Date().toISOString(),
+          meta: { requestedFilters: requestedFilterNames(body) },
+        });
+        res.status(409).json({
+          error: {
+            code: 'unsupported_query_combination',
+            message: plan.hint,
+            hint: plan.hint,
+          },
+        });
+        return;
+      }
+
+      const libraryId = body.libraryId as string;
+
+      // Base index: (tenantId?, libraryId). Use the existing photosList
+      // pattern — query by libraryId, then apply per-photo predicates.
+      const photos = await dataAdapter.queryData<Photo>('photos', [
+        { field: 'libraryId', operator: '==', value: libraryId },
+      ]);
+
+      // Tenant scoping: cross-tenant libraryId leaks return 404.
+      const requesterTenantId =
+        (req as { tenantId?: string }).tenantId ??
+        req.tenant?.id ??
+        (req.user as { tenantId?: string } | undefined)?.tenantId ??
+        null;
+      const scoped = requesterTenantId
+        ? photos.filter(
+            (p) => !p.tenantId || p.tenantId === requesterTenantId
+          )
+        : photos;
+
+      // If nothing exists for this library under the caller's tenant,
+      // treat as 404 (do not leak existence of a sibling tenant's
+      // library).
+      if (photos.length > 0 && scoped.length === 0) {
+        res.status(404).json({
+          error: {
+            code: 'LIBRARY_NOT_FOUND',
+            message: 'libraryId not found for this tenant',
+          },
+        });
+        return;
+      }
+
+      const wantedTags = normalizedTags(body.tags);
+      const filtered = scoped.filter(
+        (p) =>
+          matchFilename(p, body.q) &&
+          matchTags(p, wantedTags) &&
+          matchRating(p, body.rating) &&
+          matchFlag(p, body.flag) &&
+          matchColorLabel(p, body.colorLabel) &&
+          matchCaptured(p, body.capturedBetween) &&
+          matchCamera(p, body.camera) &&
+          matchTrashed(p, body.trashed)
+      );
+
+      // Stable sort: newest-first by capturedAt (falling back to createdAt),
+      // then id as a tiebreaker so cursor pagination is deterministic.
+      const sorted = filtered.sort((a, b) => {
+        const av = a.exif?.capturedAt || a.metadata?.takenAt || a.createdAt;
+        const bv = b.exif?.capturedAt || b.metadata?.takenAt || b.createdAt;
+        if (av !== bv) return av < bv ? 1 : -1;
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      });
+
+      const limit = body.limit ?? DEFAULT_LIMIT;
+      const startOffset = body.cursor
+        ? decodeCursor(body.cursor)?.offset ?? 0
+        : 0;
+      const page = sorted.slice(startOffset, startOffset + limit);
+      const nextCursor =
+        startOffset + limit < sorted.length
+          ? encodeCursor({ offset: startOffset + limit })
+          : undefined;
+
+      const items = page.map(photoSummary);
+
+      emitMeteringEvent({
+        type: 'photos.searched',
+        tenantId: requesterTenantId ?? 'unknown',
+        count: 1,
+        resourceId: libraryId,
+        occurredAt: new Date().toISOString(),
+        meta: {
+          libraryId,
+          resultCount: items.length,
+          hasFullText: !!body.q,
+          filterCount: countFilters(body),
+        },
+      });
+
+      res.json({
+        items,
+        ...(nextCursor ? { nextCursor } : {}),
+        totalEstimate: sorted.length,
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -131,6 +131,7 @@ import {
   loadAllowedOriginsForTenant,
 } from './routes/embedV1.js';
 import { createBulkPhotosRouter } from './routes/photosBatchV1.js';
+import { createPhotosSearchV1Router } from './routes/photosSearchV1.js';
 import { createPhotoExportRouter } from './routes/photoExportV1.js';
 import { createTenantExportPresetsRouter } from './routes/tenantExportPresetsV1.js';
 import { createTenantEditPresetsRouter } from './routes/tenantEditPresetsV1.js';
@@ -273,7 +274,33 @@ app.use('/api/v1/compliance', authMiddleware, createComplianceV1Router(dataAdapt
 // Bulk photo operations (issue #142). Express routes treat `:` as a param
 // separator, so we register the exact literal path.
 // Gated by per-tenant `bulkOps` feature flag (issue #175).
-app.use('/api/v1/photos\\:batch', authMiddleware, requireFeature('bulkOps'), createBulkPhotosRouter(dataAdapter));
+app.use('/api/v1/photos\:batch', authMiddleware, requireFeature('bulkOps'), createBulkPhotosRouter(dataAdapter));
+
+// Ad-hoc photo search (issue #207). Mounted at both `/v1/photos:search`
+// (spec) and `/api/v1/photos:search` (in-product). Gated by per-tenant
+// `search` feature flag. Idempotency-Key middleware applied so a retried
+// POST after a network blip is replayed rather than double-metered.
+const photosSearchIdempotency = createIdempotencyMiddleware({
+  route: 'POST /v1/photos:search',
+  dataAdapter,
+  resolveTenantId: (req) => req.tenant?.id ?? req.tenantId ?? req.user?.uid ?? null,
+});
+app.use(
+  '/v1/photos\:search',
+  authMiddleware,
+  resolveTenant,
+  requireFeature('search'),
+  photosSearchIdempotency,
+  createPhotosSearchV1Router(dataAdapter)
+);
+app.use(
+  '/api/v1/photos\:search',
+  authMiddleware,
+  resolveTenant,
+  requireFeature('search'),
+  photosSearchIdempotency,
+  createPhotosSearchV1Router(dataAdapter)
+);
 
 // Photos: soft-delete (Trash) + restore + trashed list (issue #152),
 // plus keyword tags add/remove + per-library tag enumeration (issue #173).

--- a/functions/src/services/metering/eventCatalog.ts
+++ b/functions/src/services/metering/eventCatalog.ts
@@ -45,7 +45,7 @@
  *
  * Use a date string so the value is human-readable in logs.
  */
-export const CATALOG_VERSION = '2026-07-02';
+export const CATALOG_VERSION = '2026-07-13';
 
 /**
  * JSON Schema describing the `meta` payload for a single event type.
@@ -579,6 +579,38 @@ export const EVENT_CATALOG = [
       newValue: S_BOOLEAN,
       actor: S_STRING,
     }),
+  },
+  {
+    name: 'photos.searched',
+    version: 1,
+    billable: true,
+    description:
+      'A `POST /v1/photos:search` call completed successfully (issue #207). One event per call regardless of result count.',
+    schema: metaSchema(
+      {
+        libraryId: S_STRING,
+        resultCount: S_INTEGER,
+        hasFullText: S_BOOLEAN,
+        filterCount: S_INTEGER,
+      },
+      ['libraryId', 'resultCount', 'hasFullText', 'filterCount']
+    ),
+  },
+  {
+    name: 'photos.search.unsupported',
+    version: 1,
+    billable: false,
+    description:
+      'A `POST /v1/photos:search` call was rejected with HTTP 409 because the requested filter combination has no server-side index (issue #207).',
+    schema: metaSchema(
+      {
+        requestedFilters: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+      ['requestedFilters']
+    ),
   },
 ] as const satisfies readonly RegisteredEvent[];
 


### PR DESCRIPTION
## What Problem This Solves

Every embedded host that wanted an ad-hoc "type a query, get matching
photos" experience was gluing together multiple `photosListV1` calls
client-side. That multiplied API-call billing signal without giving
hosts a "this is search traffic" signal, forced clients to know which
fields are indexable, and made a future server-side full-text upgrade
impossible without breaking callers.

## Why This Change Was Made

Issue #207 asks for a single ad-hoc search entrypoint that composes the
existing photo indexes (tags #173, rating #141, flag, colorLabel #184,
EXIF #151) with no new storage engine. Smart Albums (#165) remain the
answer for *saved* filters; this endpoint is the answer for *one-shot*
queries.

## User Impact

Hosts can now POST a single request describing the search — filename
prefix (`q`), tag AND-set, rating range, flag, color label, capturedAt
range, camera, trashed — and get back the standard `PhotoSummary` shape
with cursor pagination. Filter combos that would need a missing index
are rejected with HTTP `409 unsupported_query_combination` + a
machine-readable `hint` (no silent client-side filtering).

## What Landed

- `functions/src/routes/photosSearchV1.ts` — new route, zod-validated
  body, cursor pagination, per-request query planner.
- Mounted at `/v1/photos:search` and `/api/v1/photos:search` with
  `authMiddleware`, `resolveTenant`, `requireFeature('search')`, and
  the shared `Idempotency-Key` middleware.
- `search` added to `FEATURE_FLAG_NAMES` in `TenantFeaturesConfig`
  (default-on).
- `filenameLower` denormalized field added to the `Photo` model and
  populated on `createPhotoDocument`; the handler falls back to
  `originalName.toLowerCase()` for legacy photos.
- Two new events in `EVENT_CATALOG`:
  - `photos.searched { libraryId, resultCount, hasFullText, filterCount }` (billable)
  - `photos.search.unsupported { requestedFilters }` (non-billable)
  `CATALOG_VERSION` bumped to `2026-07-13`.
- `contracts/openapi/photos-search.openapi.json` published; existing
  `npm run contract:check` is green.
- `docs/features/library-and-organization.md` gains an "Ad-hoc Search"
  subsection covering request shape, 409 semantics, feature flag,
  metering, idempotency, and `filenameLower`.

## Evidence

- `cd functions && npx vitest run src/routes/photosSearchV1.test.ts` → 9/9 passing
  (filename prefix, multi-filter AND, unsupported combo 409, cross-tenant 404,
  cursor pagination, auth required, camera match, trashed default-exclude,
  `trashed=true`).
- `cd functions && npx vitest run src/routes/hostWebhookEventsV1.test.ts` → 8/8
  passing (validates new EVENT_CATALOG entries flow into the public catalog).
- `cd functions && npx vitest run src/middleware/requireFeature.test.ts` → 5/5
  passing (validates new `search` flag doesn't break default-on behavior).
- `npm run contract:check` → validation + breaking check both green.
- `cd functions && npx tsc -p . --noEmit` → clean for all files touched by
  this PR (pre-existing unrelated test type errors elsewhere).

## Deferred (called out for follow-up)

- **Firestore backfill of `filenameLower`** for photos written before
  this PR — the handler transparently falls back to
  `originalName.toLowerCase()` in memory, but a one-shot backfill job
  would let a future Firestore-native prefix query use the field
  directly. Not shipped here because the local JSON adapter can't
  drive a real Firestore migration.
- **Firestore-native filter pushdown.** v1 fetches by `libraryId` and
  applies the remaining predicates in memory, matching the existing
  `photosListV1` pattern. Follow-up work should move `tags` (array-
  contains), `rating`, `flag`, `colorLabel`, and `capturedAt` range
  down into Firestore composite indexes.
- **Full-text over filename/tags** (Algolia / Firestore text search) —
  explicitly out of scope per the issue.
- **Per-tenant rate limiter mount** (issue #154) — the middleware
  exists elsewhere but wiring it onto this specific route is
  deferred to keep this PR focused.

Fixes rwrife/AuraPix#207